### PR TITLE
[Do not merge]: Remove `browser` rule

### DIFF
--- a/crates/jarl-core/src/lints/mod.rs
+++ b/crates/jarl-core/src/lints/mod.rs
@@ -51,7 +51,7 @@ pub fn all_rules_and_safety() -> RuleTable {
     rule_table.enable("any_duplicated", "PERF", FixStatus::Safe, None);
     rule_table.enable("any_is_na", "PERF", FixStatus::Safe, None);
     rule_table.enable("assignment", "READ", FixStatus::Safe, None);
-    rule_table.enable("browser", "CORR", FixStatus::Safe, None);
+    // rule_table.enable("browser", "CORR", FixStatus::Safe, None);
     rule_table.enable("class_equals", "SUSP", FixStatus::Safe, None);
     rule_table.enable("comparison_negation", "READ", FixStatus::Safe, None);
     rule_table.enable("coalesce", "READ", FixStatus::Safe, Some((4, 4, 0)));


### PR DESCRIPTION
The ecosystem check in #185 didn't work properly because of the use of `pull_request_target`. We were comparing `main` twice and therefore didn't see any change in ecosystem. This PR removes `browser` to see if there are any changes in the ecosystem (now that CI has been fixed). This is not meant to be merged.

@jonocarroll FYI