### PR TITLE
feat!: Disable `sample_int` by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,8 @@
 
 - The rule `assignment` is now disabled by default (#258).
 
+- The rule `sample_int` is now disabled by default (#262).
+
 ### Bug fixes
 
 - When `output-format` is `json` or `github`, additional information displayed in

--- a/crates/jarl-core/src/rule_set.rs
+++ b/crates/jarl-core/src/rule_set.rs
@@ -426,7 +426,7 @@ declare_rules! {
     SampleInt => {
         name: "sample_int",
         categories: [Read],
-        default: Enabled,
+        default: Disabled,
         fix: Safe,
         min_r_version: None,
     },

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -21,6 +21,8 @@
 
 - The rule `assignment` is now disabled by default (#258).
 
+- The rule `sample_int` is now disabled by default (#262).
+
 ### Bug fixes
 
 - When `output-format` is `json` or `github`, additional information displayed in


### PR DESCRIPTION
I'm not convinced at all this makes the code more readable.

Fixes #121 