### PR TITLE
chore: Fix Alpine current stable release in integrations docs

### DIFF
--- a/docs/integrations.md
+++ b/docs/integrations.md
@@ -39,7 +39,7 @@ For container-based CI/CD, here is an example of using `jarl` within a slim alpi
 ```yaml
 steps:
   - name: lint-r-jarl
-    image: alpine:2.23
+    image: alpine:3.23
     commands: |
       apk add --no-cache -q curl
       curl -L -o jarl-installer.sh https://github.com/etiennebacher/jarl/releases/latest/download/jarl-installer.sh


### PR DESCRIPTION
Hey @etiennebacher I noticed that I wrongly put `alpine:2.23` which should be `alpine:3.23` for a current stable release.