### PR TITLE
Assignment linter shouldn't be only on identifiers

### DIFF
--- a/crates/flir-core/src/lints/assignment/assignment.rs
+++ b/crates/flir-core/src/lints/assignment/assignment.rs
@@ -60,9 +60,6 @@ pub fn assignment(ast: &RBinaryExpression) -> anyhow::Result<Option<Diagnostic>>
 
     let replacement = match operator.kind() {
         RSyntaxKind::EQUAL => {
-            if lhs.kind() != RSyntaxKind::R_IDENTIFIER {
-                return Ok(None);
-            }
             range_to_report = TextRange::new(
                 lhs.text_trimmed_range().start(),
                 operator.text_trimmed_range().end(),
@@ -70,9 +67,6 @@ pub fn assignment(ast: &RBinaryExpression) -> anyhow::Result<Option<Diagnostic>>
             format!("{} <- {}", lhs.text_trimmed(), rhs.text_trimmed())
         }
         RSyntaxKind::ASSIGN_RIGHT => {
-            if rhs.kind() != RSyntaxKind::R_IDENTIFIER {
-                return Ok(None);
-            }
             range_to_report = TextRange::new(
                 operator.text_trimmed_range().start(),
                 rhs.text_trimmed_range().end(),

--- a/crates/flir-core/src/lints/assignment/mod.rs
+++ b/crates/flir-core/src/lints/assignment/mod.rs
@@ -12,8 +12,12 @@ mod tests {
         expect_lint("blah=1", expected_message, "assignment", None);
         expect_lint("blah = 1", expected_message, "assignment", None);
         expect_lint("blah = fun(1)", expected_message, "assignment", None);
+        expect_lint("names(blah) = 'a'", expected_message, "assignment", None);
+        expect_lint("x[[1]] = 2", expected_message, "assignment", None);
         expect_lint("fun((blah = fun(1)))", expected_message, "assignment", None);
         expect_lint("1 -> fun", expected_message, "assignment", None);
+        expect_lint("1 -> names(fun)", expected_message, "assignment", None);
+        expect_lint("2 -> x[[1]]", expected_message, "assignment", None);
 
         assert_snapshot!(
             "fix_output",
@@ -22,8 +26,12 @@ mod tests {
                     "blah=1",
                     "blah = 1",
                     "blah = fun(1)",
+                    "names(blah) = 'a'",
+                    "x[[1]] = 2",
                     "fun((blah = fun(1)))",
                     "1 -> fun",
+                    "'a' -> names(fun)",
+                    "2 -> x[[1]]",
                 ],
                 "assignment",
                 None

--- a/crates/flir-core/src/lints/assignment/snapshots/flir_core__lints__assignment__tests__fix_output.snap
+++ b/crates/flir-core/src/lints/assignment/snapshots/flir_core__lints__assignment__tests__fix_output.snap
@@ -1,6 +1,6 @@
 ---
 source: crates/flir-core/src/lints/assignment/mod.rs
-expression: "get_fixed_text(vec![\"blah=1\", \"blah = 1\", \"blah = fun(1)\",\n\"fun((blah = fun(1)))\", \"1 -> fun\",], \"assignment\", None)"
+expression: "get_fixed_text(vec![\"blah=1\", \"blah = 1\", \"blah = fun(1)\",\n\"names(blah) = 'a'\", \"x[[1]] = 2\", \"fun((blah = fun(1)))\", \"1 -> fun\",\n\"'a' -> names(fun)\", \"2 -> x[[1]]\",], \"assignment\", None)"
 ---
   OLD:
   ====
@@ -25,6 +25,20 @@ blah <- fun(1)
 
   OLD:
   ====
+names(blah) = 'a'
+  NEW:
+  ====
+names(blah) <- 'a'
+
+  OLD:
+  ====
+x[[1]] = 2
+  NEW:
+  ====
+x[[1]] <- 2
+
+  OLD:
+  ====
 fun((blah = fun(1)))
   NEW:
   ====
@@ -36,3 +50,17 @@ fun((blah <- fun(1)))
   NEW:
   ====
 fun <- 1
+
+  OLD:
+  ====
+'a' -> names(fun)
+  NEW:
+  ====
+names(fun) <- 'a'
+
+  OLD:
+  ====
+2 -> x[[1]]
+  NEW:
+  ====
+x[[1]] <- 2


### PR DESCRIPTION
Fixes #89 