### PR TITLE
refactor: Gather all Rmd chunks and then process them

### DIFF
--- a/crates/jarl-core/src/check.rs
+++ b/crates/jarl-core/src/check.rs
@@ -4,14 +4,12 @@ use crate::package::{
     summarize_package_info,
 };
 use crate::roxygen::{extract_roxygen_examples, remap_roxygen_fix, remap_roxygen_range};
-use crate::rule_set::Rule;
 use crate::suppression::SuppressionManager;
 use crate::vcs::check_version_control;
 use air_fs::relativize_path;
 use air_r_parser::RParserOptions;
 use air_r_syntax::{RExpressionList, RSyntaxNode};
 use anyhow::{Context, Result};
-use biome_rowan::TextSize;
 use rayon::prelude::*;
 use std::collections::HashMap;
 use std::fs;
@@ -384,141 +382,56 @@ fn get_checks_roxygen(
     Ok(all_diagnostics)
 }
 
-/// Lint an Rmd/Qmd file by extracting R code chunks and checking each one.
+/// Lint an Rmd/Qmd file by concatenating R code chunks into a virtual R
+/// string and running the normal linting pipeline on it.
 ///
 /// Key differences from regular R file linting:
 /// - No autofix (Quarto code annotations make position-based edits unsafe)
-/// - Diagnostic ranges are remapped from chunk-local byte offsets to file offsets
-/// - `#| jarl-ignore-chunk` silently skips an entire chunk
-/// - `#| jarl-ignore-file` suppression is applied across all chunks
+/// - `#| jarl-ignore-chunk:` YAML blocks are translated to `# jarl-ignore-start`
+///   / `# jarl-ignore-end` pairs before linting
+/// - Chunks with parse errors are silently dropped
+/// - Diagnostic ranges are remapped from virtual-string offsets to original file offsets
 fn get_checks_rmd(contents: &str, file: &Path, config: &Config) -> Result<Vec<Diagnostic>> {
-    use std::collections::HashSet;
-
     let chunks = crate::rmd::extract_r_chunks(contents);
+    let (virtual_source, offset_map) = crate::rmd::build_virtual_r_source(&chunks);
 
-    struct ChunkState {
-        parsed: air_r_parser::Parse,
-        suppression: SuppressionManager,
-        start_byte: usize,
+    if virtual_source.trim().is_empty() {
+        return Ok(Vec::new());
     }
 
-    // ── Pass 1: parse each chunk, build suppression managers,
-    //    and collect file-level suppressed rules across all chunks ──
-    let mut file_suppressed: HashSet<Rule> = HashSet::new();
-    // Maps each file-level suppression comment to its rule, using file-level byte
-    // offsets (chunk-local offset + chunk start_byte). Used later to remove
-    // spurious outdated_suppression diagnostics for cross-chunk suppressions.
-    let mut file_suppression_ranges: Vec<(biome_rowan::TextRange, Rule)> = Vec::new();
-    let mut states: Vec<Option<ChunkState>> = Vec::with_capacity(chunks.len());
-
-    for (chunk_index, chunk) in chunks.iter().enumerate() {
-        let parsed = air_r_parser::parse(&chunk.code, RParserOptions::default());
-        if parsed.has_error() {
-            // Silently skip chunks with parse errors (e.g. documentation examples).
-            states.push(None);
-            continue;
-        }
-        let mut suppression = SuppressionManager::from_node(&parsed.syntax(), &chunk.code);
-
-        // `# jarl-ignore-file` is only valid in the first R chunk (before any code).
-        // In subsequent chunks it behaves like any other misplaced file suppression.
-        if chunk_index > 0 {
-            for fs in suppression.file_suppressions.drain(..) {
-                suppression
-                    .misplaced_file_suppressions
-                    .push(fs.comment_range);
-            }
-        }
-
-        let offset = TextSize::from(chunk.start_byte as u32);
-        for fs in &suppression.file_suppressions {
-            file_suppressed.insert(fs.rule);
-            file_suppression_ranges.push((
-                biome_rowan::TextRange::new(
-                    fs.comment_range.start() + offset,
-                    fs.comment_range.end() + offset,
-                ),
-                fs.rule,
-            ));
-        }
-        states.push(Some(ChunkState {
-            parsed,
-            suppression,
-            start_byte: chunk.start_byte,
-        }));
+    let parsed = air_r_parser::parse(&virtual_source, RParserOptions::default());
+    if parsed.has_error() {
+        return Err(crate::error::ParseError { filename: file.to_path_buf() }.into());
     }
 
-    // ── Pass 2: run lints on each chunk using its pre-built suppression manager ──
-    let mut all_diagnostics: Vec<Diagnostic> = Vec::new();
+    let suppression = SuppressionManager::from_node(&parsed.syntax(), &virtual_source);
+    let mut checker = Checker::new(suppression, config.rule_options.clone());
+    checker.rule_set = config.rules_to_apply.clone();
+    checker.minimum_r_version = config.minimum_r_version;
 
-    for state in states {
-        let Some(ChunkState { parsed, suppression, start_byte }) = state else {
-            continue;
-        };
+    let expressions = &parsed.tree().expressions();
+    for expr in expressions {
+        check_expression(&expr, &mut checker)?;
+    }
+    // check_document runs suppression filtering internally, so
+    // checker.diagnostics is the post-suppression list after this call.
+    // Rmd chunks don't participate in package-level analysis, so pass empty slices.
+    check_document(expressions, &mut checker, &[], &[])?;
 
-        let expressions = &parsed.tree().expressions();
-        let mut checker = Checker::new(suppression, config.rule_options.clone());
-        checker.rule_set = config.rules_to_apply.clone();
-        checker.minimum_r_version = config.minimum_r_version;
-
-        for expr in expressions {
-            check_expression(&expr, &mut checker)?;
-        }
-        // check_document runs suppression filtering internally, so
-        // checker.diagnostics is the post-suppression list after this call.
-        // Rmd chunks don't participate in package-level analysis, so pass empty slices.
-        check_document(expressions, &mut checker, &[], &[])?;
-
-        let offset = TextSize::from(start_byte as u32);
-        let diagnostics = checker.diagnostics.into_iter().map(|mut d| {
+    // Remap ranges from virtual-string offsets to original Rmd file offsets.
+    let diagnostics: Vec<Diagnostic> = checker
+        .diagnostics
+        .into_iter()
+        .map(|mut d| {
             d.filename = file.to_path_buf();
-            d.fix = Fix::empty(); // no autofix for Rmd/Qmd
-            // Remap range from chunk-local byte offsets to original file offsets.
-            d.range = biome_rowan::TextRange::new(d.range.start() + offset, d.range.end() + offset);
+            d.fix = Fix::empty();
+            d.range = offset_map.remap_range(d.range);
             d
-        });
-        all_diagnostics.extend(diagnostics);
-    }
-
-    // A `# jarl-ignore-file` comment in one chunk can suppress violations in
-    // other chunks. From the perspective of the chunk that contains the comment,
-    // there are no local violations to suppress, so `check_document` marks the
-    // suppression as unused and emits an `outdated_suppression` diagnostic.
-    // Before the cross-chunk filter below removes the actual violations, we
-    // identify which file-suppression comments are genuinely used cross-chunk
-    // and remove the spurious outdated_suppression diagnostics for them.
-    if !file_suppression_ranges.is_empty() {
-        // Rules that have at least one real violation somewhere in the document.
-        let rules_violated: HashSet<Rule> = all_diagnostics
-            .iter()
-            .filter(|d| d.message.name != "outdated_suppression")
-            .filter_map(|d| Rule::from_name(&d.message.name))
-            .filter(|r| file_suppressed.contains(r))
-            .collect();
-
-        if !rules_violated.is_empty() {
-            // File-level suppression comment ranges that are actively used cross-chunk.
-            let used_file_ranges: HashSet<biome_rowan::TextRange> = file_suppression_ranges
-                .iter()
-                .filter(|(_, rule)| rules_violated.contains(rule))
-                .map(|(range, _)| *range)
-                .collect();
-
-            all_diagnostics.retain(|d| {
-                !(d.message.name == "outdated_suppression" && used_file_ranges.contains(&d.range))
-            });
-        }
-    }
-
-    // Apply cross-chunk jarl-ignore-file suppressions.
-    all_diagnostics.retain(|d| {
-        Rule::from_name(&d.message.name)
-            .map(|r| !file_suppressed.contains(&r))
-            .unwrap_or(true)
-    });
+        })
+        .collect();
 
     let loc_new_lines = crate::utils::find_new_lines_from_content(contents);
-    Ok(compute_lints_location(all_diagnostics, &loc_new_lines))
+    Ok(compute_lints_location(diagnostics, &loc_new_lines))
 }
 
 #[cfg(test)]

--- a/crates/jarl-core/src/rmd/extraction.rs
+++ b/crates/jarl-core/src/rmd/extraction.rs
@@ -127,6 +127,17 @@ impl OffsetMap {
     }
 }
 
+/// An invalid YAML array item that should be translated into a comment
+/// recognizable by the suppression system.
+struct InvalidChunkItem {
+    /// The original `rule: reason` text extracted from the YAML item.
+    text: String,
+    /// The parse result (`InvalidRuleName`, `MissingExplanation`, etc.).
+    result: DirectiveParseResult,
+    /// Byte range within the chunk code.
+    range: (usize, usize),
+}
+
 /// Parsed chunk suppression info for translation.
 struct ChunkIgnoreBlock {
     /// Rules with their full `rule: reason` text for start comments.
@@ -136,6 +147,8 @@ struct ChunkIgnoreBlock {
     header_end: usize,
     /// Per-item byte ranges within the chunk code (for offset mapping).
     item_ranges: Vec<(usize, usize)>, // (start, end) within chunk code
+    /// Invalid items that should be emitted as detectable comments.
+    invalid_items: Vec<InvalidChunkItem>,
 }
 
 /// Scan a chunk's code for `#| jarl-ignore-chunk:` YAML blocks and collect
@@ -149,6 +162,7 @@ fn find_chunk_ignore_blocks(code: &str) -> Vec<ChunkIgnoreBlock> {
             let header_start = offset;
             let mut rules = Vec::new();
             let mut item_ranges = Vec::new();
+            let mut invalid_items = Vec::new();
             let mut scan_offset = offset + line.len();
 
             // Look ahead for YAML array items.
@@ -165,22 +179,32 @@ fn find_chunk_ignore_blocks(code: &str) -> Vec<ChunkIgnoreBlock> {
                         item_ranges.push((scan_offset, scan_offset + item_line.len()));
                         scan_offset += item_line.len();
                     }
-                    Some(_) => {
+                    Some(result) => {
                         // Invalid item (missing explanation, bad rule name) — still
-                        // part of the YAML block. Include it so we skip past it, but
-                        // don't add a rule. The suppression system will report it.
+                        // part of the YAML block. Track it so we can emit a
+                        // detectable comment in the virtual source.
+                        let trimmed = item_line.trim();
+                        let rest = trimmed.strip_prefix("#|").unwrap_or(trimmed);
+                        let rest = rest.trim_start().strip_prefix('-').unwrap_or(rest);
+                        let text = rest.trim().to_string();
+                        invalid_items.push(InvalidChunkItem {
+                            text,
+                            result,
+                            range: (scan_offset, scan_offset + item_line.len()),
+                        });
                         scan_offset += item_line.len();
                     }
                     None => break, // Not a YAML item — stop look-ahead.
                 }
             }
 
-            if !rules.is_empty() {
+            if !rules.is_empty() || !invalid_items.is_empty() {
                 blocks.push(ChunkIgnoreBlock {
                     rules,
                     header_start,
                     header_end: scan_offset,
                     item_ranges,
+                    invalid_items,
                 });
             }
         }
@@ -289,20 +313,39 @@ fn emit_translated_chunk(
             });
         }
 
