### PR TITLE
fix: Properly detect suppression comments on second, third, etc. arguments in a function call

### DIFF
--- a/crates/jarl/tests/integration/comments.rs
+++ b/crates/jarl/tests/integration/comments.rs
@@ -167,6 +167,37 @@ foo(
     Ok(())
 }
 
+// I observed this in real-life packages where a suppression comment on the
+// second arg wasn't used.
+#[test]
+fn test_jarl_ignore_nested_in_call_second_argument() -> anyhow::Result<()> {
+    let directory = TempDir::new()?;
+    let directory = directory.path();
+
+    let test_path = "test.R";
+    std::fs::write(
+        directory.join(test_path),
+        "
+foo(
+  first_arg,
+  # jarl-ignore implicit_assignment: suppressing second arg
+  x <- 1
+)
+",
+    )?;
+
+    insta::assert_snapshot!(
+        &mut Command::new(binary_path())
+            .current_dir(directory)
+            .arg("check")
+            .arg(".")
+            .run()
+            .normalize_os_executable_name()
+    );
+
+    Ok(())
+}
+
 #[test]
 fn test_jarl_ignore_multiple_rules_multiple_comments() -> anyhow::Result<()> {
     let directory = TempDir::new()?;

--- a/crates/jarl/tests/integration/snapshots/integration__comments__jarl_ignore_nested_in_call_second_argument.snap
+++ b/crates/jarl/tests/integration/snapshots/integration__comments__jarl_ignore_nested_in_call_second_argument.snap
@@ -1,0 +1,13 @@
+---
+source: crates/jarl/tests/integration/comments.rs
+expression: "&mut\nCommand::new(binary_path()).current_dir(directory).arg(\"check\").arg(\".\").run().normalize_os_executable_name()"
+---
+success: true
+exit_code: 0
+----- stdout -----
+All checks passed!
+
+----- stderr -----
+
+----- args -----
+check .


### PR DESCRIPTION
Observed in `pkgcheck`:

```r
withr::with_envvar (
    list ("ROPENSCI_REVIEW_BOT" = "true"),
    # jarl-ignore implicit_assignment: to fix in next version
    x <- capture.output (summary (checks), type = "message")
)
```

The suppression comment was unused, leading to 2 violations (unused comment + implicit_assignment).

This PR fixes it.