### PR TITLE
feat!: Remove `assignment` from the VS Code / Positron settings

### DIFF
--- a/editors/code/README.md
+++ b/editors/code/README.md
@@ -9,10 +9,19 @@ A Visual Studio Code extension for [Jarl](https://jarl.etiennebacher.com/), a fa
   "jarl.logLevel": "info",
   "jarl.executableStrategy": "environment",
   "jarl.executablePath": "/path/to/custom/jarl",
-  "jarl.assignmentOperator": "="
 }
 ```
 
 ## More information
 
 See the website: https://jarl.etiennebacher.com/
+
+## Changelog
+
+### 0.0.10
+
+- Removed the setting "assignment" from the VS Code / Positron settings. This
+  should be defined in a `jarl.toml` file. To use this by default on all R files,
+  even those outside of a specific project, create a `jarl.toml` in [your config
+  folder](https://jarl.etiennebacher.com/config#config-file-detection).
+  (https://github.com/etiennebacher/jarl/pull/257)

--- a/editors/code/package.json
+++ b/editors/code/package.json
@@ -75,16 +75,6 @@
 					"scope": "application",
 					"type": "string"
 				},
-				"jarl.assignmentOperator": {
-					"default": "<-",
-					"markdownDescription": "Controls the preferred assignment operator and will report usage of the other one if the `assignment` linter is active. Changes take effect immediately.",
-					"enum": [
-						"<-",
-						"="
-					],
-					"scope": "window",
-					"type": "string"
-				},
 				"jarl.syncFileSettingsWithClient": {
 					"default": true,
 					"markdownDescription": "Whether settings from jarl.toml files should be propagated to the client (the IDE).",


### PR DESCRIPTION
Second part of #236 