### PR TITLE
docs: YAML formatting for CI branch specification

### DIFF
--- a/docs/howto/ci.md
+++ b/docs/howto/ci.md
@@ -13,7 +13,8 @@ Here is an example YAML file:
 ```yml
 on:
   push:
-    branches: main
+    branches:
+      - main
   pull_request:
 
 name: jarl-check


### PR DESCRIPTION
Hi! 

Just a small PR to update CI example in the doc. `branches` expects an array rather than a single element, which triggers a message from some GA linters, and might break one day (unlikely but better be safe than sorry):

<img width="760" height="538" alt="image" src="https://github.com/user-attachments/assets/45d8db51-f9a2-4038-9f1d-ee56beb402bd" />
