### PR TITLE
fix: Remove infinite loop when fixing some `fixed_regex` diagnostics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -66,6 +66,11 @@
 
 * Jarl can be used with `pre-commit` and `prek`, see [Pre-commit tools](https://jarl.etiennebacher.com/precommit) (#379).
 
+### Bug fixes
+
+* `fixed_regex` could loop infinitely trying to add `fixed = TRUE`. This is
+  fixed (#387).
+
 ## 0.4.0
 
 ### Breaking changes

--- a/crates/jarl-core/src/lints/base/fixed_regex/fixed_regex.rs
+++ b/crates/jarl-core/src/lints/base/fixed_regex/fixed_regex.rs
@@ -1,5 +1,4 @@
 use crate::diagnostic::*;
-use crate::utils::drop_arg_by_name_or_position;
 use crate::utils::{get_arg_by_name_then_position, get_function_name, node_contains_comments};
 use air_r_syntax::*;
 use biome_rowan::AstNode;
@@ -60,27 +59,20 @@ pub fn fixed_regex(ast: &RCall) -> anyhow::Result<Option<Diagnostic>> {
         _ => return Ok(None),
     };
 
-    // Check if fixed is already set to TRUE
-    if let Some(fixed_arg) = get_arg_by_name_then_position(&args, "fixed", fixed_position)
-        && let Some(value) = fixed_arg.value()
-        && value.syntax().text_trimmed() == "TRUE"
-    {
-        // fixed = TRUE is already set, no need to lint
+    // Check if `fixed` is already explicitly supplied (by name or position).
+    // If the user wrote `fixed = TRUE`, `fixed = FALSE`, or `fixed = some_var`,
+    // they are making a deliberate choice and we should not second-guess it.
+    if get_arg_by_name_then_position(&args, "fixed", fixed_position).is_some() {
         return Ok(None);
     }
 
-    // Check if ignore.case is set to TRUE (implies regex interpretation)
+    // Check if ignore.case is explicitly supplied (implies regex interpretation)
     let ignore_case_position = match fn_name.as_str() {
         "gsub" | "sub" => 4,
         "regexpr" | "gregexpr" | "regexec" | "grep" | "grepl" => 3,
         _ => return Ok(None),
     };
-    if let Some(ignore_case_arg) =
-        get_arg_by_name_then_position(&args, "ignore.case", ignore_case_position)
-        && let Some(value) = ignore_case_arg.value()
-        && value.syntax().text_trimmed() == "TRUE"
-    {
-        // ignore.case = TRUE implies regex interpretation is needed
+    if get_arg_by_name_then_position(&args, "ignore.case", ignore_case_position).is_some() {
         return Ok(None);
     }
 
@@ -101,26 +93,13 @@ pub fn fixed_regex(ast: &RCall) -> anyhow::Result<Option<Diagnostic>> {
         return Ok(None);
     }
 
-    // Pattern is fixed but fixed = TRUE is not set
-    // Build the fix by adding fixed = TRUE to the arguments or changing the value
-    // of fixed = FALSE.
-    let args_text = if let Some(fixed_arg) =
-        get_arg_by_name_then_position(&args, "fixed", fixed_position)
-        && let Some(value) = fixed_arg.value()
-        && value.syntax().text_trimmed() == "FALSE"
-    {
-        unwrap_or_return_none!(drop_arg_by_name_or_position(&args, "fixed", fixed_position))
-            .into_iter()
-            .map(|arg| arg.syntax().text_trimmed().to_string())
-            .collect::<Vec<_>>()
-            .join(", ")
-    } else {
-        args.into_iter()
-            .filter_map(|arg| arg.ok())
-            .map(|arg| arg.syntax().text_trimmed().to_string())
-            .collect::<Vec<_>>()
-            .join(", ")
-    };
+    // Pattern is fixed but `fixed` is not set — build fix by adding `fixed = TRUE`.
+    let args_text = args
+        .into_iter()
+        .filter_map(|arg| arg.ok())
+        .map(|arg| arg.syntax().text_trimmed().to_string())
+        .collect::<Vec<_>>()
+        .join(", ");
 
     let fixed_content = format!("{}({}, fixed = TRUE)", fn_name, args_text);
 

--- a/crates/jarl-core/src/lints/base/fixed_regex/mod.rs
+++ b/crates/jarl-core/src/lints/base/fixed_regex/mod.rs
@@ -26,8 +26,10 @@ mod tests {
         // Pattern is not a string literal
         expect_no_lint("grepl(fmt, y)", "fixed_regex", None);
 
-        // fixed = TRUE is already set, regex patterns don't matter
+        // fixed is already set (TRUE, FALSE, or variable)
         expect_no_lint("{gsub('abc', '', y, fixed = TRUE)}", "fixed_regex", None);
+        expect_no_lint("grepl('Foo', x, fixed = fixed)", "fixed_regex", None);
+        expect_no_lint("grepl('Foo', x, fixed = FALSE)", "fixed_regex", None);
 
         // TODO: once again, get_arg_by_name_then_position() fails to get the correct value
         // fixed = TRUE but by position
@@ -37,12 +39,13 @@ mod tests {
         //     None,
         // );
 
-        // ignore.case=TRUE implies regex interpretation
+        // ignore.case is explicitly supplied (TRUE, FALSE, or variable)
         expect_no_lint(
             "gsub('abcdefg', '', y, ignore.case = TRUE)",
             "fixed_regex",
             None,
         );
+        expect_no_lint("grep('foo', x, ignore.case = ic)", "fixed_regex", None);
 
         // char classes starting with [] might contain other characters -> not fixed
         expect_no_lint("sub('[][]', '', y)", "fixed_regex", None);
@@ -194,8 +197,6 @@ mod tests {
                     "sub('abcdefg', 'a', x)",
                     "gregexpr('abcdefg', x)",
                     "gregexpr('a-z', y)",
-                    "gregexpr('a-z', y, fixed = FALSE)",
-                    "gregexpr('a-z', y, fixed = FALSE, ignore.case = FALSE)",
                     "gregexpr(pattern = 'a-z', y)",
                 ],
                 "fixed_regex",

--- a/crates/jarl-core/src/lints/base/fixed_regex/snapshots/jarl_core__lints__base__fixed_regex__tests__fix_output.snap
+++ b/crates/jarl-core/src/lints/base/fixed_regex/snapshots/jarl_core__lints__base__fixed_regex__tests__fix_output.snap
@@ -1,6 +1,6 @@
 ---
 source: crates/jarl-core/src/lints/base/fixed_regex/mod.rs
-expression: "get_fixed_text(vec![\"grepl('abcdefg', x)\", \"grep('abcdefg', x)\",\n\"regexec('abcdefg', x)\", \"regexpr('abcdefg', x)\", \"gsub('abcdefg', 'a', x)\",\n\"sub('abcdefg', 'a', x)\", \"gregexpr('abcdefg', x)\", \"gregexpr('a-z', y)\",\n\"gregexpr('a-z', y, fixed = FALSE)\",\n\"gregexpr('a-z', y, fixed = FALSE, ignore.case = FALSE)\",\n\"gregexpr(pattern = 'a-z', y)\",], \"fixed_regex\", None)"
+expression: "get_fixed_text(vec![\"grepl('abcdefg', x)\", \"grep('abcdefg', x)\",\n\"regexec('abcdefg', x)\", \"regexpr('abcdefg', x)\", \"gsub('abcdefg', 'a', x)\",\n\"sub('abcdefg', 'a', x)\", \"gregexpr('abcdefg', x)\", \"gregexpr('a-z', y)\",\n\"gregexpr(pattern = 'a-z', y)\",], \"fixed_regex\", None)"
 ---
 OLD:
 ====
@@ -57,20 +57,6 @@ gregexpr('a-z', y)
 NEW:
 ====
 gregexpr('a-z', y, fixed = TRUE)
-
-OLD:
-====
-gregexpr('a-z', y, fixed = FALSE)
-NEW:
-====
-gregexpr('a-z', y, fixed = TRUE)
-
-OLD:
-====
-gregexpr('a-z', y, fixed = FALSE, ignore.case = FALSE)
-NEW:
-====
-gregexpr('a-z', y, ignore.case = FALSE, fixed = TRUE)
 
 OLD:
 ====

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -66,6 +66,11 @@
 
 * Jarl can be used with `pre-commit` and `prek`, see [Pre-commit tools](https://jarl.etiennebacher.com/precommit) (#379).
 
+### Bug fixes
+
+* `fixed_regex` could loop infinitely trying to add `fixed = TRUE`. This is
+  fixed (#387).
+
 ## 0.4.0
 
 ### Breaking changes


### PR DESCRIPTION
Would happen when `fixed = some_var` was already in `grepl()` for instance. 