### PR TITLE
fix: Fix `get_arg_by_name_then_position()` selecting wrong argument by position

### DIFF
--- a/crates/jarl-core/src/lints/expect_null/mod.rs
+++ b/crates/jarl-core/src/lints/expect_null/mod.rs
@@ -31,8 +31,7 @@ mod tests {
         expect_no_lint("expect_true(is.null())", "expect_null", None);
         expect_no_lint("expect_true(is.null(x =))", "expect_null", None);
 
-        // TODO: https://github.com/etiennebacher/jarl/issues/203
-        // expect_no_lint("expect_equal(expected = NULL)", "expect_null", None);
+        expect_no_lint("expect_equal(expected = NULL)", "expect_null", None);
     }
 
     #[test]

--- a/crates/jarl-core/src/utils.rs
+++ b/crates/jarl-core/src/utils.rs
@@ -136,9 +136,15 @@ pub fn get_arg_by_position(args: &RArgumentList, pos: usize) -> Option<RArgument
     args.iter().nth(pos - 1).map(|x| x.unwrap())
 }
 
+/// Takes a list of arguments and tries to extract the unnamed one in position `pos`.
+/// Argument `pos` is 1-indexed.
+pub fn get_unnamed_arg_by_position(args: &RArgumentList, pos: usize) -> Option<RArgument> {
+    get_unnamed_args(args).into_iter().nth(pos - 1)
+}
+
 /// Takes a list of arguments and first tries to extract the one named `name`.
 /// If it doesn't find any argument with this name, it tries to get the
-/// argument in position `pos`.
+/// unnamed argument in position `pos`.
 /// Returns None if this second attempt also fails.
 /// Argument `pos` is 1-indexed.
 pub fn get_arg_by_name_then_position(
@@ -148,7 +154,7 @@ pub fn get_arg_by_name_then_position(
 ) -> Option<RArgument> {
     match get_arg_by_name(args, name) {
         Some(by_name) => Some(by_name),
-        _ => get_arg_by_position(args, pos),
+        _ => get_unnamed_arg_by_position(args, pos),
     }
 }
 


### PR DESCRIPTION
Fixes #203