-        // Replace each line in the YAML block (header + items) with `#\n`.
+        // Replace each line in the YAML block with either an inert `#\n`
+        // comment or a detectable `# jarl-ignore` comment for invalid items.
         let block_text = &code[block.header_start..block.header_end];
         let mut line_offset = block.header_start;
         for line in block_text.split_inclusive('\n') {
-            let replacement = "#\n";
+            let line_start = line_offset;
+            let line_end = line_offset + line.len();
+
+            // Check if this line corresponds to an invalid item.
+            let replacement =
+                if let Some(item) = block.invalid_items.iter().find(|i| i.range.0 == line_start) {
+                    match item.result {
+                        DirectiveParseResult::InvalidRuleName => {
+                            format!("# jarl-ignore {}\n", item.text)
+                        }
+                        DirectiveParseResult::MissingExplanation => {
+                            format!("# jarl-ignore {}\n", item.text)
+                        }
+                        _ => "#\n".to_string(),
+                    }
+                } else {
+                    "#\n".to_string()
+                };
+
             let v_start = virtual_src.len();
-            virtual_src.push_str(replacement);
+            virtual_src.push_str(&replacement);
             segments.push(Segment {
                 virtual_start: v_start,
                 virtual_len: replacement.len(),
-                original_start: start_byte + line_offset,
-                original_len: line.len(),
+                original_start: start_byte + line_start,
+                original_len: line_end - line_start,
             });
-            line_offset += line.len();
+            line_offset = line_end;
         }
 
         code_offset = block.header_end;

