### PR TITLE
refactor: Ensure each project root has its own package cache

### DIFF
--- a/crates/jarl/src/commands/check.rs
+++ b/crates/jarl/src/commands/check.rs
@@ -1,7 +1,7 @@
 use air_workspace::resolve::PathResolver;
 use jarl_core::discovery::{discover_r_file_paths, discover_settings};
 use jarl_core::library_paths::is_r_available;
-use jarl_core::package_cache::PackageCache;
+use jarl_core::package_cache::{PackageCache, find_r_project_root};
 use jarl_core::rule_set::Rule;
 use jarl_core::{
     config::ArgsConfig,
@@ -106,11 +106,10 @@ pub fn check(args: CheckCommand) -> Result<ExitStatus> {
         groups.entry(key).or_default().push(path);
     }
 
-    // Lazily discover R library paths only when a config enables package-
-    // specific rules (e.g., DPLYR). This avoids the ~200ms Rscript cost
-    // when no such rules are active, which also avoids requiring R in CI.
-    let mut package_cache: Option<Arc<PackageCache>> = None;
-    let mut cache_initialized = false;
+    // Track whether we've already verified R is available (avoid repeated checks).
+    let mut r_available_checked = false;
+    // Cache of project root - PackageCache to avoid duplicate Rscript calls.
+    let mut root_caches: HashMap<Option<PathBuf>, Option<Arc<PackageCache>>> = HashMap::new();
 
     let mut file_results = Vec::new();
     for (dir_key, group_paths) in groups {
@@ -118,38 +117,60 @@ pub fn check(args: CheckCommand) -> Result<ExitStatus> {
             .as_deref()
             .and_then(|dir| resolver.items().iter().find(|item| item.path() == dir))
             .map(|item| item.value());
-        let mut config = build_config(&check_config, settings, group_paths)?;
 
-        if config.rules_to_apply.has_package_specific_rules() {
-            if !cache_initialized {
-                if !is_r_available() {
-                    let pkg_categories: Vec<_> = config
-                        .rules_to_apply
-                        .package_specific_categories()
-                        .into_iter()
-                        .map(|c| c.as_str())
-                        .collect();
-                    return Err(anyhow::anyhow!(
-                        "Package-specific rules are enabled ({}) but R is not available.\n\n\
-                         These rules require R and installed packages to resolve function origins.\n\n\
-                         If running in CI with `setup-jarl`, uncomment (or add yourself) the R setup steps in your workflow:\n\n\
-                         \x20 - uses: r-lib/actions/setup-r@v2\n\
-                         \x20 - uses: r-lib/actions/setup-r-dependencies@v2\n\n\
-                         You can also disable these rules instead.",
-                        pkg_categories.join(", "),
-                    ));
-                }
-                let r_pkg_names = config.rules_to_apply.pkg_names_from_category();
-                let project_root = cwd.as_deref();
-                if let Some(cache) = PackageCache::from_rscript(&r_pkg_names, project_root) {
-                    package_cache = Some(Arc::new(cache));
-                }
-                cache_initialized = true;
-            }
-            config.package_cache = package_cache.clone();
+        let config = build_config(&check_config, settings, group_paths.clone())?;
+
+        if !config.rules_to_apply.has_package_specific_rules() {
+            file_results.extend(jarl_core::check::check(config));
+            continue;
         }
 
-        file_results.extend(jarl_core::check::check(config));
+        // Package-specific rules are enabled — need per-project-root caches.
+        if !r_available_checked {
+            if !is_r_available() {
+                let pkg_categories: Vec<_> = config
+                    .rules_to_apply
+                    .package_specific_categories()
+                    .into_iter()
+                    .map(|c| c.as_str())
+                    .collect();
+                return Err(anyhow::anyhow!(
+                    "Package-specific rules are enabled ({}) but R is not available.\n\n\
+                     These rules require R and installed packages to resolve function origins.\n\n\
+                     If running in CI with `setup-jarl`, uncomment (or add yourself) the R setup steps in your workflow:\n\n\
+                     \x20 - uses: r-lib/actions/setup-r@v2\n\
+                     \x20 - uses: r-lib/actions/setup-r-dependencies@v2\n\n\
+                     You can also disable these rules instead.",
+                    pkg_categories.join(", "),
+                ));
+            }
+            r_available_checked = true;
+        }
+
+        let r_pkg_names = config.rules_to_apply.pkg_names_from_category();
+        drop(config);
+
+        // Sub-group files by R project root so each renv/system project
+        // gets its own PackageCache.
+        let mut by_root: HashMap<Option<PathBuf>, Vec<PathBuf>> = HashMap::new();
+        for path in &group_paths {
+            let root = find_r_project_root(path);
+            by_root.entry(root).or_default().push(path.clone());
+        }
+
+        for (root, sub_paths) in by_root {
+            let mut config = build_config(&check_config, settings, sub_paths)?;
+
+            let cache = root_caches
+                .entry(root.clone())
+                .or_insert_with(|| {
+                    PackageCache::from_rscript(&r_pkg_names, root.as_deref()).map(Arc::new)
+                })
+                .clone();
+
+            config.package_cache = cache;
+            file_results.extend(jarl_core::check::check(config));
+        }
     }
 
     let mut all_errors = Vec::new();


### PR DESCRIPTION
When calling Jarl on a folder that contains two projects, one with `renv` and one without, we want each project to access their own package cache (respectively the `renv/library` and the system library).