### PR TITLE
docs: Neovim - Add section on enabling fix-on-save with Conform.nvim and remove typo

### DIFF
--- a/docs/editors.md
+++ b/docs/editors.md
@@ -125,8 +125,29 @@ vim.lsp.config('jarl', {})
 vim.lsp.enable 'jarl'
 ```
 
-This enables the code-actions and diagnostics (somewhat - see below note).
+This enables the code-actions and diagnostics.
 
 ![](img/nvim_diagnostic.png){fig-alt="R script with multiple errors showing in-line indicating a rule violation."}
 
 ![](img/nvim_quick_fix.png){fig-alt="The same R script as before, but this time there is a list of three actions next to the piece of code: apply fix, ignore this rule, and ignore all rules."}
+
+If you want to enable 'fix on save' behavior in Neovim, you can use the following code with [conform.nvim](https://github.com/stevearc/conform.nvim):
+
+```lua
+require("conform").setup({
+  format_on_save = {
+    timeout_ms = 1500,
+    lsp_format = 'fallback',
+  },
+  formatters_by_ft = {
+    r = { 'jarl' },
+  },
+  formatters = {
+    jarl = {
+      command = 'jarl',
+      args = { 'check', '--fix', '$FILENAME' }, -- add other commands such as '--allow-no-vcs' as needed
+      stdin = false,
+    },
+  }
+})
+```

--- a/docs/editors.md
+++ b/docs/editors.md
@@ -134,7 +134,7 @@ This enables the code-actions and diagnostics.
 If you want to enable 'fix on save' behavior in Neovim, you can use the following code with [conform.nvim](https://github.com/stevearc/conform.nvim):
 
 ```lua
-require("conform").setup({
+require('conform').setup({
   format_on_save = {
     timeout_ms = 1500,
     lsp_format = 'fallback',


### PR DESCRIPTION
I was able to get fix on save working in Neovim and thought it may be helpful to add in the editor documentation for people. It does require an additional Neovim plugin, but it is probably the most popular plugin for formatting in Neovim. I'll let you decide if it is worth adding! Somewhat of a cheat method of addressing #160 but it works well for me!

I also removed the note in parentheses about seeing the below note that no longer exists.