### PR TITLE
fix: Fix false positives of `assignment` rule when preferred operator is `=`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,9 @@
 
 * Fixed `unreachable_code` that was not running on braced expressions (#512).
 
+* Fixed false positives in `assignment` rule. Jarl could recommend replacing `<-`
+  by `=` in places where this would change the meaning of the code (#515).
+
 ## 0.5.0
 
 ### Deprecations

--- a/crates/jarl-core/src/lints/base/assignment/assignment.rs
+++ b/crates/jarl-core/src/lints/base/assignment/assignment.rs
@@ -41,6 +41,10 @@ pub fn assignment(
     ast: &RBinaryExpression,
     assignment: RSyntaxKind,
 ) -> anyhow::Result<Option<Diagnostic>> {
+    if !can_normalize_to_equal(ast) {
+        return Ok(None);
+    };
+
     let RBinaryExpressionFields { left, operator, right } = ast.as_fields();
 
     let operator = operator?;
@@ -116,4 +120,154 @@ pub fn assignment(
     );
 
     Ok(Some(diagnostic))
+}
+
+// Entirely copied from https://github.com/posit-dev/air/pull/502
+// ===============================================================
+//
+// Can we safely normalize `<-` to `=`?
+//
+// In R, it is always safe to normalize `=` to `<-`, but the reverse is not true.
+//
+// For example, it may change the semantic meaning:
+//
+// ```r
+// # Expression `x <- 1` as unnamed argument to function `f`
+// f(x <- 1)
+//
+// # Named argument `x` with value `1` to function `f`
+// f(x = 1)
+// ```
+//
+// Or it may become a syntax error:
+//
+// ```r
+// # Expression `x <- 1`'s result is used as the `condition`
+// if (x <- 1) this
+//
+// # Syntax error
+// if (x = 1) this
+// ```
+//
+// To handle this precisely, we looked for all usage of `expr_or_assign_or_help` in the
+// R `gram.y` grammar. This is the only place that `EQ_ASSIGN` is used in an assignment
+// context. Each usage of `expr_or_assign_or_help` in `gram.y` is replicated below,
+// ensuring that we capture all possible places that `=` is allowed.
+// https://github.com/wch/r-source/blob/b7e27523048d135e3a02560e51cb266702bd49c1/src/main/gram.y#L453-L455
+//
+// Note how `LEFT_ASSIGN` is instead part of `expr`, making usage of it more permissive
+// than `EQ_ASSIGN` (a superset, really). This is why we can always replace `=` with
+// `<-`.
+// https://github.com/wch/r-source/blob/b7e27523048d135e3a02560e51cb266702bd49c1/src/main/gram.y#L497
+//
+// `EQ_ASSIGN` is also used in `sub:` and `formlist:`, but these correspond to named
+// arguments (i.e. `fn(x = 1)`) and parameters with defaults (i.e. `function(x = 1) {}`)
+// respectively, so are not relevant usages for us (and in fact those are locations where
+// normalizing to `=` is not allowed).
+// https://github.com/wch/r-source/blob/b7e27523048d135e3a02560e51cb266702bd49c1/src/main/gram.y#L549-L564
+fn can_normalize_to_equal(node: &RBinaryExpression) -> bool {
+    let node = node.syntax();
+
+    let Some(parent) = node.parent() else {
+        // Should not happen, should always be at least contained in an RRoot's
+        // RExpressionList. We return the conservative `false` if we somehow get here.
+        return false;
+    };
+    let parent_kind = parent.kind();
+
+    // i.e. top level `x <- 1` to `x = 1`
+    // i.e. `{ x <- 1 }` to `{ x = 1 }`
+    if RExpressionList::can_cast(parent_kind) {
+        return true;
+    }
+
+    // i.e. `(x <- 1)` to `(x = 1)`
+    if RParenthesizedExpression::can_cast(parent_kind) {
+        return true;
+    }
+
+    // i.e. `? x <- 1` to `? x = 1`
+    if let Some(parent) = RUnaryExpression::cast_ref(&parent)
+        && let Ok(operator) = parent.operator()
+        && operator.kind() == RSyntaxKind::WAT
+    {
+        return true;
+    }
+
+    // i.e. `x <- y <- 1` to `x = y = 1`
+    // i.e. `x = y <- 1` to `x = y = 1`, but notably `x <- y = 1` is a parse error.
+    // i.e. `x <- 1 ? y` to `x = 1 ? y`
+    // i.e. `y ? x <- 1` to `y ? x = 1`
+    //
+    // We recurse through `can_normalize_to_equal()` in these cases because the parent
+    // binary expression must also be in a position where `=` would be valid. These would
+    // all result in parse errors or change semantic meaning if we didn't check this:
+    //
+    // i.e. `f(x <- y <- 1)` to `f(x <- y = 1)` gives parse error
+    // i.e. `if (x <- y <- 1) z` to `if (x <- y = 1) z` gives parse error
+    //
+    // i.e. `f(x ? y <- 1)` to `f(x ? y = 1)` gives parse error
+    // i.e. `if(x ? y <- 1) z` to `if(x ? y = 1) z` gives parse error
+    //
+    // i.e. `f(x <- 1 ? y)` to `f(x = 1 ? y)` changes semantic meaning
+    // i.e. `if(x <- 1 ? y) z` to `if(x = 1 ? y) z` gives parse error
+    if let Some(parent) = RBinaryExpression::cast_ref(&parent)
+        && let Ok(operator) = parent.operator()
+        && matches!(
+            operator.kind(),
+            RSyntaxKind::ASSIGN | RSyntaxKind::EQUAL | RSyntaxKind::WAT
+        )
+    {
+        return can_normalize_to_equal(&parent);
+    }
+
+    // i.e. `function(x) x <- 1` to `function(x) x = 1`
+    if let Some(parent) = RFunctionDefinition::cast_ref(&parent)
+        && let Ok(body) = parent.body()
+        && body.syntax() == node
+    {
+        return true;
+    }
+
+    // i.e. `if (cond) x <- 1` to `if (cond) x = 1`
+    if let Some(parent) = RIfStatement::cast_ref(&parent)
+        && let Ok(consequence) = parent.consequence()
+        && consequence.syntax() == node
+    {
+        return true;
+    }
+
+    // i.e. `if (cond) x else y <- 1` to `if (cond) x else y = 1`
+    if let Some(parent) = RElseClause::cast_ref(&parent)
+        && let Ok(alternative) = parent.alternative()
+        && alternative.syntax() == node
+    {
+        return true;
+    }
+
+    // i.e. `for(i in 1:5) x <- 1` to `for(i in 1:5) x = 1`
+    if let Some(parent) = RForStatement::cast_ref(&parent)
+        && let Ok(body) = parent.body()
+        && body.syntax() == node
+    {
+        return true;
+    }
+
+    // i.e. `while(cond) x <- 1` to `while(cond) x = 1`
+    if let Some(parent) = RWhileStatement::cast_ref(&parent)
+        && let Ok(body) = parent.body()
+        && body.syntax() == node
+    {
+        return true;
+    }
+
+    // i.e. `repeat x <- 1` to `repeat x = 1`
+    if let Some(parent) = RRepeatStatement::cast_ref(&parent)
+        && let Ok(body) = parent.body()
+        && body.syntax() == node
+    {
+        return true;
+    }
+
+    false
 }

--- a/crates/jarl-core/src/lints/base/assignment/assignment.rs
+++ b/crates/jarl-core/src/lints/base/assignment/assignment.rs
@@ -23,13 +23,25 @@ use biome_rowan::AstNode;
 ///
 /// ## Example
 ///
+/// If the `operator` parameter is `"="` then replace:
+/// ```r
+/// x <- "a"
+/// ```
+/// by:
 /// ```r
 /// x = "a"
 /// ```
 ///
-/// Use instead:
+/// Note that Jarl will not report some cases where `<-` is used because it
+/// would change the meaning of code, e.g. this:
+///
 /// ```r
-/// x <- "a"
+/// f(x <- 1)
+/// ```
+/// cannot be replaced by:
+///
+/// ```r
+/// f(x = 1)
 /// ```
 ///
 /// ## References

--- a/crates/jarl-core/src/lints/base/assignment/mod.rs
+++ b/crates/jarl-core/src/lints/base/assignment/mod.rs
@@ -213,6 +213,56 @@ mod tests {
     }
 
     #[test]
+    fn test_lint_assignment_not_replaced_in_some_context() {
+        let settings = settings_with_options(RSyntaxKind::EQUAL);
+        expect_no_lint_with_settings("f(y <- 1)", "assignment", None, settings.clone());
+        expect_no_lint_with_settings("x[y <- 1]", "assignment", None, settings.clone());
+        expect_no_lint_with_settings("x[[y <- 1]]", "assignment", None, settings.clone());
+        expect_no_lint_with_settings("f(a ? b <- 1)", "assignment", None, settings.clone());
+        expect_no_lint_with_settings("f(a <- b <- 1)", "assignment", None, settings.clone());
+        expect_no_lint_with_settings("if (y <- 1) {}", "assignment", None, settings.clone());
+        expect_no_lint_with_settings("while (y <- 1) {}", "assignment", None, settings.clone());
+        expect_no_lint_with_settings("for (x in y <- 1) {}", "assignment", None, settings.clone());
+
+        assert_snapshot!(
+            snapshot_lint_with_settings("if ((x <- f())) y", settings.clone()),
+            @"
+        warning: assignment
+         --> <test>:1:6
+          |
+        1 | if ((x <- f())) y
+          |      ---- Use `=` for assignment.
+          |
+        Found 1 error.
+        "
+        );
+        assert_snapshot!(
+            snapshot_lint_with_settings("while ((x <- f())) y", settings.clone()),
+            @"
+        warning: assignment
+         --> <test>:1:9
+          |
+        1 | while ((x <- f())) y
+          |         ---- Use `=` for assignment.
+          |
+        Found 1 error.
+        "
+        );
+        assert_snapshot!(
+            snapshot_lint_with_settings("for (i in (x <- xs)) y", settings.clone()),
+            @"
+        warning: assignment
+         --> <test>:1:12
+          |
+        1 | for (i in (x <- xs)) y
+          |            ---- Use `=` for assignment.
+          |
+        Found 1 error.
+        "
+        );
+    }
+
+    #[test]
     fn test_no_lint_assignment_with_equal_operator() {
         let settings = settings_with_options(RSyntaxKind::EQUAL);
 

--- a/crates/jarl-core/src/lints/base/assignment/mod.rs
+++ b/crates/jarl-core/src/lints/base/assignment/mod.rs
@@ -197,6 +197,18 @@ mod tests {
         "
         );
         assert_snapshot!(
+            snapshot_lint_with_settings("if (cond) y <- 1", settings.clone()),
+            @"
+        warning: assignment
+         --> <test>:1:11
+          |
+        1 | if (cond) y <- 1
+          |           ---- Use `=` for assignment.
+          |
+        Found 1 error.
+        "
+        );
+        assert_snapshot!(
             snapshot_lint_with_settings("if (cond) x else y <- 1", settings.clone()),
             @"
         warning: assignment

--- a/crates/jarl-core/src/lints/base/assignment/mod.rs
+++ b/crates/jarl-core/src/lints/base/assignment/mod.rs
@@ -196,6 +196,42 @@ mod tests {
         Found 1 error.
         "
         );
+        assert_snapshot!(
+            snapshot_lint_with_settings("if (cond) x else y <- 1", settings.clone()),
+            @"
+        warning: assignment
+         --> <test>:1:18
+          |
+        1 | if (cond) x else y <- 1
+          |                  ---- Use `=` for assignment.
+          |
+        Found 1 error.
+        "
+        );
+        assert_snapshot!(
+            snapshot_lint_with_settings("for(i in 1:5) x <- 1", settings.clone()),
+            @"
+        warning: assignment
+         --> <test>:1:15
+          |
+        1 | for(i in 1:5) x <- 1
+          |               ---- Use `=` for assignment.
+          |
+        Found 1 error.
+        "
+        );
+        assert_snapshot!(
+            snapshot_lint_with_settings("repeat x <- 1", settings.clone()),
+            @"
+        warning: assignment
+         --> <test>:1:8
+          |
+        1 | repeat x <- 1
+          |        ---- Use `=` for assignment.
+          |
+        Found 1 error.
+        "
+        );
 
         // `1 -> z` should lint when operator = "="
         assert_snapshot!(
@@ -224,6 +260,18 @@ mod tests {
         expect_no_lint_with_settings("while (y <- 1) {}", "assignment", None, settings.clone());
         expect_no_lint_with_settings("for (x in y <- 1) {}", "assignment", None, settings.clone());
 
+        assert_snapshot!(
+            snapshot_lint_with_settings("? y <- 1", settings.clone()),
+            @"
+        warning: assignment
+         --> <test>:1:3
+          |
+        1 | ? y <- 1
+          |   ---- Use `=` for assignment.
+          |
+        Found 1 error.
+        "
+        );
         assert_snapshot!(
             snapshot_lint_with_settings("if ((x <- f())) y", settings.clone()),
             @"

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -43,6 +43,9 @@
 
 * Fixed `unreachable_code` that was not running on braced expressions (#512).
 
+* Fixed false positives in `assignment` rule. Jarl could recommend replacing `<-`
+  by `=` in places where this would change the meaning of the code (#515).
+
 ## 0.5.0
 
 ### Deprecations

--- a/docs/rules/assignment.md
+++ b/docs/rules/assignment.md
@@ -21,13 +21,25 @@ operator = "=" # or "<-"
 
 ## Example
 
+If the `operator` parameter is `"="` then replace:
+```r
+x <- "a"
+```
+by:
 ```r
 x = "a"
 ```
 
-Use instead:
+Note that Jarl will not report some cases where `<-` is used because it
+would change the meaning of code, e.g. this:
+
 ```r
-x <- "a"
+f(x <- 1)
+```
+cannot be replaced by:
+
+```r
+f(x = 1)
 ```
 
 ## References


### PR DESCRIPTION
Fixes #514 (thank you @DavisVaughan)