### PR TITLE
feat: Add `missing_argument` rule

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
   * `empty_file` (#477, @JosephBARBIERDARNAL)
   * `glue` (#484, @novica)
   * `literal_coercion` (#504)
+  * `missing_argument` (#506)
   * `notin` (#459, @Yousa-Mirage)
   * `pipe_consistency` (#482)
   * `pipe_return` (#502)

--- a/crates/jarl-core/src/analyze/call.rs
+++ b/crates/jarl-core/src/analyze/call.rs
@@ -19,6 +19,7 @@ use crate::lints::base::lengths::lengths::lengths;
 use crate::lints::base::list2df::list2df::list2df;
 use crate::lints::base::literal_coercion::literal_coercion::literal_coercion;
 use crate::lints::base::matrix_apply::matrix_apply::matrix_apply;
+use crate::lints::base::missing_argument::missing_argument::missing_argument;
 use crate::lints::base::outer_negation::outer_negation::outer_negation;
 use crate::lints::base::redundant_ifelse::redundant_ifelse::redundant_ifelse;
 use crate::lints::base::sample_int::sample_int::sample_int;
@@ -92,6 +93,9 @@ pub fn call(r_expr: &RCall, checker: &mut Checker) -> anyhow::Result<()> {
     }
     if checker.is_rule_enabled(Rule::MatrixApply) {
         checker.report_diagnostic(matrix_apply(r_expr)?);
+    }
+    if checker.is_rule_enabled(Rule::MissingArgument) {
+        checker.report_diagnostic(missing_argument(r_expr, checker)?);
     }
     if checker.is_rule_enabled(Rule::OuterNegation) {
         checker.report_diagnostic(outer_negation(r_expr)?);

--- a/crates/jarl-core/src/lints/base/missing_argument/missing_argument.rs
+++ b/crates/jarl-core/src/lints/base/missing_argument/missing_argument.rs
@@ -1,0 +1,95 @@
+use crate::check::Checker;
+use crate::diagnostic::*;
+use crate::utils::get_function_name;
+use air_r_syntax::*;
+use biome_rowan::AstNode;
+use biome_rowan::AstSeparatedList;
+
+/// Version added: 0.6.0
+///
+/// ## What it does
+///
+/// Checks for empty arguments in function calls, e.g. `paste("a", , "b")`.
+///
+/// ## Why is this bad?
+///
+/// An empty argument left between commas is often a typo: a value was either
+/// deleted by mistake or never filled in. Depending on the function it can lead
+/// to an error or to a silently wrong result.
+///
+/// Several functions (e.g. `mutate()` in the `tidyverse` ecosystem) allow
+/// trailing commas. Those are ignored by default but you can also tweak this
+/// list of ignored functions in `jarl.toml`:
+///
+/// ```ignore
+/// ...
+/// [lint.missing_argument]
+/// extend-skipped-functions = ["my_function"]
+/// ```
+///
+/// See the [rule-specific arguments](https://jarl.etiennebacher.com/reference/config-file#rule-specific-arguments)
+/// for more information.
+///
+/// This rule has no automatic fix.
+///
+/// ## Example
+///
+/// ```r
+/// paste("a", , "b")
+/// mean(x, )
+/// ```
+///
+/// Use instead:
+/// ```r
+/// paste("a", "b")
+/// mean(x)
+/// ```
+/// (or add additional arguments).
+pub fn missing_argument(ast: &RCall, checker: &Checker) -> anyhow::Result<Option<Diagnostic>> {
+    let function = ast.function()?;
+    let function_name = get_function_name(function);
+    if checker
+        .rule_options
+        .missing_argument
+        .skipped_functions
+        .contains(&function_name)
+    {
+        return Ok(None);
+    }
+
+    let args = ast.arguments()?;
+    let missing_arg_idx = args
+        .items()
+        .iter()
+        .enumerate()
+        .filter(|(_, x)| x.clone().ok().unwrap().is_hole())
+        .map(|(index, _)| (index + 1).to_string())
+        .collect::<Vec<_>>();
+
+    if missing_arg_idx.is_empty() {
+        return Ok(None);
+    }
+
+    let msg = if missing_arg_idx.len() == 1 {
+        format!("Argument {} is empty.", missing_arg_idx.first().unwrap())
+    } else if missing_arg_idx.len() == 2 {
+        let (last, rest) = missing_arg_idx.split_last().unwrap();
+        format!("Arguments {} and {} are empty.", rest.join(", "), last)
+    } else {
+        let (last, rest) = missing_arg_idx.split_last().unwrap();
+        format!("Arguments {}, and {} are empty.", rest.join(", "), last)
+    };
+
+    let range = ast.syntax().text_trimmed_range();
+    let diagnostic = Diagnostic::new(
+        ViolationData::new(
+            "missing_argument".to_string(),
+            msg.to_string(),
+            Some("Consider removing or filling them.".to_string()),
+        ),
+        range,
+        Fix::empty(),
+    );
+
+    Ok(Some(diagnostic))
+}

--- a/crates/jarl-core/src/lints/base/missing_argument/mod.rs
+++ b/crates/jarl-core/src/lints/base/missing_argument/mod.rs
@@ -1,0 +1,93 @@
+pub(crate) mod missing_argument;
+
+#[cfg(test)]
+mod tests {
+    use crate::rule_options::ResolvedRuleOptions;
+    use crate::rule_options::missing_argument::MissingArgumentOptions;
+    use crate::rule_options::missing_argument::ResolvedMissingArgumentOptions;
+    use crate::settings::{LinterSettings, Settings};
+    use crate::utils_test::*;
+    use insta::assert_snapshot;
+
+    fn snapshot_lint(code: &str) -> String {
+        format_diagnostics(code, "missing_argument", None)
+    }
+
+    fn snapshot_lint_with_settings(code: &str, settings: Settings) -> String {
+        format_diagnostics_with_settings(code, "missing_argument", None, Some(settings))
+    }
+
+    /// Build a `Settings` with custom `MissingArgumentOptions`.
+    fn settings_with_options(options: MissingArgumentOptions) -> Settings {
+        Settings {
+            linter: LinterSettings {
+                rule_options: ResolvedRuleOptions {
+                    missing_argument: ResolvedMissingArgumentOptions::resolve(Some(&options))
+                        .unwrap(),
+                    ..Default::default()
+                },
+                ..Default::default()
+            },
+        }
+    }
+
+    #[test]
+    fn test_no_lint_missing_argument() {
+        expect_no_lint("paste('a', 'b')", "missing_argument", None);
+        expect_no_lint("mean(x)", "missing_argument", None);
+        expect_no_lint("f(x = 1, y = 2)", "missing_argument", None);
+        expect_no_lint("f(x = 1, 2)", "missing_argument", None);
+        expect_no_lint("f()", "missing_argument", None);
+        expect_no_lint(
+            "switch(type, a = , b = 'ab', c = 'c')",
+            "missing_argument",
+            None,
+        );
+    }
+
+    #[test]
+    fn test_lint_single_empty_argument() {
+        assert_snapshot!(snapshot_lint("f(x, )"));
+        assert_snapshot!(snapshot_lint("f('a', , 'b', )"));
+        assert_snapshot!(snapshot_lint("f(, 'a', , 'b', )"));
+    }
+
+    #[test]
+    fn test_skipped_functions_replaces_defaults() {
+        let settings = settings_with_options(MissingArgumentOptions {
+            skipped_functions: Some(vec!["quote".to_string()]),
+            extend_skipped_functions: None,
+        });
+
+        // "mutate" is ignored by default but here we overwrote the list
+        snapshot_lint_with_settings(
+            "
+        quote(x, )
+        mutate(x, )",
+            settings.clone(),
+        );
+    }
+
+    #[test]
+    fn test_extend_skipped_functions_adds_to_defaults() {
+        let settings = settings_with_options(MissingArgumentOptions {
+            skipped_functions: None,
+            extend_skipped_functions: Some(vec!["quote".to_string()]),
+        });
+        snapshot_lint_with_settings(
+            "
+        quote(x, )
+        mutate(x, )",
+            settings.clone(),
+        );
+    }
+
+    #[test]
+    fn test_skipped_functions_with_namespaced_call() {
+        let settings = settings_with_options(MissingArgumentOptions {
+            skipped_functions: None,
+            extend_skipped_functions: Some(vec!["my_fun".to_string()]),
+        });
+        expect_no_lint_with_settings("pkg::my_fun(x, )", "missing_argument", None, settings);
+    }
+}

--- a/crates/jarl-core/src/lints/base/missing_argument/snapshots/jarl_core__lints__base__missing_argument__tests__lint_single_empty_argument-2.snap
+++ b/crates/jarl-core/src/lints/base/missing_argument/snapshots/jarl_core__lints__base__missing_argument__tests__lint_single_empty_argument-2.snap
@@ -1,0 +1,12 @@
+---
+source: crates/jarl-core/src/lints/base/missing_argument/mod.rs
+expression: "snapshot_lint(\"f('a', , 'b', )\")"
+---
+warning: missing_argument
+ --> <test>:1:1
+  |
+1 | f('a', , 'b', )
+  | --------------- Arguments 2 and 4 are empty.
+  |
+  = help: Consider removing or filling them.
+Found 1 error.

--- a/crates/jarl-core/src/lints/base/missing_argument/snapshots/jarl_core__lints__base__missing_argument__tests__lint_single_empty_argument-3.snap
+++ b/crates/jarl-core/src/lints/base/missing_argument/snapshots/jarl_core__lints__base__missing_argument__tests__lint_single_empty_argument-3.snap
@@ -1,0 +1,12 @@
+---
+source: crates/jarl-core/src/lints/base/missing_argument/mod.rs
+expression: "snapshot_lint(\"f(, 'a', , 'b', )\")"
+---
+warning: missing_argument
+ --> <test>:1:1
+  |
+1 | f(, 'a', , 'b', )
+  | ----------------- Arguments 1, 3, and 5 are empty.
+  |
+  = help: Consider removing or filling them.
+Found 1 error.

--- a/crates/jarl-core/src/lints/base/missing_argument/snapshots/jarl_core__lints__base__missing_argument__tests__lint_single_empty_argument.snap
+++ b/crates/jarl-core/src/lints/base/missing_argument/snapshots/jarl_core__lints__base__missing_argument__tests__lint_single_empty_argument.snap
@@ -1,0 +1,12 @@
+---
+source: crates/jarl-core/src/lints/base/missing_argument/mod.rs
+expression: "snapshot_lint(\"f(x, )\")"
+---
+warning: missing_argument
+ --> <test>:1:1
+  |
+1 | f(x, )
+  | ------ Argument 2 is empty.
+  |
+  = help: Consider removing or filling them.
+Found 1 error.

--- a/crates/jarl-core/src/lints/base/mod.rs
+++ b/crates/jarl-core/src/lints/base/mod.rs
@@ -30,6 +30,7 @@ pub(crate) mod lengths;
 pub(crate) mod list2df;
 pub(crate) mod literal_coercion;
 pub(crate) mod matrix_apply;
+pub(crate) mod missing_argument;
 pub(crate) mod notin;
 pub(crate) mod numeric_leading_zero;
 pub(crate) mod nzchar;

--- a/crates/jarl-core/src/rule_options/missing_argument.rs
+++ b/crates/jarl-core/src/rule_options/missing_argument.rs
@@ -3,7 +3,14 @@ use std::collections::HashSet;
 use super::resolve_with_extend;
 
 /// Default functions whose empty arguments are not reported.
-const DEFAULT_SKIPPED_FUNCTIONS: &[&str] = &["tibble", "list2", "mutate", "summarize", "transmute"];
+const DEFAULT_SKIPPED_FUNCTIONS: &[&str] = &[
+    "switch",
+    "tibble",
+    "list2",
+    "mutate",
+    "summarize",
+    "transmute",
+];
 
 /// TOML options for `[lint.missing_argument]`.
 ///

--- a/crates/jarl-core/src/rule_options/missing_argument.rs
+++ b/crates/jarl-core/src/rule_options/missing_argument.rs
@@ -1,0 +1,48 @@
+use std::collections::HashSet;
+
+use super::resolve_with_extend;
+
+/// Default functions whose empty arguments are not reported.
+const DEFAULT_SKIPPED_FUNCTIONS: &[&str] = &["tibble", "list2", "mutate", "summarize", "transmute"];
+
+/// TOML options for `[lint.missing_argument]`.
+///
+/// Use `skipped-functions` to fully replace the default list of functions
+/// whose empty arguments are allowed. Use `extend-skipped-functions` to add
+/// to the default list. Specifying both is an error.
+#[derive(Clone, Debug, PartialEq, Eq, Default, serde::Deserialize)]
+#[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
+#[serde(deny_unknown_fields, rename_all = "kebab-case")]
+pub struct MissingArgumentOptions {
+    pub skipped_functions: Option<Vec<String>>,
+    pub extend_skipped_functions: Option<Vec<String>>,
+}
+
+/// Resolved options for the `missing_argument` rule, ready for use during
+/// linting.
+#[derive(Clone, Debug)]
+pub struct ResolvedMissingArgumentOptions {
+    pub skipped_functions: HashSet<String>,
+}
+
+impl ResolvedMissingArgumentOptions {
+    pub fn resolve(options: Option<&MissingArgumentOptions>) -> anyhow::Result<Self> {
+        let (base, extend) = match options {
+            Some(opts) => (
+                opts.skipped_functions.as_ref(),
+                opts.extend_skipped_functions.as_ref(),
+            ),
+            None => (None, None),
+        };
+
+        let skipped_functions = resolve_with_extend(
+            base,
+            extend,
+            DEFAULT_SKIPPED_FUNCTIONS,
+            "missing_argument",
+            "skipped-functions",
+        )?;
+
+        Ok(Self { skipped_functions })
+    }
+}

--- a/crates/jarl-core/src/rule_options/mod.rs
+++ b/crates/jarl-core/src/rule_options/mod.rs
@@ -1,6 +1,7 @@
 pub mod assignment;
 pub mod duplicated_arguments;
 pub mod implicit_assignment;
+pub mod missing_argument;
 pub mod pipe_consistency;
 pub mod quotes;
 pub mod undesirable_function;
@@ -21,6 +22,8 @@ use unused_function::UnusedFunctionOptions;
 
 use crate::rule_options::implicit_assignment::ImplicitAssignmentOptions;
 use crate::rule_options::implicit_assignment::ResolvedImplicitAssignmentOptions;
+use crate::rule_options::missing_argument::MissingArgumentOptions;
+use crate::rule_options::missing_argument::ResolvedMissingArgumentOptions;
 use crate::rule_options::pipe_consistency::PipeConsistencyOptions;
 use crate::rule_options::pipe_consistency::ResolvedPipeConsistencyOptions;
 use crate::rule_options::quotes::QuotesOptions;
@@ -74,6 +77,7 @@ pub struct ResolvedRuleOptions {
     pub assignment: ResolvedAssignmentOptions,
     pub duplicated_arguments: ResolvedDuplicatedArgumentsOptions,
     pub implicit_assignment: ResolvedImplicitAssignmentOptions,
+    pub missing_argument: ResolvedMissingArgumentOptions,
     pub pipe_consistency: ResolvedPipeConsistencyOptions,
     pub quotes: ResolvedQuotesOptions,
     pub undesirable_function: ResolvedUndesirableFunctionOptions,
@@ -87,6 +91,7 @@ impl ResolvedRuleOptions {
         assignment: Option<&AssignmentOptions>,
         duplicated_arguments: Option<&DuplicatedArgumentsOptions>,
         implicit_assignment: Option<&ImplicitAssignmentOptions>,
+        missing_argument: Option<&MissingArgumentOptions>,
         pipe_consistency: Option<&PipeConsistencyOptions>,
         quotes: Option<&QuotesOptions>,
         undesirable_function: Option<&UndesirableFunctionOptions>,
@@ -99,6 +104,7 @@ impl ResolvedRuleOptions {
                 duplicated_arguments,
             )?,
             implicit_assignment: ResolvedImplicitAssignmentOptions::resolve(implicit_assignment)?,
+            missing_argument: ResolvedMissingArgumentOptions::resolve(missing_argument)?,
             pipe_consistency: ResolvedPipeConsistencyOptions::resolve(pipe_consistency)?,
             quotes: ResolvedQuotesOptions::resolve(quotes)?,
             undesirable_function: ResolvedUndesirableFunctionOptions::resolve(
@@ -112,7 +118,7 @@ impl ResolvedRuleOptions {
 
 impl Default for ResolvedRuleOptions {
     fn default() -> Self {
-        Self::resolve(None, None, None, None, None, None, None, None)
+        Self::resolve(None, None, None, None, None, None, None, None, None)
             .expect("default rule options should always resolve")
     }
 }

--- a/crates/jarl-core/src/rule_set.rs
+++ b/crates/jarl-core/src/rule_set.rs
@@ -468,6 +468,13 @@ declare_rules! {
         fix: Safe,
         min_r_version: None,
     },
+    MissingArgument => {
+        name: "missing_argument",
+        categories: [Susp],
+        default: Enabled,
+        fix: None,
+        min_r_version: None,
+    },
     NotIn => {
         name: "notin",
         categories: [Read],

--- a/crates/jarl-core/src/toml.rs
+++ b/crates/jarl-core/src/toml.rs
@@ -21,6 +21,7 @@ use crate::rule_options::assignment::AssignmentConfig;
 use crate::rule_options::assignment::AssignmentOptions;
 use crate::rule_options::duplicated_arguments::DuplicatedArgumentsOptions;
 use crate::rule_options::implicit_assignment::ImplicitAssignmentOptions;
+use crate::rule_options::missing_argument::MissingArgumentOptions;
 use crate::rule_options::pipe_consistency::PipeConsistencyOptions;
 use crate::rule_options::quotes::QuotesOptions;
 use crate::rule_options::undesirable_function::UndesirableFunctionOptions;
@@ -266,6 +267,15 @@ pub struct LinterTomlOptions {
     #[serde(rename = "implicit_assignment")]
     pub implicit_assignment: Option<ImplicitAssignmentOptions>,
 
+    /// # Options for the `missing_argument` rule
+    ///
+    /// Use `skipped-functions` to fully replace the default list of functions
+    /// whose empty arguments are allowed. Use `extend-skipped-functions` to
+    /// add to the default list.
+    /// Specifying both is an error.
+    #[serde(rename = "missing_argument")]
+    pub missing_argument: Option<MissingArgumentOptions>,
+
     /// # Options for the `pipe_consistency` rule
     ///
     /// Use `preferred` to choose the preferred pipe operator. Valid values
@@ -387,6 +397,7 @@ impl TomlOptions {
                 assignment_options.as_ref(),
                 linter.duplicated_arguments.as_ref(),
                 linter.implicit_assignment.as_ref(),
+                linter.missing_argument.as_ref(),
                 linter.pipe_consistency.as_ref(),
                 linter.quotes.as_ref(),
                 linter.undesirable_function.as_ref(),

--- a/crates/jarl/tests/integration/toml_rule_args.rs
+++ b/crates/jarl/tests/integration/toml_rule_args.rs
@@ -213,6 +213,48 @@ unknown-option = ["list"]
     Ok(())
 }
 
+// missing_argument ----------------------------------------
+
+#[test]
+fn test_missing_argument_both_skipped_and_extend_is_error() -> anyhow::Result<()> {
+    let case = CliTest::with_files([
+        (
+            "jarl.toml",
+            r#"
+[lint]
+
+[lint.missing_argument]
+skipped-functions = ["list"]
+extend-skipped-functions = ["my_fun"]
+"#,
+        ),
+        ("test.R", "list(a = 1, a = 2)"),
+    ])?;
+
+    insta::assert_snapshot!(
+        &mut case
+            .command()
+            .arg("check")
+            .arg(".")
+            .run()
+            .normalize_os_executable_name()
+            .normalize_temp_paths(),
+        @"
+
+    success: false
+    exit_code: 255
+    ----- stdout -----
+
+    ----- stderr -----
+    jarl failed
+      Cause: Invalid configuration in [TEMP_DIR]/jarl.toml:
+    Cannot specify both `skipped-functions` and `extend-skipped-functions` in `[lint.missing_argument]`.
+    "
+    );
+
+    Ok(())
+}
+
 // pipe_consistency ----------------------------------------
 
 #[test]

--- a/docs/_quarto.yml
+++ b/docs/_quarto.yml
@@ -128,6 +128,7 @@ website:
       - rules/misnamed_suppression.md
       - rules/misplaced_file_suppression.md
       - rules/misplaced_suppression.md
+      - rules/missing_argument.md
       - rules/notin.md
       - rules/numeric_leading_zero.md
       - rules/nzchar.md

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -12,6 +12,7 @@
   * `empty_file` (#477, @JosephBARBIERDARNAL)
   * `glue` (#484, @novica)
   * `literal_coercion` (#504)
+  * `missing_argument` (#506)
   * `notin` (#459, @Yousa-Mirage)
   * `pipe_consistency` (#482)
   * `pipe_return` (#502)

--- a/docs/reference/config-file.md
+++ b/docs/reference/config-file.md
@@ -350,6 +350,27 @@ Default: `skipped-functions = ["expect_error", "expect_warning", "expect_message
 skipped-functions = ["list"]
 ```
 
+### `missing_argument`
+
+Use `skipped-functions` to fully replace the default list of functions that are
+allowed to contain missing arguments. Use `extend-skipped-functions` to add to
+the default list. Specifying both is an error.
+
+Function names in `skipped-functions` or `extend-skipped-functions` also match
+namespaced calls, e.g. `skipped-functions = ["list2"]` will ignore `list2()` and
+`rlang::list2()`.
+
+Default: `skipped-functions = ["tibble", "list2", "mutate", "summarize", "transmute"]`
+
+```toml
+[lint]
+...
+
+[lint.missing_argument]
+# Ignore missing arguments in `my_function()` only.
+skipped-functions = ["my_function"]
+```
+
 ### `pipe_consistency`
 
 This takes a single value (`"|>"` or `"%>%"`) indicating the preferred

--- a/docs/reference/config-file.md
+++ b/docs/reference/config-file.md
@@ -360,7 +360,14 @@ Function names in `skipped-functions` or `extend-skipped-functions` also match
 namespaced calls, e.g. `skipped-functions = ["list2"]` will ignore `list2()` and
 `rlang::list2()`.
 
-Default: `skipped-functions = ["tibble", "list2", "mutate", "summarize", "transmute"]`
+Default: `skipped-functions = [
+    "switch",
+    "tibble",
+    "list2",
+    "mutate",
+    "summarize",
+    "transmute",
+]`
 
 ```toml
 [lint]

--- a/docs/rules.qmd
+++ b/docs/rules.qmd
@@ -98,6 +98,7 @@ dat <- as.data.frame(
     c("misnamed_suppression", "comments", "❌", ""),
     c("misplaced_file_suppression", "comments", "❌", ""),
     c("misplaced_suppression", "comments", "❌", ""),
+    c("missing_argument", "suspicious", "❌", ""),
     c("notin", "readability", "✅", "R >= 4.6"),
     c("numeric_leading_zero", "readability", "✅", ""),
     c("nzchar", "performance", "❗", "Disabled by default"),

--- a/docs/rules/missing_argument.md
+++ b/docs/rules/missing_argument.md
@@ -1,0 +1,42 @@
+# missing_argument
+::: {.callout-note title="Added in 0.6.0" .low-opacity}
+:::
+
+## What it does
+
+Checks for empty arguments in function calls, e.g. `paste("a", , "b")`.
+
+## Why is this bad?
+
+An empty argument left between commas is often a typo: a value was either
+deleted by mistake or never filled in. Depending on the function it can lead
+to an error or to a silently wrong result.
+
+Several functions (e.g. `mutate()` in the `tidyverse` ecosystem) allow
+trailing commas. Those are ignored by default but you can also tweak this
+list of ignored functions in `jarl.toml`:
+
+```ignore
+...
+[lint.missing_argument]
+extend-skipped-functions = ["my_function"]
+```
+
+See the [rule-specific arguments](https://jarl.etiennebacher.com/reference/config-file#rule-specific-arguments)
+for more information.
+
+This rule has no automatic fix.
+
+## Example
+
+```r
+paste("a", , "b")
+mean(x, )
+```
+
+Use instead:
+```r
+paste("a", "b")
+mean(x)
+```
+(or add additional arguments).


### PR DESCRIPTION
Part of #8 