### PR TITLE
fix: Fix printing of ANSI characters in Windows terminals

### DIFF
--- a/crates/jarl/src/main.rs
+++ b/crates/jarl/src/main.rs
@@ -9,6 +9,10 @@ use std::process::ExitCode;
 mod args;
 
 fn main() -> ExitCode {
+    // Enabled ANSI colors on Windows.
+    #[cfg(windows)]
+    assert!(colored::control::set_virtual_terminal(true).is_ok());
+
     let args = Args::parse();
 
     match run(args) {


### PR DESCRIPTION
Should be a fix for #177 but hard to know because I don't have a Windows machine where I can compile Rust so I'll have to do a release to test this.

Ruff does the same: https://github.com/astral-sh/ruff/blob/6cc502781ff96161c1db2af391dd56915037db2d/crates/ruff/src/main.rs#L32