### PR TITLE
Compute (row, column) at the end

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -501,7 +501,7 @@ checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
 
 [[package]]
 name = "flir"
-version = "0.0.5"
+version = "0.0.6"
 dependencies = [
  "air_r_parser",
  "air_r_syntax",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "flir"
 description = "R linter written in Rust"
 authors = ["Etienne Bacher"]
-version = "0.0.5"
+version = "0.0.6"
 edition = "2021"
 
 license-file = "LICENSE.md"

--- a/src/lints/any_duplicated/any_duplicated.rs
+++ b/src/lints/any_duplicated/any_duplicated.rs
@@ -1,7 +1,5 @@
-use crate::location::Location;
 use crate::message::*;
 use crate::trait_lint_checker::LintChecker;
-use crate::utils::find_row_col;
 use air_r_syntax::RSyntaxNode;
 use air_r_syntax::*;
 use anyhow::{Context, Result};
@@ -18,12 +16,7 @@ impl Violation for AnyDuplicated {
 }
 
 impl LintChecker for AnyDuplicated {
-    fn check(
-        &self,
-        ast: &RSyntaxNode,
-        loc_new_lines: &[usize],
-        file: &str,
-    ) -> Result<Vec<Diagnostic>> {
+    fn check(&self, ast: &RSyntaxNode, file: &str) -> Result<Vec<Diagnostic>> {
         let mut diagnostics = vec![];
         if ast.kind() != RSyntaxKind::R_CALL {
             return Ok(diagnostics);
@@ -65,18 +58,17 @@ impl LintChecker for AnyDuplicated {
                 .text();
 
             if fun.text_trimmed() == "duplicated" && fun.kind() == RSyntaxKind::R_IDENTIFIER {
-                let (row, column) = find_row_col(ast, loc_new_lines);
                 let range = ast.text_trimmed_range();
-                diagnostics.push(Diagnostic {
-                    message: AnyDuplicated.into(),
-                    filename: file.into(),
-                    location: Location { row, column },
-                    fix: Fix {
+                diagnostics.push(Diagnostic::new(
+                    AnyDuplicated,
+                    file.into(),
+                    range,
+                    Fix {
                         content: format!("anyDuplicated({}) > 0", fun_content),
                         start: range.start().into(),
                         end: range.end().into(),
                     },
-                })
+                ))
             }
         }
         Ok(diagnostics)

--- a/src/lints/any_is_na/any_is_na.rs
+++ b/src/lints/any_is_na/any_is_na.rs
@@ -1,7 +1,5 @@
-use crate::location::Location;
 use crate::message::*;
 use crate::trait_lint_checker::LintChecker;
-use crate::utils::find_row_col;
 use air_r_syntax::RSyntaxNode;
 use air_r_syntax::*;
 use anyhow::{Context, Result};
@@ -18,12 +16,7 @@ impl Violation for AnyIsNa {
 }
 
 impl LintChecker for AnyIsNa {
-    fn check(
-        &self,
-        ast: &RSyntaxNode,
-        loc_new_lines: &[usize],
-        file: &str,
-    ) -> Result<Vec<Diagnostic>> {
+    fn check(&self, ast: &RSyntaxNode, file: &str) -> Result<Vec<Diagnostic>> {
         let mut diagnostics = vec![];
         if ast.kind() != RSyntaxKind::R_CALL {
             return Ok(diagnostics);
@@ -65,18 +58,17 @@ impl LintChecker for AnyIsNa {
                 .text();
 
             if fun.text_trimmed() == "is.na" && fun.kind() == RSyntaxKind::R_IDENTIFIER {
-                let (row, column) = find_row_col(ast, loc_new_lines);
                 let range = ast.text_trimmed_range();
-                diagnostics.push(Diagnostic {
-                    message: AnyIsNa.into(),
-                    filename: file.into(),
-                    location: Location { row, column },
-                    fix: Fix {
+                diagnostics.push(Diagnostic::new(
+                    AnyIsNa,
+                    file.into(),
+                    range,
+                    Fix {
                         content: format!("anyNA({})", fun_content),
                         start: range.start().into(),
                         end: range.end().into(),
                     },
-                })
+                ))
             }
         }
         Ok(diagnostics)

--- a/src/lints/class_equals/class_equals.rs
+++ b/src/lints/class_equals/class_equals.rs
@@ -1,7 +1,6 @@
-use crate::location::Location;
 use crate::message::*;
 use crate::trait_lint_checker::LintChecker;
-use crate::utils::{find_row_col, get_first_arg, node_is_in_square_brackets};
+use crate::utils::{get_first_arg, node_is_in_square_brackets};
 use air_r_syntax::RSyntaxNode;
 use air_r_syntax::*;
 use anyhow::Result;
@@ -20,12 +19,7 @@ impl Violation for ClassEquals {
 }
 
 impl LintChecker for ClassEquals {
-    fn check(
-        &self,
-        ast: &RSyntaxNode,
-        loc_new_lines: &[usize],
-        file: &str,
-    ) -> Result<Vec<Diagnostic>> {
+    fn check(&self, ast: &RSyntaxNode, file: &str) -> Result<Vec<Diagnostic>> {
         let mut diagnostics = vec![];
         let bin_expr = RBinaryExpression::cast(ast.clone());
 
@@ -80,18 +74,17 @@ impl LintChecker for ClassEquals {
             class_name = lhs.text_trimmed();
         };
 
-        let (row, column) = find_row_col(ast, loc_new_lines);
         let range = ast.text_trimmed_range();
-        diagnostics.push(Diagnostic {
-            message: ClassEquals.into(),
-            filename: file.into(),
-            location: Location { row, column },
-            fix: Fix {
+        diagnostics.push(Diagnostic::new(
+            ClassEquals,
+            file.into(),
+            range,
+            Fix {
                 content: format!("{}({}, {})", fun_name, fun_content.unwrap(), class_name),
                 start: range.start().into(),
                 end: range.end().into(),
             },
-        });
+        ));
         Ok(diagnostics)
     }
 }

--- a/src/lints/duplicated_arguments/duplicated_arguments.rs
+++ b/src/lints/duplicated_arguments/duplicated_arguments.rs
@@ -1,7 +1,5 @@
-use crate::location::Location;
 use crate::message::*;
 use crate::trait_lint_checker::LintChecker;
-use crate::utils::find_row_col;
 use air_r_syntax::RSyntaxNode;
 use air_r_syntax::*;
 use anyhow::{anyhow, Result};
@@ -19,12 +17,7 @@ impl Violation for DuplicatedArguments {
 }
 
 impl LintChecker for DuplicatedArguments {
-    fn check(
-        &self,
-        ast: &RSyntaxNode,
-        loc_new_lines: &[usize],
-        file: &str,
-    ) -> Result<Vec<Diagnostic>> {
+    fn check(&self, ast: &RSyntaxNode, file: &str) -> Result<Vec<Diagnostic>> {
         let mut diagnostics: Vec<Diagnostic> = vec![];
         if ast.kind() != RSyntaxKind::R_CALL {
             return Ok(diagnostics);
@@ -93,13 +86,13 @@ impl LintChecker for DuplicatedArguments {
             .collect::<Vec<String>>();
 
         if has_duplicates(&arg_names) {
-            let (row, column) = find_row_col(ast, loc_new_lines);
-            diagnostics.push(Diagnostic {
-                message: DuplicatedArguments.into(),
-                filename: file.into(),
-                location: Location { row, column },
-                fix: Fix::empty(),
-            })
+            let range = ast.text_trimmed_range();
+            diagnostics.push(Diagnostic::new(
+                DuplicatedArguments,
+                file.into(),
+                range,
+                Fix::empty(),
+            ))
         }
         Ok(diagnostics)
     }

--- a/src/lints/empty_assignment/empty_assignment.rs
+++ b/src/lints/empty_assignment/empty_assignment.rs
@@ -1,7 +1,5 @@
-use crate::location::Location;
 use crate::message::*;
 use crate::trait_lint_checker::LintChecker;
-use crate::utils::find_row_col;
 use air_r_syntax::RSyntaxNode;
 use air_r_syntax::*;
 use anyhow::Result;
@@ -19,12 +17,7 @@ impl Violation for EmptyAssignment {
 }
 
 impl LintChecker for EmptyAssignment {
-    fn check(
-        &self,
-        ast: &RSyntaxNode,
-        loc_new_lines: &[usize],
-        file: &str,
-    ) -> Result<Vec<Diagnostic>> {
+    fn check(&self, ast: &RSyntaxNode, file: &str) -> Result<Vec<Diagnostic>> {
         let mut diagnostics = vec![];
         let bin_expr = RBinaryExpression::cast(ast.clone());
 
@@ -64,13 +57,13 @@ impl LintChecker for EmptyAssignment {
         };
 
         if value_is_empty {
-            let (row, column) = find_row_col(ast, loc_new_lines);
-            diagnostics.push(Diagnostic {
-                message: EmptyAssignment.into(),
-                filename: file.into(),
-                location: Location { row, column },
-                fix: Fix::empty(),
-            });
+            let range = ast.text_trimmed_range();
+            diagnostics.push(Diagnostic::new(
+                EmptyAssignment,
+                file.into(),
+                range,
+                Fix::empty(),
+            ));
         }
 
         Ok(diagnostics)

--- a/src/lints/equal_assignment/equal_assignment.rs
+++ b/src/lints/equal_assignment/equal_assignment.rs
@@ -1,7 +1,5 @@
-use crate::location::Location;
 use crate::message::*;
 use crate::trait_lint_checker::LintChecker;
-use crate::utils::find_row_col;
 use air_r_syntax::RSyntaxNode;
 use air_r_syntax::*;
 use anyhow::Result;
@@ -19,12 +17,7 @@ impl Violation for EqualAssignment {
 }
 
 impl LintChecker for EqualAssignment {
-    fn check(
-        &self,
-        ast: &RSyntaxNode,
-        loc_new_lines: &[usize],
-        file: &str,
-    ) -> Result<Vec<Diagnostic>> {
+    fn check(&self, ast: &RSyntaxNode, file: &str) -> Result<Vec<Diagnostic>> {
         let mut diagnostics = vec![];
         let bin_expr = RBinaryExpression::cast(ast.clone());
 
@@ -58,18 +51,17 @@ impl LintChecker for EqualAssignment {
             _ => unreachable!(),
         };
 
-        let (row, column) = find_row_col(ast, loc_new_lines);
         let range = ast.text_trimmed_range();
-        diagnostics.push(Diagnostic {
-            message: EqualAssignment.into(),
-            filename: file.into(),
-            location: Location { row, column },
-            fix: Fix {
+        diagnostics.push(Diagnostic::new(
+            EqualAssignment,
+            file.into(),
+            range,
+            Fix {
                 content: replacement,
                 start: range.start().into(),
                 end: range.end().into(),
             },
-        });
+        ));
 
         Ok(diagnostics)
     }

--- a/src/lints/expect_length/expect_length.rs
+++ b/src/lints/expect_length/expect_length.rs
@@ -1,8 +1,6 @@
-use crate::location::Location;
 use crate::message::*;
 use crate::trait_lint_checker::LintChecker;
 use crate::traits::ArgumentListExt;
-use crate::utils::find_row_col;
 use air_r_syntax::RSyntaxNode;
 use air_r_syntax::*;
 use anyhow::{Context, Result};
@@ -20,12 +18,7 @@ impl Violation for ExpectLength {
 }
 
 impl LintChecker for ExpectLength {
-    fn check(
-        &self,
-        ast: &RSyntaxNode,
-        loc_new_lines: &[usize],
-        file: &str,
-    ) -> Result<Vec<Diagnostic>> {
+    fn check(&self, ast: &RSyntaxNode, file: &str) -> Result<Vec<Diagnostic>> {
         let mut diagnostics = vec![];
 
         // Check that the call is expect_equal / expect_identical ------------
@@ -75,18 +68,17 @@ impl LintChecker for ExpectLength {
             return Ok(diagnostics);
         }
 
-        let (row, column) = find_row_col(ast, loc_new_lines);
         let range = ast.text_trimmed_range();
-        diagnostics.push(Diagnostic {
-            message: ExpectLength.into(),
-            filename: file.into(),
-            location: Location { row, column },
-            fix: Fix {
+        diagnostics.push(Diagnostic::new(
+            ExpectLength,
+            file.into(),
+            range,
+            Fix {
                 content: format!("expect_length({}, {})", arg_obj.text(), arg_exp.text()),
                 start: range.start().into(),
                 end: range.end().into(),
             },
-        });
+        ));
         Ok(diagnostics)
     }
 }

--- a/src/lints/expect_length/snapshots/flir__lints__expect_length__tests__fix_output.snap
+++ b/src/lints/expect_length/snapshots/flir__lints__expect_length__tests__fix_output.snap
@@ -1,0 +1,31 @@
+---
+source: src/lints/expect_length/mod.rs
+expression: "get_fixed_text(vec![\"expect_equal(length(x), 2)\",\n\"expect_equal(length(x), 2L)\", \"expect_identical(length(x), 2)\",\n\"expect_equal(2, length(x))\",], \"expect_length\")"
+---
+  OLD:
+  ====
+expect_equal(length(x), 2)
+  NEW:
+  ====
+expect_length(x, 2)
+
+  OLD:
+  ====
+expect_equal(length(x), 2L)
+  NEW:
+  ====
+expect_length(x, 2L)
+
+  OLD:
+  ====
+expect_identical(length(x), 2)
+  NEW:
+  ====
+expect_length(x, 2)
+
+  OLD:
+  ====
+expect_equal(2, length(x))
+  NEW:
+  ====
+expect_equal(2, length(x))

--- a/src/lints/length_levels/length_levels.rs
+++ b/src/lints/length_levels/length_levels.rs
@@ -1,7 +1,5 @@
-use crate::location::Location;
 use crate::message::*;
 use crate::trait_lint_checker::LintChecker;
-use crate::utils::find_row_col;
 use air_r_syntax::RSyntaxNode;
 use air_r_syntax::*;
 use anyhow::{Context, Result};
@@ -18,12 +16,7 @@ impl Violation for LengthLevels {
 }
 
 impl LintChecker for LengthLevels {
-    fn check(
-        &self,
-        ast: &RSyntaxNode,
-        loc_new_lines: &[usize],
-        file: &str,
-    ) -> Result<Vec<Diagnostic>> {
+    fn check(&self, ast: &RSyntaxNode, file: &str) -> Result<Vec<Diagnostic>> {
         let mut diagnostics = vec![];
         if ast.kind() != RSyntaxKind::R_CALL {
             return Ok(diagnostics);
@@ -60,18 +53,17 @@ impl LintChecker for LengthLevels {
                 .text();
 
             if fun.text_trimmed() == "levels" && fun.kind() == RSyntaxKind::R_IDENTIFIER {
-                let (row, column) = find_row_col(ast, loc_new_lines);
                 let range = ast.text_trimmed_range();
-                diagnostics.push(Diagnostic {
-                    message: LengthLevels.into(),
-                    filename: file.into(),
-                    location: Location { row, column },
-                    fix: Fix {
+                diagnostics.push(Diagnostic::new(
+                    LengthLevels,
+                    file.into(),
+                    range,
+                    Fix {
                         content: format!("nlevels({})", fun_content),
                         start: range.start().into(),
                         end: range.end().into(),
                     },
-                })
+                ))
             }
         }
         Ok(diagnostics)

--- a/src/lints/length_test/length_test.rs
+++ b/src/lints/length_test/length_test.rs
@@ -1,7 +1,5 @@
-use crate::location::Location;
 use crate::message::*;
 use crate::trait_lint_checker::LintChecker;
-use crate::utils::find_row_col;
 use air_r_syntax::RSyntaxKind::*;
 use air_r_syntax::RSyntaxNode;
 use air_r_syntax::*;
@@ -20,12 +18,7 @@ impl Violation for LengthTest {
 }
 
 impl LintChecker for LengthTest {
-    fn check(
-        &self,
-        ast: &RSyntaxNode,
-        loc_new_lines: &[usize],
-        file: &str,
-    ) -> Result<Vec<Diagnostic>> {
+    fn check(&self, ast: &RSyntaxNode, file: &str) -> Result<Vec<Diagnostic>> {
         let mut diagnostics = vec![];
         let call = RCall::cast(ast.clone());
         if call.is_none() {
@@ -69,18 +62,17 @@ impl LintChecker for LengthTest {
         }
 
         if arg_is_binary_expr {
-            let (row, column) = find_row_col(ast, loc_new_lines);
             let range = ast.text_trimmed_range();
-            diagnostics.push(Diagnostic {
-                message: LengthTest.into(),
-                filename: file.into(),
-                location: Location { row, column },
-                fix: Fix {
+            diagnostics.push(Diagnostic::new(
+                LengthTest,
+                file.into(),
+                range,
+                Fix {
                     content: format!("length({}) {} {}", lhs, operator_text, rhs),
                     start: range.start().into(),
                     end: range.end().into(),
                 },
-            });
+            ));
         }
 
         Ok(diagnostics)

--- a/src/lints/lengths/lengths.rs
+++ b/src/lints/lengths/lengths.rs
@@ -1,8 +1,6 @@
-use crate::location::Location;
 use crate::message::*;
 use crate::trait_lint_checker::LintChecker;
 use crate::traits::ArgumentListExt;
-use crate::utils::find_row_col;
 use air_r_syntax::RSyntaxNode;
 use air_r_syntax::*;
 use anyhow::{Context, Result};
@@ -20,12 +18,7 @@ impl Violation for Lengths {
 }
 
 impl LintChecker for Lengths {
-    fn check(
-        &self,
-        ast: &RSyntaxNode,
-        loc_new_lines: &[usize],
-        file: &str,
-    ) -> Result<Vec<Diagnostic>> {
+    fn check(&self, ast: &RSyntaxNode, file: &str) -> Result<Vec<Diagnostic>> {
         let mut diagnostics = vec![];
         let call = RCall::cast(ast.clone());
         if call.is_none() {
@@ -50,18 +43,17 @@ impl LintChecker for Lengths {
                 .text()
                 == "length"
             {
-                let (row, column) = find_row_col(ast, loc_new_lines);
                 let range = ast.text_trimmed_range();
-                diagnostics.push(Diagnostic {
-                    message: Lengths.into(),
-                    filename: file.into(),
-                    location: Location { row, column },
-                    fix: Fix {
+                diagnostics.push(Diagnostic::new(
+                    Lengths,
+                    file.into(),
+                    range,
+                    Fix {
                         content: format!("lengths({})", arg_x.unwrap().text()),
                         start: range.start().into(),
                         end: range.end().into(),
                     },
-                })
+                ))
             }
         };
 

--- a/src/lints/redundant_equals/redundant_equals.rs
+++ b/src/lints/redundant_equals/redundant_equals.rs
@@ -1,7 +1,5 @@
-use crate::location::Location;
 use crate::message::*;
 use crate::trait_lint_checker::LintChecker;
-use crate::utils::find_row_col;
 use air_r_syntax::RSyntaxNode;
 use air_r_syntax::*;
 use biome_rowan::AstNode;
@@ -18,12 +16,7 @@ impl Violation for RedundantEquals {
 }
 
 impl LintChecker for RedundantEquals {
-    fn check(
-        &self,
-        ast: &RSyntaxNode,
-        loc_new_lines: &[usize],
-        file: &str,
-    ) -> anyhow::Result<Vec<Diagnostic>> {
+    fn check(&self, ast: &RSyntaxNode, file: &str) -> anyhow::Result<Vec<Diagnostic>> {
         let mut diagnostics = vec![];
         let bin_expr = RBinaryExpression::cast(ast.clone());
 
@@ -56,18 +49,17 @@ impl LintChecker for RedundantEquals {
                     return Ok(diagnostics);
                 };
 
-                let (row, column) = find_row_col(ast, loc_new_lines);
                 let range = ast.text_trimmed_range();
-                diagnostics.push(Diagnostic {
-                    message: RedundantEquals.into(),
-                    filename: file.into(),
-                    location: Location { row, column },
-                    fix: Fix {
+                diagnostics.push(Diagnostic::new(
+                    RedundantEquals,
+                    file.into(),
+                    range,
+                    Fix {
                         content: fix,
                         start: range.start().into(),
                         end: range.end().into(),
                     },
-                });
+                ));
             }
             RSyntaxKind::NOT_EQUAL => {
                 let fix = if *left_is_true {
@@ -81,18 +73,17 @@ impl LintChecker for RedundantEquals {
                 } else {
                     return Ok(diagnostics);
                 };
-                let (row, column) = find_row_col(ast, loc_new_lines);
                 let range = ast.text_trimmed_range();
-                diagnostics.push(Diagnostic {
-                    message: RedundantEquals.into(),
-                    filename: file.into(),
-                    location: Location { row, column },
-                    fix: Fix {
+                diagnostics.push(Diagnostic::new(
+                    RedundantEquals,
+                    file.into(),
+                    range,
+                    Fix {
                         content: fix,
                         start: range.start().into(),
                         end: range.end().into(),
                     },
-                });
+                ));
             }
             _ => return Ok(diagnostics),
         };

--- a/src/lints/true_false_symbol/true_false_symbol.rs
+++ b/src/lints/true_false_symbol/true_false_symbol.rs
@@ -1,7 +1,5 @@
-use crate::location::Location;
 use crate::message::*;
 use crate::trait_lint_checker::LintChecker;
-use crate::utils::find_row_col;
 use air_r_syntax::RSyntaxNode;
 use air_r_syntax::*;
 use anyhow::Result;
@@ -19,12 +17,7 @@ impl Violation for TrueFalseSymbol {
 }
 
 impl LintChecker for TrueFalseSymbol {
-    fn check(
-        &self,
-        ast: &RSyntaxNode,
-        loc_new_lines: &[usize],
-        file: &str,
-    ) -> Result<Vec<Diagnostic>> {
+    fn check(&self, ast: &RSyntaxNode, file: &str) -> Result<Vec<Diagnostic>> {
         let mut diagnostics: Vec<Diagnostic> = vec![];
         if ast.kind() != RSyntaxKind::R_IDENTIFIER
             || (ast.text_trimmed() != "T" && ast.text_trimmed() != "F")
@@ -65,13 +58,12 @@ impl LintChecker for TrueFalseSymbol {
             return Ok(diagnostics);
         }
 
-        let (row, column) = find_row_col(ast, loc_new_lines);
         let range = ast.text_trimmed_range();
-        diagnostics.push(Diagnostic {
-            message: TrueFalseSymbol.into(),
-            filename: file.into(),
-            location: Location { row, column },
-            fix: Fix {
+        diagnostics.push(Diagnostic::new(
+            TrueFalseSymbol,
+            file.into(),
+            range,
+            Fix {
                 content: if ast.text_trimmed() == "T" {
                     "TRUE".to_string()
                 } else {
@@ -80,7 +72,7 @@ impl LintChecker for TrueFalseSymbol {
                 start: range.start().into(),
                 end: range.end().into(),
             },
-        });
+        ));
 
         Ok(diagnostics)
     }

--- a/src/lints/which_grepl/which_grepl.rs
+++ b/src/lints/which_grepl/which_grepl.rs
@@ -1,7 +1,5 @@
-use crate::location::Location;
 use crate::message::*;
 use crate::trait_lint_checker::LintChecker;
-use crate::utils::find_row_col;
 use air_r_syntax::RSyntaxNode;
 use air_r_syntax::*;
 use anyhow::{Context, Result};
@@ -18,12 +16,7 @@ impl Violation for WhichGrepl {
 }
 
 impl LintChecker for WhichGrepl {
-    fn check(
-        &self,
-        ast: &RSyntaxNode,
-        loc_new_lines: &[usize],
-        file: &str,
-    ) -> Result<Vec<Diagnostic>> {
+    fn check(&self, ast: &RSyntaxNode, file: &str) -> Result<Vec<Diagnostic>> {
         let mut diagnostics = vec![];
         if ast.kind() != RSyntaxKind::R_CALL {
             return Ok(diagnostics);
@@ -60,18 +53,17 @@ impl LintChecker for WhichGrepl {
                 .text();
 
             if fun.text_trimmed() == "grepl" && fun.kind() == RSyntaxKind::R_IDENTIFIER {
-                let (row, column) = find_row_col(ast, loc_new_lines);
                 let range = ast.text_trimmed_range();
-                diagnostics.push(Diagnostic {
-                    message: WhichGrepl.into(),
-                    filename: file.into(),
-                    location: Location { row, column },
-                    fix: Fix {
+                diagnostics.push(Diagnostic::new(
+                    WhichGrepl,
+                    file.into(),
+                    range,
+                    Fix {
                         content: format!("grep({})", fun_content),
                         start: range.start().into(),
                         end: range.end().into(),
                     },
-                })
+                ))
             }
         }
         Ok(diagnostics)

--- a/src/location.rs
+++ b/src/location.rs
@@ -15,9 +15,7 @@ impl Location {
     ) -> std::fmt::Result {
         write!(f, "{} at line {} column {}", e, self.row(), self.column())
     }
-}
 
-impl Location {
     pub fn new(row: usize, column: usize) -> Self {
         Location { row, column }
     }

--- a/src/trait_lint_checker.rs
+++ b/src/trait_lint_checker.rs
@@ -5,10 +5,5 @@ use anyhow::Result;
 /// Takes an AST node and checks whether it satisfies or violates the
 /// implemented rule.
 pub trait LintChecker {
-    fn check(
-        &self,
-        ast: &RSyntaxNode,
-        loc_new_lines: &[usize],
-        file: &str,
-    ) -> Result<Vec<Diagnostic>>;
+    fn check(&self, ast: &RSyntaxNode, file: &str) -> Result<Vec<Diagnostic>>;
 }


### PR DESCRIPTION
We don't need to do this in each lint definition, just export the range and then compute all locations at the end.

Fixes #11