### PR TITLE
fix: Skip chained assignments in `implicit_assignment`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,7 @@
 ### Bug fixes
 
 * `implicit_assignment` no longer flags chained assignments like
-  `if (TRUE) a <- b <- 1`, aligning with `lintr` behavior (#480).
+  `if (TRUE) a <- b <- 1`, aligning with `lintr` behavior (#480, @atsyplenkov).
 
 * Automatic fixes now skip rewrites when comments are inside the rewritten
   expression, while still allowing leading and trailing comments (#461, @Yousa-Mirage).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,9 @@
 
 ### Bug fixes
 
+* `implicit_assignment` no longer flags chained assignments like
+  `if (TRUE) a <- b <- 1`, aligning with `lintr` behavior (#480).
+
 * Automatic fixes now skip rewrites when comments are inside the rewritten
   expression, while still allowing leading and trailing comments (#461, @Yousa-Mirage).
 

--- a/crates/jarl-core/src/lints/base/implicit_assignment/implicit_assignment.rs
+++ b/crates/jarl-core/src/lints/base/implicit_assignment/implicit_assignment.rs
@@ -57,6 +57,44 @@ pub fn implicit_assignment(
         return Ok(None);
     };
 
+    // Skip chained assignments like `a <- b <- 1` or `x <- y <<- z`
+
+    // Helper to check if an operator is an assignment operator
+    let is_assignment_op = |op: &RSyntaxToken| {
+        op.kind() == RSyntaxKind::ASSIGN
+            || op.kind() == RSyntaxKind::SUPER_ASSIGN
+            || op.kind() == RSyntaxKind::ASSIGN_RIGHT
+            || op.kind() == RSyntaxKind::SUPER_ASSIGN_RIGHT
+    };
+
+    // Early return: if this assignment's RHS is also an assignment
+    // (i.e., we're the left part of a chain like `a <- b <- 1`)
+    if let Ok(right) = ast.right() {
+        if let Some(right_binary) = right.as_r_binary_expression() {
+            if let Ok(right_op) = right_binary.operator() {
+                if is_assignment_op(&right_op) {
+                    return Ok(None);
+                }
+            }
+        }
+    }
+
+    // Early return: if this assignment is the RHS of a parent assignment
+    // (i.e., we're the right part of a chain like `a <- b <- 1`)
+    if let Some(parent) = ast.syntax().parent() {
+        if let Some(parent_binary) = RBinaryExpression::cast(parent) {
+            if let Ok(parent_op) = parent_binary.operator() {
+                if is_assignment_op(&parent_op) {
+                    if let Ok(parent_rhs) = parent_binary.right() {
+                        if parent_rhs.syntax() == ast.syntax() {
+                            return Ok(None);
+                        }
+                    }
+                }
+            }
+        }
+    }
+
     // We want to report the use of assignment in function arguments, but not
     // when they're part of the body of some functions, e.g.
     // ```

--- a/crates/jarl-core/src/lints/base/implicit_assignment/implicit_assignment.rs
+++ b/crates/jarl-core/src/lints/base/implicit_assignment/implicit_assignment.rs
@@ -48,18 +48,6 @@ pub fn implicit_assignment(
     ast: &RBinaryExpression,
     checker: &Checker,
 ) -> anyhow::Result<Option<Diagnostic>> {
-    let operator = ast.operator()?;
-    if operator.kind() != RSyntaxKind::ASSIGN
-        && operator.kind() != RSyntaxKind::SUPER_ASSIGN
-        && operator.kind() != RSyntaxKind::ASSIGN_RIGHT
-        && operator.kind() != RSyntaxKind::SUPER_ASSIGN_RIGHT
-    {
-        return Ok(None);
-    };
-
-    // Skip chained assignments like `a <- b <- 1` or `x <- y <<- z`
-
-    // Helper to check if an operator is an assignment operator
     let is_assignment_op = |op: &RSyntaxToken| {
         op.kind() == RSyntaxKind::ASSIGN
             || op.kind() == RSyntaxKind::SUPER_ASSIGN
@@ -67,18 +55,13 @@ pub fn implicit_assignment(
             || op.kind() == RSyntaxKind::SUPER_ASSIGN_RIGHT
     };
 
-    // Early return: if this assignment's RHS is also an assignment
-    // (i.e., we're the left part of a chain like `a <- b <- 1`)
-    if let Ok(right) = ast.right()
-        && let Some(right_binary) = right.as_r_binary_expression()
-        && let Ok(right_op) = right_binary.operator()
-        && is_assignment_op(&right_op)
-    {
+    let operator = ast.operator()?;
+    if !is_assignment_op(&operator) {
         return Ok(None);
-    }
+    };
 
-    // Early return: if this assignment is the RHS of a parent assignment
-    // (i.e., we're the right part of a chain like `a <- b <- 1`)
+    // Skip chained assignments like `a <- b <- 1` or `x <- y <<- z`
+    // by returning early if this assignment is the RHS of a parent assignment.
     if let Some(parent) = ast.syntax().parent()
         && let Some(parent_binary) = RBinaryExpression::cast(parent)
         && let Ok(parent_op) = parent_binary.operator()

--- a/crates/jarl-core/src/lints/base/implicit_assignment/implicit_assignment.rs
+++ b/crates/jarl-core/src/lints/base/implicit_assignment/implicit_assignment.rs
@@ -69,30 +69,24 @@ pub fn implicit_assignment(
 
     // Early return: if this assignment's RHS is also an assignment
     // (i.e., we're the left part of a chain like `a <- b <- 1`)
-    if let Ok(right) = ast.right() {
-        if let Some(right_binary) = right.as_r_binary_expression() {
-            if let Ok(right_op) = right_binary.operator() {
-                if is_assignment_op(&right_op) {
-                    return Ok(None);
-                }
-            }
-        }
+    if let Ok(right) = ast.right()
+        && let Some(right_binary) = right.as_r_binary_expression()
+        && let Ok(right_op) = right_binary.operator()
+        && is_assignment_op(&right_op)
+    {
+        return Ok(None);
     }
 
     // Early return: if this assignment is the RHS of a parent assignment
     // (i.e., we're the right part of a chain like `a <- b <- 1`)
-    if let Some(parent) = ast.syntax().parent() {
-        if let Some(parent_binary) = RBinaryExpression::cast(parent) {
-            if let Ok(parent_op) = parent_binary.operator() {
-                if is_assignment_op(&parent_op) {
-                    if let Ok(parent_rhs) = parent_binary.right() {
-                        if parent_rhs.syntax() == ast.syntax() {
-                            return Ok(None);
-                        }
-                    }
-                }
-            }
-        }
+    if let Some(parent) = ast.syntax().parent()
+        && let Some(parent_binary) = RBinaryExpression::cast(parent)
+        && let Ok(parent_op) = parent_binary.operator()
+        && is_assignment_op(&parent_op)
+        && let Ok(parent_rhs) = parent_binary.right()
+        && parent_rhs.syntax() == ast.syntax()
+    {
+        return Ok(None);
     }
 
     // We want to report the use of assignment in function arguments, but not

--- a/crates/jarl-core/src/lints/base/implicit_assignment/mod.rs
+++ b/crates/jarl-core/src/lints/base/implicit_assignment/mod.rs
@@ -205,6 +205,9 @@ mod tests {
             "implicit_assignment",
             None,
         );
+        // Triple chained assignments
+        expect_no_lint("if (TRUE) a <- b <- c <- 1", "implicit_assignment", None);
+        expect_no_lint("if (TRUE) { a <- b <- c <- 1 }", "implicit_assignment", None);
         // Nested braced blocks with chained assignment
         expect_no_lint(
             "if (TRUE) { if (TRUE) { obj$x <- y <- foo() } }",

--- a/crates/jarl-core/src/lints/base/implicit_assignment/mod.rs
+++ b/crates/jarl-core/src/lints/base/implicit_assignment/mod.rs
@@ -207,7 +207,11 @@ mod tests {
         );
         // Triple chained assignments
         expect_no_lint("if (TRUE) a <- b <- c <- 1", "implicit_assignment", None);
-        expect_no_lint("if (TRUE) { a <- b <- c <- 1 }", "implicit_assignment", None);
+        expect_no_lint(
+            "if (TRUE) { a <- b <- c <- 1 }",
+            "implicit_assignment",
+            None,
+        );
         // Nested braced blocks with chained assignment
         expect_no_lint(
             "if (TRUE) { if (TRUE) { obj$x <- y <- foo() } }",

--- a/crates/jarl-core/src/lints/base/implicit_assignment/mod.rs
+++ b/crates/jarl-core/src/lints/base/implicit_assignment/mod.rs
@@ -200,7 +200,11 @@ mod tests {
         expect_no_lint("while (TRUE) a <- b <- 1", "implicit_assignment", None);
         expect_no_lint("while (TRUE) { a <- b <- 1 }", "implicit_assignment", None);
         expect_no_lint("for (i in 1:2) a <- b <- 1", "implicit_assignment", None);
-        expect_no_lint("for (i in 1:2) { a <- b <- 1 }", "implicit_assignment", None);
+        expect_no_lint(
+            "for (i in 1:2) { a <- b <- 1 }",
+            "implicit_assignment",
+            None,
+        );
         // Nested braced blocks with chained assignment
         expect_no_lint(
             "if (TRUE) { if (TRUE) { obj$x <- y <- foo() } }",

--- a/crates/jarl-core/src/lints/base/implicit_assignment/mod.rs
+++ b/crates/jarl-core/src/lints/base/implicit_assignment/mod.rs
@@ -191,6 +191,22 @@ mod tests {
         expect_no_lint("suppressMessages(x <- 1)", "implicit_assignment", None);
         expect_no_lint("suppressWarnings(x <- 1)", "implicit_assignment", None);
         expect_no_lint("suppressWarnings({x <- 1})", "implicit_assignment", None);
+
+        // Chained assignments should NOT be flagged (issue #480)
+        expect_no_lint("if (TRUE) a <- b <- 1", "implicit_assignment", None);
+        expect_no_lint("if (TRUE) { a <- b <- 1 }", "implicit_assignment", None);
+        expect_no_lint("if (TRUE) x <<- y <- z", "implicit_assignment", None);
+        expect_no_lint("if (TRUE) { x <<- y <- z }", "implicit_assignment", None);
+        expect_no_lint("while (TRUE) a <- b <- 1", "implicit_assignment", None);
+        expect_no_lint("while (TRUE) { a <- b <- 1 }", "implicit_assignment", None);
+        expect_no_lint("for (i in 1:2) a <- b <- 1", "implicit_assignment", None);
+        expect_no_lint("for (i in 1:2) { a <- b <- 1 }", "implicit_assignment", None);
+        // Nested braced blocks with chained assignment
+        expect_no_lint(
+            "if (TRUE) { if (TRUE) { obj$x <- y <- foo() } }",
+            "implicit_assignment",
+            None,
+        );
     }
 
     // ---- Rule-specific config tests ----

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -18,7 +18,7 @@
 ### Bug fixes
 
 * `implicit_assignment` no longer flags chained assignments like
-  `if (TRUE) a <- b <- 1`, aligning with `lintr` behavior (#480).
+  `if (TRUE) a <- b <- 1`, aligning with `lintr` behavior (#480, @atsyplenkov).
 
 * Automatic fixes now skip rewrites when comments are inside the rewritten
   expression, while still allowing leading and trailing comments (#461, @Yousa-Mirage).

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -17,6 +17,9 @@
 
 ### Bug fixes
 
+* `implicit_assignment` no longer flags chained assignments like
+  `if (TRUE) a <- b <- 1`, aligning with `lintr` behavior (#480).
+
 * Automatic fixes now skip rewrites when comments are inside the rewritten
   expression, while still allowing leading and trailing comments (#461, @Yousa-Mirage).
 


### PR DESCRIPTION
fix #480 