--- a/crates/jarl-core/src/rmd/extraction.rs
+++ b/crates/jarl-core/src/rmd/extraction.rs
@@ -1,7 +1,15 @@
 //! Extraction of R code chunks from R Markdown and Quarto documents.
 
+use air_r_parser::RParserOptions;
+use biome_rowan::TextRange;
+use biome_rowan::TextSize;
 use regex::Regex;
 use std::sync::LazyLock;
+
+use crate::directive::{
+    DirectiveParseResult, LintDirective, is_quarto_chunk_array_header,
+    parse_quarto_chunk_array_item,
+};
 
 /// Matches the opening fence of an executable R code chunk.
 ///
@@ -65,6 +73,284 @@ pub fn extract_r_chunks(content: &str) -> Vec<RCodeChunk> {
     }
 
     chunks
+}
+
+/// A segment mapping virtual-string byte positions to original-file byte positions.
+#[derive(Debug, Clone)]
+struct Segment {
+    /// Start byte in the virtual R string.
+    virtual_start: usize,
+    /// Length in the virtual R string.
+    virtual_len: usize,
+    /// Corresponding start byte in the original Rmd file.
+    original_start: usize,
+    /// Length in the original file (may differ from `virtual_len` for translated lines).
+    original_len: usize,
+}
+
+/// Maps byte offsets from a virtual concatenated R string back to the original
+/// Rmd/Qmd file positions.
+#[derive(Debug, Clone)]
+pub struct OffsetMap {
+    segments: Vec<Segment>,
+}
+
+impl OffsetMap {
+    /// Remap a single byte offset from virtual-string space to original-file space.
+    fn remap_offset(&self, offset: usize) -> usize {
+        // Binary search for the segment containing this offset.
+        let idx = self
+            .segments
+            .partition_point(|s| s.virtual_start + s.virtual_len <= offset);
+        if idx < self.segments.len() {
+            let seg = &self.segments[idx];
+            let offset_within = offset.saturating_sub(seg.virtual_start);
+            seg.original_start + offset_within.min(seg.original_len.saturating_sub(1))
+        } else if let Some(last) = self.segments.last() {
+            // Past the end — clamp to end of last segment.
+            last.original_start + last.original_len
+        } else {
+            offset
+        }
+    }
+
+    /// Remap a `TextRange` from virtual-string space to original-file space.
+    pub fn remap_range(&self, range: TextRange) -> TextRange {
+        let start: usize = range.start().into();
+        let end: usize = range.end().into();
+        let new_start = self.remap_offset(start);
+        let new_end = self.remap_offset(end);
+        TextRange::new(
+            TextSize::from(new_start as u32),
+            TextSize::from(new_end as u32),
+        )
+    }
+}
+
+/// Parsed chunk suppression info for translation.
+struct ChunkIgnoreBlock {
+    /// Rules with their full `rule: reason` text for start comments.
+    rules: Vec<(String, String)>, // (rule_name, "rule: reason")
+    /// Byte range within the chunk code covering the `#|` header + item lines.
+    header_start: usize,
+    header_end: usize,
+    /// Per-item byte ranges within the chunk code (for offset mapping).
+    item_ranges: Vec<(usize, usize)>, // (start, end) within chunk code
+}
+
+/// Scan a chunk's code for `#| jarl-ignore-chunk:` YAML blocks and collect
+/// the rules and byte ranges.
+fn find_chunk_ignore_blocks(code: &str) -> Vec<ChunkIgnoreBlock> {
+    let mut blocks = Vec::new();
+    let mut offset = 0;
+
+    for line in code.split_inclusive('\n') {
+        if is_quarto_chunk_array_header(line) {
+            let header_start = offset;
+            let mut rules = Vec::new();
+            let mut item_ranges = Vec::new();
+            let mut scan_offset = offset + line.len();
+
+            // Look ahead for YAML array items.
+            for item_line in code[scan_offset..].split_inclusive('\n') {
+                match parse_quarto_chunk_array_item(item_line) {
+                    Some(DirectiveParseResult::Valid(LintDirective::IgnoreChunk(rule))) => {
+                        let rule_name = rule.name().to_string();
+                        // Reconstruct "rule: reason" from the parsed item line.
+                        let trimmed = item_line.trim();
+                        let rest = trimmed.strip_prefix("#|").unwrap_or(trimmed);
+                        let rest = rest.trim_start().strip_prefix('-').unwrap_or(rest);
+                        let rule_reason = rest.trim().to_string();
+                        rules.push((rule_name, rule_reason));
+                        item_ranges.push((scan_offset, scan_offset + item_line.len()));
+                        scan_offset += item_line.len();
+                    }
+                    Some(_) => {
+                        // Invalid item (missing explanation, bad rule name) — still
+                        // part of the YAML block. Include it so we skip past it, but
+                        // don't add a rule. The suppression system will report it.
+                        scan_offset += item_line.len();
+                    }
+                    None => break, // Not a YAML item — stop look-ahead.
+                }
+            }
+
+            if !rules.is_empty() {
+                blocks.push(ChunkIgnoreBlock {
+                    rules,
+                    header_start,
+                    header_end: scan_offset,
+                    item_ranges,
+                });
+            }
+        }
+        offset += line.len();
+    }
+
+    blocks
+}
+
+/// Build a virtual R source string by concatenating all valid R chunks,
+/// translating `#| jarl-ignore-chunk:` YAML blocks into
+/// `# jarl-ignore-start` / `# jarl-ignore-end` pairs.
+///
+/// Chunks with parse errors are silently dropped.
+///
+/// Returns the virtual source and an `OffsetMap` for remapping diagnostic
+/// byte offsets back to the original Rmd file.
+pub fn build_virtual_r_source(chunks: &[RCodeChunk]) -> (String, OffsetMap) {
+    let mut virtual_src = String::new();
+    let mut segments: Vec<Segment> = Vec::new();
+
+    for chunk in chunks {
+        // Skip empty chunks.
+        if chunk.code.trim().is_empty() {
+            continue;
+        }
+
+        // Pre-validate: skip chunks with parse errors.
+        let parsed = air_r_parser::parse(&chunk.code, RParserOptions::default());
+        if parsed.has_error() {
+            continue;
+        }
+
+        let blocks = find_chunk_ignore_blocks(&chunk.code);
+
+        if blocks.is_empty() {
+            // No YAML ignore blocks — emit chunk code as-is.
+            let v_start = virtual_src.len();
+            virtual_src.push_str(&chunk.code);
+            segments.push(Segment {
+                virtual_start: v_start,
+                virtual_len: chunk.code.len(),
+                original_start: chunk.start_byte,
+                original_len: chunk.code.len(),
+            });
+        } else {
+            // Translate YAML blocks into start/end comments.
+            emit_translated_chunk(
+                &chunk.code,
+                chunk.start_byte,
+                &blocks,
+                &mut virtual_src,
+                &mut segments,
+            );
+        }
+
+        // Ensure chunks are separated by a newline.
+        if !virtual_src.ends_with('\n') {
+            virtual_src.push('\n');
+        }
+    }
+
+    (virtual_src, OffsetMap { segments })
+}
+
+/// Emit a single chunk with YAML ignore blocks translated to start/end comments.
+fn emit_translated_chunk(
+    code: &str,
+    start_byte: usize,
+    blocks: &[ChunkIgnoreBlock],
+    virtual_src: &mut String,
+    segments: &mut Vec<Segment>,
+) {
+    // Collect all rules from all blocks (for prepend/append).
+    let all_rules: Vec<&(String, String)> = blocks.iter().flat_map(|b| &b.rules).collect();
+
+    // Prepend `# jarl-ignore-start` lines.
+    for (_rule_name, rule_reason) in &all_rules {
+        let start_comment = format!("# jarl-ignore-start {rule_reason}\n");
+        let v_start = virtual_src.len();
+        virtual_src.push_str(&start_comment);
+        // Map to the corresponding item line in the original file.
+        // Find the item range for this rule.
+        let item_original = find_item_original(blocks, rule_reason);
+        segments.push(Segment {
+            virtual_start: v_start,
+            virtual_len: start_comment.len(),
+            original_start: start_byte + item_original.0,
+            original_len: item_original.1 - item_original.0,
+        });
+    }
+
+    // Emit the chunk code, replacing YAML block lines with inert `#\n` comments.
+    let mut code_offset = 0;
+    for block in blocks {
+        // Emit code before this block.
+        if code_offset < block.header_start {
+            let slice = &code[code_offset..block.header_start];
+            let v_start = virtual_src.len();
+            virtual_src.push_str(slice);
+            segments.push(Segment {
+                virtual_start: v_start,
+                virtual_len: slice.len(),
+                original_start: start_byte + code_offset,
+                original_len: slice.len(),
+            });
+        }
+
+        // Replace each line in the YAML block (header + items) with `#\n`.
+        let block_text = &code[block.header_start..block.header_end];
+        let mut line_offset = block.header_start;
+        for line in block_text.split_inclusive('\n') {
+            let replacement = "#\n";
+            let v_start = virtual_src.len();
+            virtual_src.push_str(replacement);
+            segments.push(Segment {
+                virtual_start: v_start,
+                virtual_len: replacement.len(),
+                original_start: start_byte + line_offset,
+                original_len: line.len(),
+            });
+            line_offset += line.len();
+        }
+
+        code_offset = block.header_end;
+    }
+
+    // Emit remaining code after last block.
+    if code_offset < code.len() {
+        let slice = &code[code_offset..];
+        let v_start = virtual_src.len();
+        virtual_src.push_str(slice);
+        segments.push(Segment {
+            virtual_start: v_start,
+            virtual_len: slice.len(),
+            original_start: start_byte + code_offset,
+            original_len: slice.len(),
+        });
+    }
+
+    // Append `# jarl-ignore-end` lines.
+    for (rule_name, _rule_reason) in &all_rules {
+        let end_comment = format!("# jarl-ignore-end {rule_name}\n");
+        let v_start = virtual_src.len();
+        virtual_src.push_str(&end_comment);
+        // Map to the YAML header line as fallback.
+        let header_start = blocks[0].header_start;
+        let header_end = code[header_start..]
+            .find('\n')
+            .map_or(code.len(), |p| header_start + p + 1);
+        segments.push(Segment {
+            virtual_start: v_start,
+            virtual_len: end_comment.len(),
+            original_start: start_byte + header_start,
+            original_len: header_end - header_start,
+        });
+    }
+}
+
+/// Find the original byte range for a rule's item line in the YAML blocks.
+fn find_item_original(blocks: &[ChunkIgnoreBlock], rule_reason: &str) -> (usize, usize) {
+    for block in blocks {
+        for (i, (_name, reason)) in block.rules.iter().enumerate() {
+            if reason == rule_reason {
+                return block.item_ranges[i];
+            }
+        }
+    }
+    // Fallback: return the first block's header range.
+    (blocks[0].header_start, blocks[0].header_end)
 }
 
 #[cfg(test)]

