### PR TITLE
ci: Add benchmark workflow

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -91,10 +91,10 @@ jobs:
             repo_dir=$(echo "$repo_name" | tr '/' '_')
 
             # Run main
-            (cd "$repo_dir" && hyperfine --warmup 5 --min-runs 5 '$MAIN_JARL check .' --ignore-failure  --export-json ../../results_bench/${repo_dir}_main.json) || true
+            (cd "$repo_dir" && hyperfine --warmup 5 --min-runs 50 '$MAIN_JARL check .' --ignore-failure  --export-json ../../results_bench/${repo_dir}_main.json) || true
 
             # Run PR
-            (cd "$repo_dir" && hyperfine --warmup 5 --min-runs 5 '$PR_JARL check .' --ignore-failure  --export-json ../../results_bench/${repo_dir}_pr.json) || true
+            (cd "$repo_dir" && hyperfine --warmup 5 --min-runs 50 '$PR_JARL check .' --ignore-failure  --export-json ../../results_bench/${repo_dir}_pr.json) || true
           done
 
       - name: Upload all result JSONs


### PR DESCRIPTION
Tried to play a bit with `divan` so that it can be integrated with CodSpeed, but the setup quickly became very complicated. Maybe eventually I would like to have narrower and more precise micro benchmarks, but for now I just want to check obvious perf regressions in real-life repos.

`hyperfine` is quite easy to use to test the perf of the final CLI.

Part of #22