### PR TITLE
fix: Wrong parsing error with `next()` and `break()`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -80,6 +80,8 @@
 
 * Suppression comments now work better when inserted in piped chains (#397).
 
+* Fix a wrong parsing error when using `next()` or `break()` (#417).
+
 ## 0.4.0
 
 ### Breaking changes

--- a/crates/jarl-core/src/lints/base/duplicated_arguments/duplicated_arguments.rs
+++ b/crates/jarl-core/src/lints/base/duplicated_arguments/duplicated_arguments.rs
@@ -29,27 +29,29 @@ pub fn duplicated_arguments(ast: &RCall, checker: &Checker) -> anyhow::Result<Op
     let RCallFields { function, arguments } = ast.as_fields();
 
     let fun_name = match function? {
-        AnyRExpression::RNamespaceExpression(x) => {
-            x.right()?.into_syntax().text_trimmed().to_string()
-        }
+        AnyRExpression::AnyRValue(x) => x.into_syntax().text_trimmed().to_string(),
         AnyRExpression::RBracedExpressions(x) => x
             .expressions()
             .into_iter()
             .map(|x| x.to_string())
             .collect::<Vec<String>>()
             .join(""),
+        AnyRExpression::RBreakExpression(_) => "break".to_string(),
         AnyRExpression::RExtractExpression(x) => {
             x.right()?.into_syntax().text_trimmed().to_string()
         }
         AnyRExpression::RCall(x) => x.function()?.into_syntax().text_trimmed().to_string(),
-        AnyRExpression::RSubset(x) => x.arguments()?.into_syntax().text_trimmed().to_string(),
-        AnyRExpression::RSubset2(x) => x.arguments()?.into_syntax().text_trimmed().to_string(),
         AnyRExpression::RIdentifier(x) => x.into_syntax().text_trimmed().to_string(),
-        AnyRExpression::AnyRValue(x) => x.into_syntax().text_trimmed().to_string(),
+        AnyRExpression::RNamespaceExpression(x) => {
+            x.right()?.into_syntax().text_trimmed().to_string()
+        }
+        AnyRExpression::RNextExpression(_) => "next".to_string(),
         AnyRExpression::RParenthesizedExpression(x) => {
             x.body()?.into_syntax().text_trimmed().to_string()
         }
         AnyRExpression::RReturnExpression(x) => x.into_syntax().text_trimmed().to_string(),
+        AnyRExpression::RSubset(x) => x.arguments()?.into_syntax().text_trimmed().to_string(),
+        AnyRExpression::RSubset2(x) => x.arguments()?.into_syntax().text_trimmed().to_string(),
         _ => {
             return Err(anyhow!(
                 "couldn't find function name for duplicated_arguments linter.",

--- a/crates/jarl/tests/integration/edge_cases.rs
+++ b/crates/jarl/tests/integration/edge_cases.rs
@@ -1,0 +1,48 @@
+use std::process::Command;
+use tempfile::TempDir;
+
+use crate::helpers::CommandExt;
+use crate::helpers::binary_path;
+
+// This collects edge cases and runs them with all rules to ensure that we didn't
+// fix just one particular rule but left errors in another one;
+
+// https://github.com/etiennebacher/jarl/issues/416
+#[test]
+fn test_jarl_break_and_next_kw_as_call() -> anyhow::Result<()> {
+    let directory = TempDir::new()?;
+    let directory = directory.path();
+
+    let test_path = "test.R";
+    std::fs::write(
+        directory.join(test_path),
+        "
+for (i in 1:3) {
+    break()
+}
+for (i in 1:3) {
+    next()
+}",
+    )?;
+
+    insta::assert_snapshot!(
+        &mut Command::new(binary_path())
+            .current_dir(directory)
+            .arg("check")
+            .arg(".")
+            .run()
+            .normalize_os_executable_name(),
+        @"
+
+    success: true
+    exit_code: 0
+    ----- stdout -----
+    ── Summary ──────────────────────────────────────
+    All checks passed!
+
+    ----- stderr -----
+    "
+    );
+
+    Ok(())
+}

--- a/crates/jarl/tests/integration/main.rs
+++ b/crates/jarl/tests/integration/main.rs
@@ -11,6 +11,7 @@ mod allow_dirty;
 mod allow_no_vcs;
 mod assignment;
 mod comments;
+mod edge_cases;
 mod exclude;
 mod help;
 mod helpers;

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -80,6 +80,8 @@
 
 * Suppression comments now work better when inserted in piped chains (#397).
 
+* Fix a wrong parsing error when using `next()` or `break()` (#417).
+
 ## 0.4.0
 
 ### Breaking changes


### PR DESCRIPTION
Fixes #416 

New violations in ecosystem checks because some files that had a parsing error are now analyzed.