--- a/crates/jarl-core/src/rmd/mod.rs
+++ b/crates/jarl-core/src/rmd/mod.rs
@@ -1,2 +1,2 @@
 pub mod extraction;
-pub use extraction::{RCodeChunk, extract_r_chunks};
+pub use extraction::{OffsetMap, RCodeChunk, build_virtual_r_source, extract_r_chunks};

--- a/crates/jarl/tests/integration/rmd.rs
+++ b/crates/jarl/tests/integration/rmd.rs
@@ -462,7 +462,7 @@ any(is.na(x))
     Ok(())
 }
 
-/// One of the suppressions is misnamed
+/// One of the suppressions is invalid
 #[test]
 fn test_wrong_rule_name() -> anyhow::Result<()> {
     let case = CliTest::with_file(
@@ -472,12 +472,14 @@ fn test_wrong_rule_name() -> anyhow::Result<()> {
 #| jarl-ignore-chunk:
 #|   - any_is_na: foo
 #|   - wrong_rule: bar
+#|   - any_duplicated:
 any(is.na(x))
 ```
 
 ```{r}
 # jarl-ignore any_is_na: foo
 # jarl-ignore wrong_rule: bar
+# jarl-ignore any_duplicated:
 any(is.na(x))
 ```
 ",
@@ -503,17 +505,33 @@ any(is.na(x))
       |
       = help: Check the rule name for typos.
 
+    warning: unexplained_suppression
+     --> test.Rmd:6:1
+      |
+    6 | #|   - any_duplicated:
+      | ---------------------- This comment isn't used by Jarl because it is missing an explanation.
+      |
+      = help: Add an explanation after the colon, e.g., `# jarl-ignore rule: <reason>`.
+
     warning: misnamed_suppression
-      --> test.Rmd:11:1
+      --> test.Rmd:12:1
        |
-    11 | # jarl-ignore wrong_rule: bar
+    12 | # jarl-ignore wrong_rule: bar
        | ----------------------------- This comment isn't used by Jarl because it contains an unrecognized rule name.
        |
        = help: Check the rule name for typos.
 
+    warning: unexplained_suppression
+      --> test.Rmd:13:1
+       |
+    13 | # jarl-ignore any_duplicated:
+       | ----------------------------- This comment isn't used by Jarl because it is missing an explanation.
+       |
+       = help: Add an explanation after the colon, e.g., `# jarl-ignore rule: <reason>`.
+
 
     ── Summary ──────────────────────────────────────
-    Found 2 errors.
+    Found 4 errors.
 
     ----- stderr -----
     "

--- a/crates/jarl/tests/integration/rmd.rs
+++ b/crates/jarl/tests/integration/rmd.rs
@@ -462,6 +462,66 @@ any(is.na(x))
     Ok(())
 }
 
+/// One of the suppressions is misnamed
+#[test]
+fn test_wrong_rule_name() -> anyhow::Result<()> {
+    let case = CliTest::with_file(
+        "test.Rmd",
+        "
+```{r}
+#| jarl-ignore-chunk:
+#|   - any_is_na: foo
+#|   - wrong_rule: bar
+any(is.na(x))
+```
+
+```{r}
+# jarl-ignore any_is_na: foo
+# jarl-ignore wrong_rule: bar
+any(is.na(x))
+```
+",
+    )?;
+
+    insta::assert_snapshot!(
+        &mut case
+            .command()
+            .arg("check")
+            .arg(".")
+            .run()
+            .normalize_os_executable_name(),
+        @"
+
+    success: false
+    exit_code: 1
+    ----- stdout -----
+    warning: misnamed_suppression
+     --> test.Rmd:5:1
+      |
+    5 | #|   - wrong_rule: bar
+      | ---------------------- This comment isn't used by Jarl because it contains an unrecognized rule name.
+      |
+      = help: Check the rule name for typos.
+
+    warning: misnamed_suppression
+      --> test.Rmd:11:1
+       |
+    11 | # jarl-ignore wrong_rule: bar
+       | ----------------------------- This comment isn't used by Jarl because it contains an unrecognized rule name.
+       |
+       = help: Check the rule name for typos.
+
+
+    ── Summary ──────────────────────────────────────
+    Found 2 errors.
+
+    ----- stderr -----
+    "
+    );
+
+    Ok(())
+}
+
 // ---------------------------------------------------------------------------
 // Chunk suppression scope
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
Do this instead of considering each chunk as an individual entity. This is necessary for rules that go beyond simple pattern recognition, such as `unused_object`.

Chunk suppression comments are converted to `jarl-ignore-start` and `jarl-ignore-end` pairs.