### PR TITLE
chore: Upgrade project dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -29,7 +29,7 @@ dependencies = [
 [[package]]
 name = "air_r_factory"
 version = "0.0.0"
-source = "git+https://github.com/posit-dev/air?rev=0eadd6938d0316b1fc885c91e7af55d7c8de8530#0eadd6938d0316b1fc885c91e7af55d7c8de8530"
+source = "git+https://github.com/Goldziher/r-air-fork?rev=c916545f14f76e1d6bd6ff918870f86dfa704b63#c916545f14f76e1d6bd6ff918870f86dfa704b63"
 dependencies = [
  "air_r_syntax",
  "biome_rowan",
@@ -38,13 +38,14 @@ dependencies = [
 [[package]]
 name = "air_r_formatter"
 version = "0.0.0"
-source = "git+https://github.com/posit-dev/air?rev=0eadd6938d0316b1fc885c91e7af55d7c8de8530#0eadd6938d0316b1fc885c91e7af55d7c8de8530"
+source = "git+https://github.com/Goldziher/r-air-fork?rev=c916545f14f76e1d6bd6ff918870f86dfa704b63#c916545f14f76e1d6bd6ff918870f86dfa704b63"
 dependencies = [
  "air_r_syntax",
  "biome_formatter",
  "biome_rowan",
  "comments",
  "itertools",
+ "line_ending",
  "settings",
  "tracing",
 ]
@@ -52,7 +53,7 @@ dependencies = [
 [[package]]
 name = "air_r_parser"
 version = "0.0.0"
-source = "git+https://github.com/posit-dev/air?rev=0eadd6938d0316b1fc885c91e7af55d7c8de8530#0eadd6938d0316b1fc885c91e7af55d7c8de8530"
+source = "git+https://github.com/Goldziher/r-air-fork?rev=c916545f14f76e1d6bd6ff918870f86dfa704b63#c916545f14f76e1d6bd6ff918870f86dfa704b63"
 dependencies = [
  "air_r_factory",
  "air_r_syntax",
@@ -68,7 +69,7 @@ dependencies = [
 [[package]]
 name = "air_r_syntax"
 version = "0.0.0"
-source = "git+https://github.com/posit-dev/air?rev=0eadd6938d0316b1fc885c91e7af55d7c8de8530#0eadd6938d0316b1fc885c91e7af55d7c8de8530"
+source = "git+https://github.com/Goldziher/r-air-fork?rev=c916545f14f76e1d6bd6ff918870f86dfa704b63#c916545f14f76e1d6bd6ff918870f86dfa704b63"
 dependencies = [
  "biome_rowan",
  "serde",
@@ -76,11 +77,12 @@ dependencies = [
 
 [[package]]
 name = "annotate-snippets"
-version = "0.11.5"
+version = "0.12.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "710e8eae58854cdc1790fcb56cca04d712a17be849eeb81da2a724bf4bae2bc4"
+checksum = "f211a51805bc641f3ad5b7664c77d2547af685cc33b4cd8d31964027a46f13f1"
 dependencies = [
  "anstyle",
+ "memchr",
  "unicode-width 0.2.2",
 ]
 
@@ -101,9 +103,9 @@ dependencies = [
 
 [[package]]
 name = "anstyle"
-version = "1.0.13"
+version = "1.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5192cca8006f1fd4f7237516f40fa183bb07f8fbdfedaa0036de5ea9b0b45e78"
+checksum = "940b3a0ca603d1eade50a4846a2afffd5ef57a9feac2c0e2ec2e14f9ead76000"
 
 [[package]]
 name = "anstyle-parse"
@@ -120,7 +122,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys",
 ]
 
 [[package]]
@@ -131,14 +133,26 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.60.2",
+ "windows-sys",
 ]
 
 [[package]]
 name = "anyhow"
-version = "1.0.101"
+version = "1.0.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f0e0fee31ef5ed1ba1316088939cea399010ed7731dba877ed44aeb407a75ea"
+checksum = "2a4385e2e34eb35d6b3efe798b9eb88096925d87726c0798709bf56d9ed84af3"
+
+[[package]]
+name = "auditable-serde"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c7bf8143dfc3c0258df908843e169b5cc5fcf76c7718bd66135ef4a9cd558c5"
+dependencies = [
+ "semver",
+ "serde",
+ "serde_json",
+ "topological-sort",
+]
 
 [[package]]
 name = "backtrace"
@@ -367,52 +381,52 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
-version = "2.11.0"
+version = "2.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "843867be96c8daad0d758b57df9392b6d8d271134fce549de6ce169ff98a92af"
+checksum = "b4388bee8683e3d04af747c73422af53102d2bd24d9eadb6cbc100baef4b43f8"
 
 [[package]]
 name = "bpaf"
-version = "0.9.23"
+version = "0.9.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22a59e5c2bac9ccb280150ef4b58e07e4169d8c5c6ce0f70170e3c0b7c7b6124"
+checksum = "0b86829876e7e200161a5aa6ea688d46c32d64d70ee3100127790dde84688d6e"
 dependencies = [
  "bpaf_derive",
 ]
 
 [[package]]
 name = "bpaf_derive"
-version = "0.5.23"
+version = "0.5.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "549ca9c364fdc06f9f36d1356980193d930abc80db848193c2dd4d0e9a83de1b"
+checksum = "2f7e98cee839b19076cb3ce1afdb62bb182e04ff5f71f70188827002fae91094"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
 name = "bstr"
-version = "1.12.1"
+version = "1.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "63044e1ae8e69f3b5a92c736ca6269b8d12fa7efe39bf34ddb06d102cf0e2cab"
+checksum = "5cee35f73844aa3014bb606320a6c1f010249dbdf43342fe54b5a4f6a8ed4b79"
 dependencies = [
  "memchr",
  "regex-automata",
- "serde",
+ "serde_core",
 ]
 
 [[package]]
 name = "camino"
-version = "1.2.2"
+version = "1.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e629a66d692cb9ff1a1c664e41771b3dcaf961985a9774c0eb0bd1b51cf60a48"
+checksum = "5f2d30e4173c4026932d51d31d6b0613b1fd3014bf3f9f8943d4ba139c437ba0"
 
 [[package]]
 name = "cc"
-version = "1.2.56"
+version = "1.2.65"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aebf35691d1bfb0ac386a69bac2fde4dd276fb618cf8bf4f5318fe285e821bb2"
+checksum = "e228eec9be7c17ccb640b59b36a5cd805ea2a564a4c5e162c2f659fea30d3b96"
 dependencies = [
  "find-msvc-tools",
  "shlex",
@@ -426,9 +440,9 @@ checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
 name = "clap"
-version = "4.6.0"
+version = "4.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b193af5b67834b676abd72466a96c1024e6a6ad978a1f484bd90b85c94041351"
+checksum = "1ddb117e43bbf7dacf0a4190fef4d345b9bad68dfc649cb349e7d17d28428e51"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -448,27 +462,27 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "4.6.0"
+version = "4.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1110bd8a634a1ab8cb04345d8d878267d57c3cf1b38d91b71af6686408bbca6a"
+checksum = "f2ce8604710f6733aa641a2b3731eaa1e8b3d9973d5e3565da11800813f997a9"
 dependencies = [
- "heck 0.5.0",
+ "heck",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
 name = "clap_lex"
-version = "1.0.0"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a822ea5bc7590f9d40f1ba12c0dc3c2760f3482c6984db1573ad11031420831"
+checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "colorchoice"
-version = "1.0.4"
+version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b05b61dc5112cbb17e4b6cd61790d9845d13888356391624cbe7e41efeac1e75"
+checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
 
 [[package]]
 name = "colored"
@@ -476,13 +490,13 @@ version = "3.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "faf9468729b8cbcea668e36183cb69d317348c2e08e994829fb56ebfdfbaac34"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys",
 ]
 
 [[package]]
 name = "comments"
 version = "0.0.0"
-source = "git+https://github.com/posit-dev/air?rev=0eadd6938d0316b1fc885c91e7af55d7c8de8530#0eadd6938d0316b1fc885c91e7af55d7c8de8530"
+source = "git+https://github.com/Goldziher/r-air-fork?rev=c916545f14f76e1d6bd6ff918870f86dfa704b63#c916545f14f76e1d6bd6ff918870f86dfa704b63"
 
 [[package]]
 name = "console"
@@ -492,7 +506,16 @@ checksum = "d64e8af5551369d19cf50138de61f1c42074ab970f74e99be916646777f8fc87"
 dependencies = [
  "encode_unicode",
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys",
+]
+
+[[package]]
+name = "crc32fast"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9481c1c90cbf2ac953f07c8d4a58aa3945c425b7185c9154d67a65e4230da511"
+dependencies = [
+ "cfg-if",
 ]
 
 [[package]]
@@ -553,13 +576,13 @@ checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
 
 [[package]]
 name = "displaydoc"
-version = "0.2.5"
+version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
+checksum = "1ac70aa55017e108007fbaf5aa0f54b021c98f92ff8af59d42eda9da96e3dd4f"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -576,9 +599,9 @@ checksum = "d0881ea181b1df73ff77ffaaf9c7544ecc11e82fba9b5f27b262a3c73a332555"
 
 [[package]]
 name = "either"
-version = "1.15.0"
+version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
+checksum = "91622ff5e7162018101f2fea40d6ebf4a78bbe5a49736a2020649edf9693679e"
 
 [[package]]
 name = "encode_unicode"
@@ -604,7 +627,7 @@ checksum = "67c78a4d8fdf9953a5c9d458f9efe940fd97a0cab0941c075a813ac594733827"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -620,7 +643,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys",
 ]
 
 [[package]]
@@ -630,20 +653,39 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "de48cc4d1c1d97a20fd819def54b890cadde72ed3ad0c614822a0a433361be96"
 dependencies = [
  "cfg-if",
- "windows-sys 0.61.2",
+ "windows-sys",
 ]
 
 [[package]]
 name = "fastrand"
-version = "2.3.0"
+version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
+checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
 
 [[package]]
 name = "find-msvc-tools"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
+
+[[package]]
+name = "flate2"
+version = "1.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "843fba2746e448b37e26a819579957415c8cef339bf08564fe8b7ddbd959573c"
+dependencies = [
+ "crc32fast",
+ "miniz_oxide",
+]
+
+[[package]]
+name = "fluent-uri"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "17c704e9dbe1ddd863da1e6ff3567795087b1eb201ce80d8fa81162e1516500d"
+dependencies = [
+ "bitflags 1.3.2",
+]
 
 [[package]]
 name = "foldhash"
@@ -663,22 +705,108 @@ dependencies = [
 [[package]]
 name = "fs"
 version = "0.0.0"
-source = "git+https://github.com/posit-dev/air?rev=0eadd6938d0316b1fc885c91e7af55d7c8de8530#0eadd6938d0316b1fc885c91e7af55d7c8de8530"
+source = "git+https://github.com/Goldziher/r-air-fork?rev=c916545f14f76e1d6bd6ff918870f86dfa704b63#c916545f14f76e1d6bd6ff918870f86dfa704b63"
 dependencies = [
  "path-absolutize",
 ]
 
 [[package]]
-name = "getrandom"
-version = "0.4.1"
+name = "futures"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "139ef39800118c7683f2fd3c98c1b23c09ae076556b435f8e9064ae108aaeeec"
+checksum = "8b147ee9d1f6d097cef9ce628cd2ee62288d963e16fb287bd9286455b241382d"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "futures-executor",
+ "futures-io",
+ "futures-sink",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
+name = "futures-channel"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "07bbe89c50d7a535e539b8c17bc0b49bdb77747034daa8087407d655f3f7cc1d"
+dependencies = [
+ "futures-core",
+ "futures-sink",
+]
+
+[[package]]
+name = "futures-core"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7e3450815272ef58cec6d564423f6e755e25379b217b0bc688e295ba24df6b1d"
+
+[[package]]
+name = "futures-executor"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "baf29c38818342a3b26b5b923639e7b1f4a61fc5e76102d4b1981c6dc7a7579d"
+dependencies = [
+ "futures-core",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
+name = "futures-io"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cecba35d7ad927e23624b22ad55235f2239cfa44fd10428eecbeba6d6a717718"
+
+[[package]]
+name = "futures-macro"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e835b70203e41293343137df5c0664546da5745f82ec9b84d40be8336958447b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.118",
+]
+
+[[package]]
+name = "futures-sink"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c39754e157331b013978ec91992bde1ac089843443c49cbc7f46150b0fad0893"
+
+[[package]]
+name = "futures-task"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "037711b3d59c33004d3856fbdc83b99d4ff37a24768fa1be9ce3538a1cde4393"
+
+[[package]]
+name = "futures-util"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "389ca41296e6190b48053de0321d02a77f32f8a5d2461dd38762c0593805c6d6"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "futures-io",
+ "futures-macro",
+ "futures-sink",
+ "futures-task",
+ "memchr",
+ "pin-project-lite",
+ "slab",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "300e883d756b2e4ec94e02791f39b04b522276138852cfc41d9fb7e904106099"
 dependencies = [
  "cfg-if",
  "libc",
  "r-efi",
- "wasip2",
- "wasip3",
 ]
 
 [[package]]
@@ -711,18 +839,9 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.16.1"
+version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
-
-[[package]]
-name = "heck"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
-dependencies = [
- "unicode-segmentation",
-]
+checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
 
 [[package]]
 name = "heck"
@@ -732,12 +851,13 @@ checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "icu_collections"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c6b649701667bbe825c3b7e6388cb521c23d88644678e83c0c4d0a621a34b43"
+checksum = "2984d1cd16c883d7935b9e07e44071dca8d917fd52ecc02c04d5fa0b5a3f191c"
 dependencies = [
  "displaydoc",
  "potential_utf",
+ "utf8_iter",
  "yoke",
  "zerofrom",
  "zerovec",
@@ -745,9 +865,9 @@ dependencies = [
 
 [[package]]
 name = "icu_locale_core"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "edba7861004dd3714265b4db54a3c390e880ab658fec5f7db895fae2046b5bb6"
+checksum = "92219b62b3e2b4d88ac5119f8904c10f8f61bf7e95b640d25ba3075e6cac2c29"
 dependencies = [
  "displaydoc",
  "litemap",
@@ -758,9 +878,9 @@ dependencies = [
 
 [[package]]
 name = "icu_normalizer"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f6c8828b67bf8908d82127b2054ea1b4427ff0230ee9141c54251934ab1b599"
+checksum = "c56e5ee99d6e3d33bd91c5d85458b6005a22140021cc324cea84dd0e72cff3b4"
 dependencies = [
  "icu_collections",
  "icu_normalizer_data",
@@ -772,15 +892,15 @@ dependencies = [
 
 [[package]]
 name = "icu_normalizer_data"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7aedcccd01fc5fe81e6b489c15b247b8b0690feb23304303a9e560f37efc560a"
+checksum = "da3be0ae77ea334f4da67c12f149704f19f81d1adf7c51cf482943e84a2bad38"
 
 [[package]]
 name = "icu_properties"
-version = "2.1.2"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "020bfc02fe870ec3a66d93e677ccca0562506e5872c650f893269e08615d74ec"
+checksum = "bee3b67d0ea5c2cca5003417989af8996f8604e34fb9ddf96208a033901e70de"
 dependencies = [
  "icu_collections",
  "icu_locale_core",
@@ -792,15 +912,15 @@ dependencies = [
 
 [[package]]
 name = "icu_properties_data"
-version = "2.1.2"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "616c294cf8d725c6afcd8f55abc17c56464ef6211f9ed59cccffe534129c77af"
+checksum = "8e2bbb201e0c04f7b4b3e14382af113e17ba4f63e2c9d2ee626b720cbce54a14"
 
 [[package]]
 name = "icu_provider"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85962cf0ce02e1e0a629cc34e7ca3e373ce20dda4c4d7294bbd0bf1fdb59e614"
+checksum = "139c4cf31c8b5f33d7e199446eff9c1e02decfc2f0eec2c8d71f65befa45b421"
 dependencies = [
  "displaydoc",
  "icu_locale_core",
@@ -830,9 +950,9 @@ dependencies = [
 
 [[package]]
 name = "idna_adapter"
-version = "1.2.1"
+version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3acae9609540aa318d1bc588455225fb2085b9ed0c4f6bd0d9d5bcd86f1a0344"
+checksum = "cb68373c0d6620ef8105e855e7745e18b0d00d3bdb07fb532e434244cdb9a714"
 dependencies = [
  "icu_normalizer",
  "icu_properties",
@@ -840,9 +960,9 @@ dependencies = [
 
 [[package]]
 name = "ignore"
-version = "0.4.25"
+version = "0.4.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3d782a365a015e0f5c04902246139249abf769125006fbe7649e2ee88169b4a"
+checksum = "b915661dd01db3f05050265b2477bcc6527b3792388e2749b41623cc592be67d"
 dependencies = [
  "crossbeam-deque",
  "globset",
@@ -856,12 +976,12 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.13.0"
+version = "2.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7714e70437a7dc3ac8eb7e6f8df75fd8eb422675fc7678aff7364301092b1017"
+checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
 dependencies = [
  "equivalent",
- "hashbrown 0.16.1",
+ "hashbrown 0.17.1",
  "serde",
  "serde_core",
 ]
@@ -889,18 +1009,18 @@ checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
 
 [[package]]
 name = "itertools"
-version = "0.13.0"
+version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186"
+checksum = "8b4baf93f58d4425749ca49a51c50ebab072c5df6994d08fed93541c331481dc"
 dependencies = [
  "either",
 ]
 
 [[package]]
 name = "itoa"
-version = "1.0.17"
+version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92ecc6618181def0457392ccd0ee51198e065e016d1d527a7ac1b6dc7c1f09d2"
+checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
 name = "jarl"
@@ -965,6 +1085,7 @@ dependencies = [
  "serde_json",
  "tempfile",
  "tracing",
+ "url",
  "workspace",
 ]
 
@@ -975,12 +1096,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
-name = "leb128"
-version = "0.2.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "884e2677b40cc8c339eaefcb701c32ef1fd2493d71118dc0ca4b6a736c93bd67"
-
-[[package]]
 name = "leb128fmt"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -988,14 +1103,14 @@ checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
 
 [[package]]
 name = "libc"
-version = "0.2.182"
+version = "0.2.186"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6800badb6cb2082ffd7b6a67e6125bb39f18782f793520caee8cb8846be06112"
+checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
 
 [[package]]
 name = "line_ending"
 version = "0.0.0"
-source = "git+https://github.com/posit-dev/air?rev=0eadd6938d0316b1fc885c91e7af55d7c8de8530#0eadd6938d0316b1fc885c91e7af55d7c8de8530"
+source = "git+https://github.com/Goldziher/r-air-fork?rev=c916545f14f76e1d6bd6ff918870f86dfa704b63#c916545f14f76e1d6bd6ff918870f86dfa704b63"
 dependencies = [
  "memchr",
  "settings",
@@ -1009,21 +1124,21 @@ checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
 
 [[package]]
 name = "litemap"
-version = "0.8.1"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6373607a59f0be73a39b6fe456b8192fcc3585f602af20751600e974dd455e77"
+checksum = "92daf443525c4cce67b150400bc2316076100ce0b3686209eb8cf3c31612e6f0"
 
 [[package]]
 name = "log"
-version = "0.4.29"
+version = "0.4.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
+checksum = "0ceec5bc11778974d1bcb055b18002eba7f4b3518b6a0081b3af5f21666da9ad"
 
 [[package]]
 name = "lsp-server"
-version = "0.7.9"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7d6ada348dbc2703cbe7637b2dda05cff84d3da2819c24abcb305dd613e0ba2e"
+checksum = "0ad8be6fe0ca81b8298bfbbe8a77e9fcd8895ad6c84cd7794d5ebadcbb09ae43"
 dependencies = [
  "crossbeam-channel",
  "log",
@@ -1034,22 +1149,22 @@ dependencies = [
 
 [[package]]
 name = "lsp-types"
-version = "0.95.1"
+version = "0.97.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e34d33a8e9b006cd3fc4fe69a921affa097bae4bb65f76271f4644f9a334365"
+checksum = "53353550a17c04ac46c585feb189c2db82154fc84b79c7a66c96c2c644f66071"
 dependencies = [
  "bitflags 1.3.2",
+ "fluent-uri",
  "serde",
  "serde_json",
  "serde_repr",
- "url",
 ]
 
 [[package]]
 name = "memchr"
-version = "2.8.0"
+version = "2.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
+checksum = "88904434abc2901f197fe8cc55f0445e7ded921dba5911dad2e2b39b48e663c4"
 
 [[package]]
 name = "miniz_oxide"
@@ -1058,6 +1173,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1fa76a2c86f704bdb222d66965fb3d63269ce38518b83cb0575fca855ebb6316"
 dependencies = [
  "adler2",
+ "simd-adler32",
 ]
 
 [[package]]
@@ -1066,7 +1182,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys",
 ]
 
 [[package]]
@@ -1080,9 +1196,9 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.21.3"
+version = "1.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
+checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
 
 [[package]]
 name = "once_cell_polyfill"
@@ -1116,15 +1232,15 @@ checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
 name = "pin-project-lite"
-version = "0.2.16"
+version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b3cff922bd51709b605d9ead9aa71031d81447142d828eb4a6eba76fe619f9b"
+checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
 name = "potential_utf"
-version = "0.1.4"
+version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b73949432f5e2a09657003c25bca5e19a0e9c84f8058ca374f49e0ebe605af77"
+checksum = "0103b1cef7ec0cf76490e969665504990193874ea05c85ff9bab8b911d0a0564"
 dependencies = [
  "zerovec",
 ]
@@ -1136,7 +1252,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
 dependencies = [
  "proc-macro2",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -1171,18 +1287,18 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.45"
+version = "1.0.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41f2619966050689382d2b44f664f4bc593e129785a36d6ee376ddf37259b924"
+checksum = "dfbc457d0c7a0759a614551b11a6409e5951f6c7537be1f1b7682b9ae9230368"
 dependencies = [
  "proc-macro2",
 ]
 
 [[package]]
 name = "r-efi"
-version = "5.3.0"
+version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
+checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
 name = "rayon"
@@ -1221,14 +1337,14 @@ checksum = "b7186006dcb21920990093f30e3dea63b7d6e977bf1256be20c3563a5db070da"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
 name = "regex"
-version = "1.12.3"
+version = "1.12.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e10754a14b9137dd7b1e3e5b0493cc9171fdd105e0ab477f51b72e7f3ac0e276"
+checksum = "f1292b7759ae1cb9ec195452d1390a074f0cd8541ab7a5a8c31cd6db45d4a6ba"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -1249,9 +1365,9 @@ dependencies = [
 
 [[package]]
 name = "regex-syntax"
-version = "0.8.9"
+version = "0.8.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a96887878f22d7bad8a3b6dc5b7440e0ada9a245242924394987b21cf2210a4c"
+checksum = "d6f6ff9a378485b298a5286656da665ba74413d36db0979633275d2e708145d4"
 
 [[package]]
 name = "rustc-demangle"
@@ -1261,9 +1377,9 @@ checksum = "b50b8869d9fc858ce7266cce0194bd74df58b9d0e3f6df3a9fc8eb470d95c09d"
 
 [[package]]
 name = "rustc-hash"
-version = "2.1.1"
+version = "2.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "357703d41365b4b27c590e3ed91eabb1b663f07c4c084095e60cbed4362dff0d"
+checksum = "94300abf3f1ae2e2b8ffb7b58043de3d399c73fa6f4b73826402a5c457614dbe"
 
 [[package]]
 name = "rustix"
@@ -1271,11 +1387,11 @@ version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.13.0",
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.60.2",
+ "windows-sys",
 ]
 
 [[package]]
@@ -1309,14 +1425,18 @@ dependencies = [
  "proc-macro2",
  "quote",
  "serde_derive_internals",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
 name = "semver"
-version = "1.0.27"
+version = "1.0.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d767eb0aabc880b29956c35734170f26ed551a859dbd361d140cdbeca61ab1e2"
+checksum = "8a7852d02fc848982e0c167ef163aaff9cd91dc640ba85e263cb1ce46fae51cd"
+dependencies = [
+ "serde",
+ "serde_core",
+]
 
 [[package]]
 name = "serde"
@@ -1345,7 +1465,7 @@ checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -1356,15 +1476,16 @@ checksum = "18d26a20a969b9e3fdf2fc2d9f21eda6c40e2de84c9408bb5d3b05d499aae711"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
 name = "serde_json"
-version = "1.0.149"
+version = "1.0.150"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "83fc039473c5595ace860d8c4fafa220ff474b3fc6bfdb4293327f1a37e94d86"
+checksum = "e8014e44b4736ed0538adeecded0fce2a272f22dc9578a7eb6b2d9993c74cfb9"
 dependencies = [
+ "indexmap",
  "itoa",
  "memchr",
  "serde",
@@ -1380,22 +1501,22 @@ checksum = "175ee3e80ae9982737ca543e96133087cbd9a485eecc3bc4de9c1a37b47ea59c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
 name = "serde_spanned"
-version = "0.6.9"
+version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf41e0cfaf7226dca15e8197172c295a782857fcb97fad1808a166870dee75a3"
+checksum = "6662b5879511e06e8999a8a235d848113e942c9124f211511b16466ee2995f26"
 dependencies = [
- "serde",
+ "serde_core",
 ]
 
 [[package]]
 name = "settings"
 version = "0.0.0"
-source = "git+https://github.com/posit-dev/air?rev=0eadd6938d0316b1fc885c91e7af55d7c8de8530#0eadd6938d0316b1fc885c91e7af55d7c8de8530"
+source = "git+https://github.com/Goldziher/r-air-fork?rev=c916545f14f76e1d6bd6ff918870f86dfa704b63#c916545f14f76e1d6bd6ff918870f86dfa704b63"
 dependencies = [
  "biome_formatter",
  "serde",
@@ -1412,9 +1533,15 @@ dependencies = [
 
 [[package]]
 name = "shlex"
-version = "1.3.0"
+version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
+checksum = "f8fadd59c855ef2080decdef8ff161eb6661b86933c9d82e5ba29dc602a55aba"
+
+[[package]]
+name = "simd-adler32"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "703d5c7ef118737c72f1af64ad2f6f8c5e1921f818cdcb97b8fe6fc69bf66214"
 
 [[package]]
 name = "similar"
@@ -1427,10 +1554,16 @@ dependencies = [
 ]
 
 [[package]]
-name = "smallvec"
-version = "1.15.1"
+name = "slab"
+version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
+checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
+
+[[package]]
+name = "smallvec"
+version = "1.15.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ed6a63f02c8539c91a8685a86f4099661ba3da017932f6ebbea6de3f0fa7c90"
 
 [[package]]
 name = "spdx"
@@ -1481,9 +1614,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.117"
+version = "2.0.118"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e665b8803e7b1d2a727f4023456bbbbe74da67099c585258af0ad9c5013b9b99"
+checksum = "1b9ae57f904213ebb649ce6895b8a66c66f0203b9319718f69a5612a065b1422"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1498,7 +1631,7 @@ checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -1511,7 +1644,7 @@ dependencies = [
  "getrandom",
  "once_cell",
  "rustix",
- "windows-sys 0.60.2",
+ "windows-sys",
 ]
 
 [[package]]
@@ -1525,12 +1658,12 @@ dependencies = [
 
 [[package]]
 name = "terminal_size"
-version = "0.4.3"
+version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "60b8cb979cb11c32ce1603f8137b22262a9d131aaa5c37b5678025f22b8becd0"
+checksum = "230a1b821ccbd75b185820a1f1ff7b14d21da1e442e22c0863ea5f08771a8874"
 dependencies = [
  "rustix",
- "windows-sys 0.60.2",
+ "windows-sys",
 ]
 
 [[package]]
@@ -1550,7 +1683,7 @@ checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -1564,9 +1697,9 @@ dependencies = [
 
 [[package]]
 name = "tinystr"
-version = "0.8.2"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42d3e9c45c09de15d06dd8acf5f4e0e399e85927b7f00711024eb7ae10fa4869"
+checksum = "c8323304221c2a851516f22236c5722a72eaa19749016521d6dff0824447d96d"
 dependencies = [
  "displaydoc",
  "zerovec",
@@ -1574,44 +1707,48 @@ dependencies = [
 
 [[package]]
 name = "toml"
-version = "0.8.23"
+version = "1.1.2+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc1beb996b9d83529a9e75c17a1686767d148d70663143c7854d8b4a09ced362"
-dependencies = [
- "serde",
- "serde_spanned",
- "toml_datetime",
- "toml_edit",
-]
-
-[[package]]
-name = "toml_datetime"
-version = "0.6.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22cddaf88f4fbc13c51aebbf5f8eceb5c7c5a9da2ac40a13519eb5b0a0e8f11c"
-dependencies = [
- "serde",
-]
-
-[[package]]
-name = "toml_edit"
-version = "0.22.27"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41fe8c660ae4257887cf66394862d21dbca4a6ddd26f04a3560410406a2f819a"
+checksum = "81f3d15e84cbcd896376e6730314d59fb5a87f31e4b038454184435cd57defee"
 dependencies = [
  "indexmap",
- "serde",
+ "serde_core",
  "serde_spanned",
  "toml_datetime",
- "toml_write",
+ "toml_parser",
+ "toml_writer",
  "winnow",
 ]
 
 [[package]]
-name = "toml_write"
-version = "0.1.2"
+name = "toml_datetime"
+version = "1.1.1+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d99f8c9a7727884afe522e9bd5edbfc91a3312b36a77b5fb8926e4c31a41801"
+checksum = "3165f65f62e28e0115a00b2ebdd37eb6f3b641855f9d636d3cd4103767159ad7"
+dependencies = [
+ "serde_core",
+]
+
+[[package]]
+name = "toml_parser"
+version = "1.1.2+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2abe9b86193656635d2411dc43050282ca48aa31c2451210f4202550afb7526"
+dependencies = [
+ "winnow",
+]
+
+[[package]]
+name = "toml_writer"
+version = "1.1.1+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "756daf9b1013ebe47a8776667b466417e2d4c5679d441c26230efd9ef78692db"
+
+[[package]]
+name = "topological-sort"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea68304e134ecd095ac6c3574494fc62b909f416c4fca77e440530221e549d3d"
 
 [[package]]
 name = "tracing"
@@ -1632,7 +1769,7 @@ checksum = "7490cfa5ec963746568740651ac6781f701c9c5ea257c58e057f3ba8cf69e8da"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -1658,9 +1795,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-subscriber"
-version = "0.3.22"
+version = "0.3.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f30143827ddab0d256fd843b7a66d164e9f271cfa0dde49142c5ca0ca291f1e"
+checksum = "cb7f578e5945fb242538965c2d0b04418d38ec25c79d160cd279bf0731c8d319"
 dependencies = [
  "nu-ansi-term",
  "sharded-slab",
@@ -1672,13 +1809,14 @@ dependencies = [
 
 [[package]]
 name = "tree-sitter"
-version = "0.24.7"
+version = "0.26.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a5387dffa7ffc7d2dae12b50c6f7aab8ff79d6210147c6613561fc3d474c6f75"
+checksum = "4dab76d0b724ba557954125188cf0633a1ca43199ced82d95c7b9c32cc3de1f3"
 dependencies = [
  "cc",
  "regex",
  "regex-syntax",
+ "serde_json",
  "streaming-iterator",
  "tree-sitter-language",
 ]
@@ -1692,7 +1830,7 @@ checksum = "009994f150cc0cd50ff54917d5bc8bffe8cad10ca10d81c34da2ec421ae61782"
 [[package]]
 name = "tree-sitter-r"
 version = "1.2.0"
-source = "git+https://github.com/r-lib/tree-sitter-r?rev=37a6b1b5c8cc2426fd6ec16ca818cc98597d755b#37a6b1b5c8cc2426fd6ec16ca818cc98597d755b"
+source = "git+https://github.com/r-lib/tree-sitter-r?rev=d459b97a9a11dd81643ab674938bede2874663b0#d459b97a9a11dd81643ab674938bede2874663b0"
 dependencies = [
  "cc",
  "tree-sitter-language",
@@ -1712,9 +1850,9 @@ checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
 
 [[package]]
 name = "unicode-segmentation"
-version = "1.12.0"
+version = "1.13.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6ccf251212114b54433ec949fd6a7841275f9ada20dddd2f29e9ceea4501493"
+checksum = "c6f5d3c3b1bf09027a88a6bc961fc00497d651009560b5463668dc81b0fa87a8"
 
 [[package]]
 name = "unicode-width"
@@ -1744,7 +1882,6 @@ dependencies = [
  "idna",
  "percent-encoding",
  "serde",
- "serde_derive",
 ]
 
 [[package]]
@@ -1785,88 +1922,41 @@ dependencies = [
 ]
 
 [[package]]
-name = "wasip2"
-version = "1.0.2+wasi-0.2.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9517f9239f02c069db75e65f174b3da828fe5f5b945c4dd26bd25d89c03ebcf5"
-dependencies = [
- "wit-bindgen 0.51.0",
-]
-
-[[package]]
-name = "wasip3"
-version = "0.4.0+wasi-0.3.0-rc-2026-01-06"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5428f8bf88ea5ddc08faddef2ac4a67e390b88186c703ce6dbd955e1c145aca5"
-dependencies = [
- "wit-bindgen 0.51.0",
-]
-
-[[package]]
 name = "wasm-encoder"
-version = "0.201.0"
+version = "0.227.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9c7d2731df60006819b013f64ccc2019691deccf6e11a1804bc850cd6748f1a"
-dependencies = [
- "leb128",
-]
-
-[[package]]
-name = "wasm-encoder"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "990065f2fe63003fe337b932cfb5e3b80e0b4d0f5ff650e6985b1048f62c8319"
+checksum = "80bb72f02e7fbf07183443b27b0f3d4144abf8c114189f2e088ed95b696a7822"
 dependencies = [
  "leb128fmt",
- "wasmparser 0.244.0",
+ "wasmparser",
 ]
 
 [[package]]
 name = "wasm-metadata"
-version = "0.201.0"
+version = "0.227.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fd83062c17b9f4985d438603cde0a5e8c5c8198201a6937f778b607924c7da2"
+checksum = "ce1ef0faabbbba6674e97a56bee857ccddf942785a336c8b47b42373c922a91d"
 dependencies = [
  "anyhow",
+ "auditable-serde",
+ "flate2",
  "indexmap",
  "serde",
  "serde_derive",
  "serde_json",
  "spdx",
- "wasm-encoder 0.201.0",
- "wasmparser 0.201.0",
-]
-
-[[package]]
-name = "wasm-metadata"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb0e353e6a2fbdc176932bbaab493762eb1255a7900fe0fea1a2f96c296cc909"
-dependencies = [
- "anyhow",
- "indexmap",
- "wasm-encoder 0.244.0",
- "wasmparser 0.244.0",
+ "url",
+ "wasm-encoder",
+ "wasmparser",
 ]
 
 [[package]]
 name = "wasmparser"
-version = "0.201.0"
+version = "0.227.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "84e5df6dba6c0d7fafc63a450f1738451ed7a0b52295d83e868218fa286bf708"
+checksum = "0f51cad774fb3c9461ab9bccc9c62dfb7388397b5deda31bf40e8108ccd678b2"
 dependencies = [
- "bitflags 2.11.0",
- "indexmap",
- "semver",
-]
-
-[[package]]
-name = "wasmparser"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
-dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.13.0",
  "hashbrown 0.15.5",
  "indexmap",
  "semver",
@@ -1878,7 +1968,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys",
 ]
 
 [[package]]
@@ -1886,15 +1976,6 @@ name = "windows-link"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
-
-[[package]]
-name = "windows-sys"
-version = "0.60.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2f500e4d28234f72040990ec9d39e3a6b950f9f22d3dba18416c35882612bcb"
-dependencies = [
- "windows-targets",
-]
 
 [[package]]
 name = "windows-sys"
@@ -1906,228 +1987,98 @@ dependencies = [
 ]
 
 [[package]]
-name = "windows-targets"
-version = "0.53.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4945f9f551b88e0d65f3db0bc25c33b8acea4d9e41163edf90dcd0b19f9069f3"
-dependencies = [
- "windows-link",
- "windows_aarch64_gnullvm",
- "windows_aarch64_msvc",
- "windows_i686_gnu",
- "windows_i686_gnullvm",
- "windows_i686_msvc",
- "windows_x86_64_gnu",
- "windows_x86_64_gnullvm",
- "windows_x86_64_msvc",
-]
-
-[[package]]
-name = "windows_aarch64_gnullvm"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9d8416fa8b42f5c947f8482c43e7d89e73a173cead56d044f6a56104a6d1b53"
-
-[[package]]
-name = "windows_aarch64_msvc"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9d782e804c2f632e395708e99a94275910eb9100b2114651e04744e9b125006"
-
-[[package]]
-name = "windows_i686_gnu"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "960e6da069d81e09becb0ca57a65220ddff016ff2d6af6a223cf372a506593a3"
-
-[[package]]
-name = "windows_i686_gnullvm"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa7359d10048f68ab8b09fa71c3daccfb0e9b559aed648a8f95469c27057180c"
-
-[[package]]
-name = "windows_i686_msvc"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e7ac75179f18232fe9c285163565a57ef8d3c89254a30685b57d83a38d326c2"
-
-[[package]]
-name = "windows_x86_64_gnu"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c3842cdd74a865a8066ab39c8a7a473c0778a3f29370b5fd6b4b9aa7df4a499"
-
-[[package]]
-name = "windows_x86_64_gnullvm"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ffa179e2d07eee8ad8f57493436566c7cc30ac536a3379fdf008f47f6bb7ae1"
-
-[[package]]
-name = "windows_x86_64_msvc"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
-
-[[package]]
 name = "winnow"
-version = "0.7.14"
+version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a5364e9d77fcdeeaa6062ced926ee3381faa2ee02d3eb83a5c27a8825540829"
-dependencies = [
- "memchr",
-]
+checksum = "0592e1c9d151f854e6fd382574c3a0855250e1d9b2f99d9281c6e6391af352f1"
 
 [[package]]
 name = "wit-bindgen"
-version = "0.22.0"
+version = "0.41.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "288f992ea30e6b5c531b52cdd5f3be81c148554b09ea416f058d16556ba92c27"
+checksum = "10fb6648689b3929d56bbc7eb1acf70c9a42a29eb5358c67c10f54dbd5d695de"
 dependencies = [
- "bitflags 2.11.0",
  "wit-bindgen-rt",
- "wit-bindgen-rust-macro 0.22.0",
-]
-
-[[package]]
-name = "wit-bindgen"
-version = "0.51.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7249219f66ced02969388cf2bb044a09756a083d0fab1e566056b04d9fbcaa5"
-dependencies = [
- "wit-bindgen-rust-macro 0.51.0",
+ "wit-bindgen-rust-macro",
 ]
 
 [[package]]
 name = "wit-bindgen-core"
-version = "0.22.0"
+version = "0.41.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e85e72719ffbccf279359ad071497e47eb0675fe22106dea4ed2d8a7fcb60ba4"
+checksum = "92fa781d4f2ff6d3f27f3cc9b74a73327b31ca0dc4a3ef25a0ce2983e0e5af9b"
 dependencies = [
  "anyhow",
- "wit-parser 0.201.0",
-]
-
-[[package]]
-name = "wit-bindgen-core"
-version = "0.51.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea61de684c3ea68cb082b7a88508a8b27fcc8b797d738bfc99a82facf1d752dc"
-dependencies = [
- "anyhow",
- "heck 0.5.0",
- "wit-parser 0.244.0",
+ "heck",
+ "wit-parser",
 ]
 
 [[package]]
 name = "wit-bindgen-rt"
-version = "0.22.0"
+version = "0.41.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fcb8738270f32a2d6739973cbbb7c1b6dd8959ce515578a6e19165853272ee64"
-
-[[package]]
-name = "wit-bindgen-rust"
-version = "0.22.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d8a39a15d1ae2077688213611209849cad40e9e5cccf6e61951a425850677ff3"
+checksum = "c4db52a11d4dfb0a59f194c064055794ee6564eb1ced88c25da2cf76e50c5621"
 dependencies = [
- "anyhow",
- "heck 0.4.1",
- "indexmap",
- "wasm-metadata 0.201.0",
- "wit-bindgen-core 0.22.0",
- "wit-component 0.201.0",
+ "bitflags 2.13.0",
+ "futures",
+ "once_cell",
 ]
 
 [[package]]
 name = "wit-bindgen-rust"
-version = "0.51.0"
+version = "0.41.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7c566e0f4b284dd6561c786d9cb0142da491f46a9fbed79ea69cdad5db17f21"
+checksum = "9d0809dc5ba19e2e98661bf32fc0addc5a3ca5bf3a6a7083aa6ba484085ff3ce"
 dependencies = [
  "anyhow",
- "heck 0.5.0",
+ "heck",
  "indexmap",
  "prettyplease",
- "syn 2.0.117",
- "wasm-metadata 0.244.0",
- "wit-bindgen-core 0.51.0",
- "wit-component 0.244.0",
+ "syn 2.0.118",
+ "wasm-metadata",
+ "wit-bindgen-core",
+ "wit-component",
 ]
 
 [[package]]
 name = "wit-bindgen-rust-macro"
-version = "0.22.0"
+version = "0.41.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d376d3ae5850526dfd00d937faea0d81a06fa18f7ac1e26f386d760f241a8f4b"
-dependencies = [
- "anyhow",
- "proc-macro2",
- "quote",
- "syn 2.0.117",
- "wit-bindgen-core 0.22.0",
- "wit-bindgen-rust 0.22.0",
-]
-
-[[package]]
-name = "wit-bindgen-rust-macro"
-version = "0.51.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c0f9bfd77e6a48eccf51359e3ae77140a7f50b1e2ebfe62422d8afdaffab17a"
+checksum = "ad19eec017904e04c60719592a803ee5da76cb51c81e3f6fbf9457f59db49799"
 dependencies = [
  "anyhow",
  "prettyplease",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
- "wit-bindgen-core 0.51.0",
- "wit-bindgen-rust 0.51.0",
+ "syn 2.0.118",
+ "wit-bindgen-core",
+ "wit-bindgen-rust",
 ]
 
 [[package]]
 name = "wit-component"
-version = "0.201.0"
+version = "0.227.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "421c0c848a0660a8c22e2fd217929a0191f14476b68962afd2af89fd22e39825"
+checksum = "635c3adc595422cbf2341a17fb73a319669cc8d33deed3a48368a841df86b676"
 dependencies = [
  "anyhow",
- "bitflags 2.11.0",
+ "bitflags 2.13.0",
  "indexmap",
  "log",
  "serde",
  "serde_derive",
  "serde_json",
- "wasm-encoder 0.201.0",
- "wasm-metadata 0.201.0",
- "wasmparser 0.201.0",
- "wit-parser 0.201.0",
-]
-
-[[package]]
-name = "wit-component"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
-dependencies = [
- "anyhow",
- "bitflags 2.11.0",
- "indexmap",
- "log",
- "serde",
- "serde_derive",
- "serde_json",
- "wasm-encoder 0.244.0",
- "wasm-metadata 0.244.0",
- "wasmparser 0.244.0",
- "wit-parser 0.244.0",
+ "wasm-encoder",
+ "wasm-metadata",
+ "wasmparser",
+ "wit-parser",
 ]
 
 [[package]]
 name = "wit-parser"
-version = "0.201.0"
+version = "0.227.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "196d3ecfc4b759a8573bf86a9b3f8996b304b3732e4c7de81655f875f6efdca6"
+checksum = "ddf445ed5157046e4baf56f9138c124a0824d4d1657e7204d71886ad8ce2fc11"
 dependencies = [
  "anyhow",
  "id-arena",
@@ -2138,31 +2089,13 @@ dependencies = [
  "serde_derive",
  "serde_json",
  "unicode-xid",
- "wasmparser 0.201.0",
-]
-
-[[package]]
-name = "wit-parser"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ecc8ac4bc1dc3381b7f59c34f00b67e18f910c2c0f50015669dde7def656a736"
-dependencies = [
- "anyhow",
- "id-arena",
- "indexmap",
- "log",
- "semver",
- "serde",
- "serde_derive",
- "serde_json",
- "unicode-xid",
- "wasmparser 0.244.0",
+ "wasmparser",
 ]
 
 [[package]]
 name = "workspace"
 version = "0.1.0"
-source = "git+https://github.com/posit-dev/air?rev=0eadd6938d0316b1fc885c91e7af55d7c8de8530#0eadd6938d0316b1fc885c91e7af55d7c8de8530"
+source = "git+https://github.com/Goldziher/r-air-fork?rev=c916545f14f76e1d6bd6ff918870f86dfa704b63#c916545f14f76e1d6bd6ff918870f86dfa704b63"
 dependencies = [
  "air_r_formatter",
  "air_r_parser",
@@ -2181,9 +2114,9 @@ dependencies = [
 
 [[package]]
 name = "writeable"
-version = "0.6.2"
+version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9edde0db4769d2dc68579893f2306b26c6ecfbe0ef499b013d731b7b9247e0b9"
+checksum = "1ffae5123b2d3fc086436f8834ae3ab053a283cfac8fe0a0b8eaae044768a4c4"
 
 [[package]]
 name = "xtask"
@@ -2206,9 +2139,9 @@ dependencies = [
 
 [[package]]
 name = "yoke"
-version = "0.8.1"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72d6e5c6afb84d73944e5cedb052c4680d5657337201555f9f2a16b7406d4954"
+checksum = "709fe23a0424b6a435d82152b1bd3fdfb0833487d5fa90d05d42762a9891fef5"
 dependencies = [
  "stable_deref_trait",
  "yoke-derive",
@@ -2217,25 +2150,25 @@ dependencies = [
 
 [[package]]
 name = "yoke-derive"
-version = "0.8.1"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b659052874eb698efe5b9e8cf382204678a0086ebf46982b79d6ca3182927e5d"
+checksum = "de844c262c8848816172cef550288e7dc6c7b7814b4ee56b3e1553f275f1858e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
  "synstructure",
 ]
 
 [[package]]
 name = "zed_extension_api"
-version = "0.2.0"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9fd16b8b30a9dc920fc1678ff852f696b5bdf5b5843bc745a128be0aac29859e"
+checksum = "0729d50b4ca0a7e28e590bbe32e3ca0194d97ef654961451a424c661a366fca0"
 dependencies = [
  "serde",
  "serde_json",
- "wit-bindgen 0.22.0",
+ "wit-bindgen",
 ]
 
 [[package]]
@@ -2247,30 +2180,30 @@ dependencies = [
 
 [[package]]
 name = "zerofrom"
-version = "0.1.6"
+version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50cc42e0333e05660c3587f3bf9d0478688e15d870fab3346451ce7f8c9fbea5"
+checksum = "0ec05a11813ea801ff6d75110ad09cd0824ddba17dfe17128ea0d5f68e6c5272"
 dependencies = [
  "zerofrom-derive",
 ]
 
 [[package]]
 name = "zerofrom-derive"
-version = "0.1.6"
+version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d71e5d6e06ab090c67b5e44993ec16b72dcbaabc526db883a360057678b48502"
+checksum = "11532158c46691caf0f2593ea8358fed6bbf68a0315e80aae9bd41fbade684a1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
  "synstructure",
 ]
 
 [[package]]
 name = "zerotrie"
-version = "0.2.3"
+version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a59c17a5562d507e4b54960e8569ebee33bee890c70aa3fe7b97e85a9fd7851"
+checksum = "0f9152d31db0792fa83f70fb2f83148effb5c1f5b8c7686c3459e361d9bc20bf"
 dependencies = [
  "displaydoc",
  "yoke",
@@ -2279,9 +2212,9 @@ dependencies = [
 
 [[package]]
 name = "zerovec"
-version = "0.11.5"
+version = "0.11.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c28719294829477f525be0186d13efa9a3c602f7ec202ca9e353d310fb9a002"
+checksum = "90f911cbc359ab6af17377d242225f4d75119aec87ea711a880987b18cd7b239"
 dependencies = [
  "yoke",
  "zerofrom",
@@ -2290,13 +2223,13 @@ dependencies = [
 
 [[package]]
 name = "zerovec-derive"
-version = "0.11.2"
+version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eadce39539ca5cb3985590102671f2567e659fca9666581ad3411d59207951f3"
+checksum = "625dc425cab0dca6dc3c3319506e6593dcb08a9f387ea3b284dbd52a92c40555"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,32 +11,32 @@ repository = "https://github.com/etiennebacher/jarl/"
 readme = "README.md"
 
 [workspace.dependencies]
-air_fs = { package = "fs", git = "https://github.com/posit-dev/air", rev = "0eadd6938d0316b1fc885c91e7af55d7c8de8530" }
-air_r_parser = { git = "https://github.com/posit-dev/air", rev = "0eadd6938d0316b1fc885c91e7af55d7c8de8530" }
-air_r_syntax = { git = "https://github.com/posit-dev/air", rev = "0eadd6938d0316b1fc885c91e7af55d7c8de8530" }
-air_workspace = { package = "workspace", git = "https://github.com/posit-dev/air", rev = "0eadd6938d0316b1fc885c91e7af55d7c8de8530" }
-anyhow = "1.0.94"
+air_fs = { package = "fs", git = "https://github.com/Goldziher/r-air-fork", rev = "c916545f14f76e1d6bd6ff918870f86dfa704b63" }
+air_r_parser = { git = "https://github.com/Goldziher/r-air-fork", rev = "c916545f14f76e1d6bd6ff918870f86dfa704b63" }
+air_r_syntax = { git = "https://github.com/Goldziher/r-air-fork", rev = "c916545f14f76e1d6bd6ff918870f86dfa704b63" }
+air_workspace = { package = "workspace", git = "https://github.com/Goldziher/r-air-fork", rev = "c916545f14f76e1d6bd6ff918870f86dfa704b63" }
+anyhow = "1.0.103"
 biome_formatter = { git = "https://github.com/lionel-/biome", rev = "a1296ea6ba363d8b8d8f02181b2a4ce9315c5ef9" }
 biome_rowan = { git = "https://github.com/lionel-/biome", rev = "a1296ea6ba363d8b8d8f02181b2a4ce9315c5ef9" }
-clap = { version = "4.6.0", features = ["derive"] }
+clap = { version = "4.6.1", features = ["derive"] }
 colored = "3.1.1"
-ignore = "0.4.23"
-insta = { version = "1.47.2", features = ["yaml", "filters"] }
+ignore = "0.4.26"
+insta = { version = "1.48.0", features = ["yaml", "filters"] }
 etcetera = "0.11.0"
 jarl-core = { path = "crates/jarl-core" }
 jarl-lsp = { path = "crates/jarl-lsp" }
 path-absolutize = "3.1.1"
 rayon = "1.12.0"
-regex = { version = "1.11.1", default-features = false, features = ["std"] }
-rustc-hash = "2.1.1"
-schemars = "1.1.0"
-serde = { version = "1.0.215", features = ["derive"] }
-serde_json = "1.0.143"
+regex = { version = "1.12.4", default-features = false, features = ["std"] }
+rustc-hash = "2.1.2"
+schemars = "1.2.1"
+serde = { version = "1.0.228", features = ["derive"] }
+serde_json = "1.0.150"
 strsim = "0.11"
 tempfile = "3.27.0"
 # Same as in Air to reduce compile time
-toml = "0.8.23"
-tracing = "0.1.41"
+toml = "1.1.2"
+tracing = "0.1.44"
 
 [profile.release]
 lto = true

--- a/crates/jarl-core/Cargo.toml
+++ b/crates/jarl-core/Cargo.toml
@@ -43,7 +43,7 @@ rayon.workspace = true
 regex.workspace = true
 
 schemars = { workspace = true, optional = true }
-annotate-snippets = "0.11"
+annotate-snippets = "0.12"
 
 [dev-dependencies]
 insta.workspace = true

--- a/crates/jarl-core/src/diagnostic.rs
+++ b/crates/jarl-core/src/diagnostic.rs
@@ -1,4 +1,4 @@
-use annotate_snippets::{Level, Renderer, Snippet};
+use annotate_snippets::{AnnotationKind, Level, Padding, Renderer, Snippet};
 use biome_rowan::TextRange;
 use serde::{Deserialize, Serialize};
 use std::cmp::Ordering;
@@ -173,22 +173,30 @@ pub fn render_diagnostic(
     // that contain the annotation span to avoid scanning the entire file.
     let (expanded, adj_start, adj_end) = expand_span_line_tabs(source, start_offset, end_offset);
 
+    // The choices below reproduce the exact output produced before the
+    // annotate-snippets 0.12 upgrade:
+    // - a `Context` annotation renders the span underline with `-` (not `^`);
+    // - a trailing `Padding` (when there is no suggestion) emits the closing
+    //   `|` connector line that 0.11 always appended;
+    // - an in-group `help` footer message renders as `= help: ...`.
     let snippet = Snippet::source(&expanded)
-        .origin(origin)
+        .path(origin)
         .fold(true)
         .annotation(
-            Level::Warning
+            AnnotationKind::Context
                 .span(adj_start..adj_end)
-                .label(&diagnostic.message.body),
+                .label(diagnostic.message.body.as_str()),
         );
 
-    let mut message = Level::Warning.title(title).snippet(snippet);
+    let mut group = Level::WARNING.primary_title(title).element(snippet);
 
     if let Some(suggestion_text) = &diagnostic.message.suggestion {
-        message = message.footer(Level::Help.title(suggestion_text));
+        group = group.element(Level::HELP.message(suggestion_text.as_str()));
+    } else {
+        group = group.element(Padding);
     }
 
-    format!("{}", renderer.render(message))
+    renderer.render(&[group])
 }
 
 /// Expand tabs only on the lines that overlap with `start..end` and adjust

--- a/crates/jarl-core/src/lints/base/duplicated_arguments/mod.rs
+++ b/crates/jarl-core/src/lints/base/duplicated_arguments/mod.rs
@@ -286,7 +286,8 @@ mod tests {
           |
         1 | / fun(
         2 | |                 arg # xxx
-        ... |
+        3 | |                 = 1,
+        4 | |                 arg # yyy
         5 | |                 = 2
         6 | |               )
           | |_______________- Avoid duplicated arguments in function calls. Duplicated argument(s): "arg".
@@ -307,7 +308,8 @@ mod tests {
           |
         1 | / fun(
         2 | |                 arg = # xxx
-        ... |
+        3 | |                 1,
+        4 | |                 arg = # yyy
         5 | |                 2
         6 | |               )
           | |_______________- Avoid duplicated arguments in function calls. Duplicated argument(s): "arg".

--- a/crates/jarl-core/src/lints/base/empty_file/mod.rs
+++ b/crates/jarl-core/src/lints/base/empty_file/mod.rs
@@ -14,10 +14,12 @@ mod tests {
         // Case 1: zero-byte file
         assert_snapshot!(snapshot_lint(""), @"
         warning: empty_file
-        --> <test>:1:1
-         |
-         |
-         = help: Consider deleting the file.
+         --> <test>:1:1
+          |
+        1 |
+          | - This file is empty or only contains comments.
+          |
+          = help: Consider deleting the file.
         Found 1 error.
         ");
 
@@ -26,8 +28,8 @@ mod tests {
         warning: empty_file
          --> <test>:1:1
           |
-        1 | ...
-         -| This file is empty or only contains comments.
+        1 |    
+          | - This file is empty or only contains comments.
           |
           = help: Consider deleting the file.
         Found 1 error.
@@ -48,10 +50,12 @@ mod tests {
         // Case 4: mixed whitespace + plain comments
         assert_snapshot!(snapshot_lint("\n  # a note\n\n"), @"
         warning: empty_file
-        --> <test>:1:1
-         |
-         |
-         = help: Consider deleting the file.
+         --> <test>:1:1
+          |
+        1 |
+          | - This file is empty or only contains comments.
+          |
+          = help: Consider deleting the file.
         Found 1 error.
         ");
     }

--- a/crates/jarl-core/src/lints/base/literal_coercion/literal_coercion.rs
+++ b/crates/jarl-core/src/lints/base/literal_coercion/literal_coercion.rs
@@ -164,7 +164,7 @@ fn parse_literal(expr: &AnyRExpression) -> Option<Literal> {
             return digits.parse::<i64>().ok().map(Literal::Integer);
         }
         if let Some(string) = value.as_r_string_value() {
-            let text = string.value_token().ok()?.token_text_trimmed();
+            let text = string.to_trimmed_text();
             return strip_string_quotes(text.text()).map(Literal::String);
         }
         // Complex and other values are not coerced.

--- a/crates/jarl-core/src/lints/base/quotes/quotes.rs
+++ b/crates/jarl-core/src/lints/base/quotes/quotes.rs
@@ -115,8 +115,8 @@ pub fn quotes(
 ) -> anyhow::Result<Option<Diagnostic>> {
     let string = unwrap_or_return_none!(ast.as_r_string_value());
 
-    let token = string.value_token()?;
-    let text = token.text_trimmed();
+    let token_text = string.to_trimmed_text();
+    let text = token_text.text();
 
     // Malformed raw strings like `r'(hello]'` are parsed as identifier (`r`)
     // followed by a regular string literal. Skip these invalid forms.

--- a/crates/jarl-core/src/lints/base/unnecessary_nesting/mod.rs
+++ b/crates/jarl-core/src/lints/base/unnecessary_nesting/mod.rs
@@ -233,8 +233,9 @@ if (x) {
           |
         2 | / if (x) {
         3 | |   if (y) {
+        4 | |     if (z) {
+        5 | |       1L
         ... |
-        7 | |   }
         8 | | }
           | |_- There is no need for nested if conditions here.
           |

--- a/crates/jarl-core/src/lints/base/unreachable_code/mod.rs
+++ b/crates/jarl-core/src/lints/base/unreachable_code/mod.rs
@@ -360,7 +360,8 @@ foo <- function(bar) {
         3 |     if (FALSE) {
           |  ______________-
         4 | |     1 + 1
-        ... |
+        5 | |     if (a) {
+        6 | |       2 + 2
         7 | |     }
         8 | |   } else {
           | |___- This code is in a branch that can never be executed.
@@ -483,6 +484,7 @@ foo <- function(bar) {
            |
         10 | /   while (bar) {
         11 | |     return(bar) # comment
+        12 | |     5 + 3
         ...  |
         20 | |     5 + 4
         21 | |   }

--- a/crates/jarl-lsp/Cargo.toml
+++ b/crates/jarl-lsp/Cargo.toml
@@ -14,8 +14,10 @@ jarl-core = { path = "../jarl-core" }
 air_workspace.workspace = true
 
 # LSP dependencies
-lsp-server = "0.7"
-lsp-types = "0.95"
+lsp-server = "0.8"
+lsp-types = "0.97"
+# `lsp_types::Uri` lacks file-path conversions; we round-trip through `url`.
+url = "2.5"
 
 # Async and concurrency
 crossbeam = "0.8"
@@ -29,7 +31,7 @@ serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 
 # Collections and utilities
-rustc-hash = "2.0"
+rustc-hash = "2.1"
 
 
 [dev-dependencies]

--- a/crates/jarl-lsp/src/client.rs
+++ b/crates/jarl-lsp/src/client.rs
@@ -123,7 +123,7 @@ impl Client {
     /// Convenience method to publish diagnostics
     pub fn publish_diagnostics(
         &self,
-        uri: types::Url,
+        uri: types::Uri,
         diagnostics: Vec<types::Diagnostic>,
         version: Option<i32>,
     ) -> Result<()> {

--- a/crates/jarl-lsp/src/document.rs
+++ b/crates/jarl-lsp/src/document.rs
@@ -2,8 +2,9 @@
 //!
 //! This module handles document lifecycle, content tracking, and position encoding.
 
+use crate::uri_ext::uri_to_file_path;
 use anyhow::{Result, anyhow};
-use lsp_types::{Position, Range, TextDocumentContentChangeEvent, Url};
+use lsp_types::{Position, Range, TextDocumentContentChangeEvent, Uri};
 use std::path::PathBuf;
 
 /// Position encoding supported by the LSP server
@@ -48,30 +49,30 @@ impl TryFrom<&lsp_types::PositionEncodingKind> for PositionEncoding {
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct DocumentKey {
     /// The URI of the document
-    uri: Url,
+    uri: Uri,
 }
 
 impl DocumentKey {
-    pub fn new(uri: Url) -> Self {
+    pub fn new(uri: Uri) -> Self {
         Self { uri }
     }
 
-    pub fn uri(&self) -> &Url {
+    pub fn uri(&self) -> &Uri {
         &self.uri
     }
 
-    pub fn into_url(self) -> Url {
+    pub fn into_url(self) -> Uri {
         self.uri
     }
 
     /// Try to get the file path if this is a file:// URI
     pub fn file_path(&self) -> Option<PathBuf> {
-        self.uri.to_file_path().ok()
+        uri_to_file_path(&self.uri)
     }
 }
 
-impl From<Url> for DocumentKey {
-    fn from(uri: Url) -> Self {
+impl From<Uri> for DocumentKey {
+    fn from(uri: Uri) -> Self {
         Self::new(uri)
     }
 }
@@ -335,6 +336,18 @@ impl TextDocument {
 mod tests {
     use super::*;
     use lsp_types::Position;
+
+    #[test]
+    fn test_document_key_uri_and_path_round_trip() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("test.R");
+        let uri = crate::uri_ext::file_path_to_uri(&path).unwrap();
+
+        let key = DocumentKey::from(uri.clone());
+        assert_eq!(key.uri(), &uri);
+        assert_eq!(key.file_path(), Some(path));
+        assert_eq!(key.into_url(), uri);
+    }
 
     #[test]
     fn test_document_creation() {

--- a/crates/jarl-lsp/src/lib.rs
+++ b/crates/jarl-lsp/src/lib.rs
@@ -17,6 +17,7 @@ pub mod document;
 pub mod lint;
 pub mod server;
 pub mod session;
+pub mod uri_ext;
 pub mod utils;
 
 #[allow(dead_code)]

--- a/crates/jarl-lsp/src/lint.rs
+++ b/crates/jarl-lsp/src/lint.rs
@@ -395,10 +395,10 @@ mod tests {
     use super::*;
     use crate::document::{DocumentKey, TextDocument};
     use crate::session::DocumentSnapshot;
-    use lsp_types::{ClientCapabilities, Url};
+    use lsp_types::ClientCapabilities;
 
     fn create_test_snapshot(file_path: &std::path::Path, content: &str) -> DocumentSnapshot {
-        let uri = Url::from_file_path(file_path).unwrap();
+        let uri = crate::uri_ext::file_path_to_uri(file_path).unwrap();
         let key = DocumentKey::from(uri);
         let document = TextDocument::new(content.to_string(), 1);
 
@@ -519,7 +519,7 @@ mod tests {
         std::fs::write(&file_path, content).unwrap();
 
         // Create snapshot for the renv file
-        let uri = lsp_types::Url::from_file_path(&file_path).unwrap();
+        let uri = crate::uri_ext::file_path_to_uri(&file_path).unwrap();
         let key = crate::document::DocumentKey::from(uri);
         let document = crate::document::TextDocument::new(content.to_string(), 1);
         let snapshot = DocumentSnapshot::new(
@@ -562,7 +562,7 @@ mod tests {
         std::fs::write(&file_path, content).unwrap();
 
         // Create snapshot for the renv file
-        let uri = lsp_types::Url::from_file_path(&file_path).unwrap();
+        let uri = crate::uri_ext::file_path_to_uri(&file_path).unwrap();
         let key = crate::document::DocumentKey::from(uri);
         let document = crate::document::TextDocument::new(content.to_string(), 1);
         let snapshot = DocumentSnapshot::new(
@@ -586,16 +586,16 @@ mod tests {
 
     /// Lint Rmd/Qmd content and return the LSP diagnostics.
     ///
-    /// Writes the content to a real temporary file so that `Url::from_file_path`
+    /// Writes the content to a real temporary file so that `file_path_to_uri`
     /// produces a valid URI on all platforms (including Windows, where a fake
-    /// `file:///test.Rmd` path would cause `to_file_path()` to fail and return
-    /// no diagnostics).
+    /// `file:///test.Rmd` path would cause the path round-trip to fail and
+    /// return no diagnostics).
     fn lint_rmd_content(content: &str, ext: &str) -> Vec<lsp_types::Diagnostic> {
         let temp_dir = TempDir::new().unwrap();
         let file_path = temp_dir.path().join(format!("test.{ext}"));
         std::fs::write(&file_path, content).unwrap();
 
-        let uri = lsp_types::Url::from_file_path(&file_path).unwrap();
+        let uri = crate::uri_ext::file_path_to_uri(&file_path).unwrap();
         let key = DocumentKey::from(uri);
         let document = TextDocument::new(content.to_string(), 1);
         let snapshot = DocumentSnapshot::new(
@@ -757,7 +757,7 @@ mod tests {
 
     /// Create a snapshot backed by a real file on disk.
     fn create_snapshot_for_file(file_path: &std::path::Path, content: &str) -> DocumentSnapshot {
-        let uri = Url::from_file_path(file_path).unwrap();
+        let uri = crate::uri_ext::file_path_to_uri(file_path).unwrap();
         let key = DocumentKey::from(uri);
         let document = TextDocument::new(content.to_string(), 1);
         DocumentSnapshot::new(
@@ -873,7 +873,7 @@ mod tests {
         std::fs::write(&file_path, content).unwrap();
 
         // Create snapshot for the generated file
-        let uri = lsp_types::Url::from_file_path(&file_path).unwrap();
+        let uri = crate::uri_ext::file_path_to_uri(&file_path).unwrap();
         let key = crate::document::DocumentKey::from(uri);
         let document = crate::document::TextDocument::new(content.to_string(), 1);
         let snapshot = DocumentSnapshot::new(

--- a/crates/jarl-lsp/src/server.rs
+++ b/crates/jarl-lsp/src/server.rs
@@ -279,7 +279,7 @@ impl Server {
                 let params: types::DidOpenTextDocumentParams =
                     serde_json::from_value(notification.params)?;
 
-                tracing::debug!("Document opened: {}", params.text_document.uri);
+                tracing::debug!("Document opened: {}", params.text_document.uri.as_str());
 
                 let document =
                     TextDocument::new(params.text_document.text, params.text_document.version)
@@ -288,7 +288,8 @@ impl Server {
                 session.open_document(params.text_document.uri.clone(), document);
 
                 // Check and notify about config file location (once per session, only if not in CWD)
-                if let Ok(file_path) = params.text_document.uri.to_file_path() {
+                if let Some(file_path) = crate::uri_ext::uri_to_file_path(&params.text_document.uri)
+                {
                     session.check_and_notify_config(&file_path);
                 }
 
@@ -299,7 +300,7 @@ impl Server {
                 let params: types::DidChangeTextDocumentParams =
                     serde_json::from_value(notification.params)?;
 
-                tracing::debug!("Document changed: {}", params.text_document.uri);
+                tracing::debug!("Document changed: {}", params.text_document.uri.as_str());
 
                 session.update_document(
                     params.text_document.uri.clone(),
@@ -326,7 +327,7 @@ impl Server {
                 let params: types::DidSaveTextDocumentParams =
                     serde_json::from_value(notification.params)?;
 
-                tracing::debug!("Document saved: {}", params.text_document.uri);
+                tracing::debug!("Document saved: {}", params.text_document.uri.as_str());
 
                 if let Some(snapshot) = session.take_snapshot(params.text_document.uri) {
                     task_sender.send(Task::LintDocument {
@@ -371,7 +372,7 @@ impl Server {
 
         tracing::debug!(
             "Linted {} in {:?}: {} diagnostics found",
-            snapshot.uri(),
+            snapshot.uri().as_str(),
             elapsed,
             output.diagnostics.len()
         );
@@ -457,6 +458,10 @@ impl Server {
     }
 
     /// Convert a diagnostic with fix information to a code action
+    // `lsp_types::WorkspaceEdit` keys its `changes` map by `Uri`, which carries
+    // an internal `Cell` for lazily-parsed offsets. The cache doesn't affect
+    // hashing (it hashes by string), so the lint is a false positive here.
+    #[allow(clippy::mutable_key_type)]
     fn diagnostic_to_code_action(
         diagnostic: &types::Diagnostic,
         snapshot: &DocumentSnapshot,
@@ -509,6 +514,7 @@ impl Server {
 
     /// Create a code action to add a jarl-ignore comment for a specific rule.
     /// Uses the hoisting infrastructure from jarl-core to find the correct insertion point.
+    #[allow(clippy::mutable_key_type)] // `Uri` key hashes by string; see above.
     fn diagnostic_to_jarl_ignore_rule_action(
         diagnostic: &types::Diagnostic,
         snapshot: &DocumentSnapshot,
@@ -615,6 +621,7 @@ impl Server {
     /// This action is only offered for Rmd/Qmd files.  It inserts the directive
     /// at the very beginning of the chunk so it is easy to spot, and suppresses
     /// the named rule for every expression in that chunk.
+    #[allow(clippy::mutable_key_type)] // `Uri` key hashes by string; see above.
     fn diagnostic_to_jarl_ignore_chunk_action(
         diagnostic: &types::Diagnostic,
         snapshot: &DocumentSnapshot,
@@ -704,7 +711,7 @@ mod tests {
     use crate::lint;
     use crate::session::DocumentSnapshot;
     use lsp_server::Connection;
-    use lsp_types::{Position, Range, Url};
+    use lsp_types::{Position, Range};
     use tempfile::TempDir;
 
     const CURSOR: &str = "<CURS>";
@@ -746,7 +753,7 @@ select = ["ALL"]
         }
 
         fn create_snapshot(&self, content: &str) -> DocumentSnapshot {
-            let uri = Url::from_file_path(&self.file_path).unwrap();
+            let uri = crate::uri_ext::file_path_to_uri(&self.file_path).unwrap();
             let key = DocumentKey::from(uri);
             let document = TextDocument::new(content.to_string(), 1);
 
@@ -760,7 +767,7 @@ select = ["ALL"]
     }
 
     fn create_test_snapshot(content: &str) -> DocumentSnapshot {
-        let uri = Url::parse("file:///test.R").unwrap();
+        let uri: lsp_types::Uri = "file:///test.R".parse().unwrap();
         let key = DocumentKey::from(uri);
         let document = TextDocument::new(content.to_string(), 1);
 
@@ -825,6 +832,7 @@ select = ["ALL"]
     }
 
     /// Apply a quick fix at the cursor position by running the actual linter.
+    #[allow(clippy::mutable_key_type)] // `Uri` key hashes by string; see above.
     fn apply_fix_at_cursor(source_with_cursor: &str) -> Option<String> {
         let cursor_pos = source_with_cursor.find(CURSOR)?;
         let content = source_with_cursor.replace(CURSOR, "");
@@ -859,6 +867,7 @@ select = ["ALL"]
     }
 
     /// Apply a jarl-ignore action at the cursor position by running the actual linter.
+    #[allow(clippy::mutable_key_type)] // `Uri` key hashes by string; see above.
     fn apply_jarl_ignore_at_cursor(source_with_cursor: &str) -> Option<String> {
         let cursor_pos = source_with_cursor.find(CURSOR)?;
         let content = source_with_cursor.replace(CURSOR, "");
@@ -893,6 +902,7 @@ select = ["ALL"]
     }
 
     /// Apply a jarl-ignore-chunk action at the cursor position for an Rmd file.
+    #[allow(clippy::mutable_key_type)] // `Uri` key hashes by string; see above.
     fn apply_jarl_ignore_chunk_at_cursor(source_with_cursor: &str) -> Option<String> {
         let cursor_pos = source_with_cursor.find(CURSOR)?;
         let content = source_with_cursor.replace(CURSOR, "");

--- a/crates/jarl-lsp/src/session.rs
+++ b/crates/jarl-lsp/src/session.rs
@@ -7,7 +7,7 @@ use anyhow::{Result, anyhow};
 use lsp_types::{
     ClientCapabilities, CodeActionKind, CodeActionOptions, CodeActionProviderCapability,
     InitializeParams, InitializeResult, SaveOptions, ServerCapabilities, ServerInfo,
-    TextDocumentSyncCapability, TextDocumentSyncKind, TextDocumentSyncOptions, Url,
+    TextDocumentSyncCapability, TextDocumentSyncKind, TextDocumentSyncOptions, Uri,
     WorkDoneProgressOptions,
 };
 use rustc_hash::FxHashMap;
@@ -95,12 +95,12 @@ impl Session {
         if let Some(workspace_folders) = params.workspace_folders {
             self.workspace_roots.clear();
             for folder in workspace_folders {
-                if let Ok(path) = folder.uri.to_file_path() {
+                if let Some(path) = crate::uri_ext::uri_to_file_path(&folder.uri) {
                     self.workspace_roots.push(path);
                 }
             }
         } else if let Some(root_uri) = params.root_uri {
-            if let Ok(path) = root_uri.to_file_path() {
+            if let Some(path) = crate::uri_ext::uri_to_file_path(&root_uri) {
                 self.workspace_roots = vec![path];
             }
         } else if let Some(root_path) = params.root_path {
@@ -149,16 +149,16 @@ impl Session {
     }
 
     /// Open a new text document
-    pub fn open_document(&mut self, uri: Url, document: TextDocument) {
+    pub fn open_document(&mut self, uri: Uri, document: TextDocument) {
         let key = DocumentKey::from(uri);
-        tracing::debug!("Opening document: {}", key.uri());
+        tracing::debug!("Opening document: {}", key.uri().as_str());
         self.documents.insert(key, document);
     }
 
     /// Update an existing document with changes
     pub fn update_document(
         &mut self,
-        uri: Url,
+        uri: Uri,
         changes: Vec<lsp_types::TextDocumentContentChangeEvent>,
         version: DocumentVersion,
     ) -> LspResult<()> {
@@ -166,7 +166,7 @@ impl Session {
 
         eprintln!(
             "JARL LSP: Updating document {} with {} changes to version {}",
-            key.uri(),
+            key.uri().as_str(),
             changes.len(),
             version
         );
@@ -174,34 +174,38 @@ impl Session {
         let document = self
             .documents
             .get_mut(&key)
-            .ok_or_else(|| anyhow!("Document not found: {}", key.uri()))?;
+            .ok_or_else(|| anyhow!("Document not found: {}", key.uri().as_str()))?;
 
         document.apply_changes(changes, version, self.position_encoding)?;
 
-        tracing::debug!("Updated document: {} to version {}", key.uri(), version);
+        tracing::debug!(
+            "Updated document: {} to version {}",
+            key.uri().as_str(),
+            version
+        );
         Ok(())
     }
 
     /// Close a document
-    pub fn close_document(&mut self, uri: Url) -> LspResult<()> {
+    pub fn close_document(&mut self, uri: Uri) -> LspResult<()> {
         let key = DocumentKey::from(uri);
 
         if self.documents.remove(&key).is_some() {
-            tracing::debug!("Closed document: {}", key.uri());
+            tracing::debug!("Closed document: {}", key.uri().as_str());
             Ok(())
         } else {
-            Err(anyhow!("Document not found: {}", key.uri()))
+            Err(anyhow!("Document not found: {}", key.uri().as_str()))
         }
     }
 
     /// Get a document by URI
-    pub fn get_document(&self, uri: &Url) -> Option<&TextDocument> {
+    pub fn get_document(&self, uri: &Uri) -> Option<&TextDocument> {
         let key = DocumentKey::from(uri.clone());
         self.documents.get(&key)
     }
 
     /// Take a snapshot of a document
-    pub fn take_snapshot(&self, uri: Url) -> Option<DocumentSnapshot> {
+    pub fn take_snapshot(&self, uri: Uri) -> Option<DocumentSnapshot> {
         let key = DocumentKey::from(uri);
         let document = self.documents.get(&key)?;
 
@@ -220,7 +224,7 @@ impl Session {
     }
 
     /// Get all open document URIs
-    pub fn open_documents(&self) -> impl Iterator<Item = &Url> {
+    pub fn open_documents(&self) -> impl Iterator<Item = &Uri> {
         self.documents.keys().map(|key| key.uri())
     }
 
@@ -364,7 +368,7 @@ impl DocumentSnapshot {
     }
 
     /// Get the document URI
-    pub fn uri(&self) -> &Url {
+    pub fn uri(&self) -> &Uri {
         self.key.uri()
     }
 
@@ -482,7 +486,7 @@ mod tests {
     #[test]
     fn test_document_lifecycle() {
         let mut session = create_test_session();
-        let uri = Url::parse("file:///test.py").unwrap();
+        let uri: Uri = "file:///test.py".parse().unwrap();
         let document = TextDocument::new("hello world".to_string(), 1);
 
         // Open document
@@ -501,6 +505,62 @@ mod tests {
         session.close_document(uri.clone()).unwrap();
         assert_eq!(session.document_count(), 0);
         assert!(session.get_document(&uri).is_none());
+    }
+
+    #[test]
+    fn test_update_document_and_open_documents() {
+        let mut session = create_test_session();
+        let uri: Uri = "file:///test.R".parse().unwrap();
+        session.open_document(uri.clone(), TextDocument::new("x <- 1".to_string(), 1));
+
+        // Apply an incremental change via update_document.
+        let change = lsp_types::TextDocumentContentChangeEvent {
+            range: Some(lsp_types::Range::new(
+                lsp_types::Position::new(0, 0),
+                lsp_types::Position::new(0, 1),
+            )),
+            range_length: None,
+            text: "y".to_string(),
+        };
+        session
+            .update_document(uri.clone(), vec![change], 2)
+            .unwrap();
+        assert_eq!(session.get_document(&uri).unwrap().content(), "y <- 1");
+
+        // open_documents lists the currently open URIs.
+        let open: Vec<_> = session.open_documents().cloned().collect();
+        assert_eq!(open, vec![uri]);
+
+        // Updating or closing an unknown document is an error.
+        let missing: Uri = "file:///missing.R".parse().unwrap();
+        assert!(session.update_document(missing.clone(), vec![], 1).is_err());
+        assert!(session.close_document(missing).is_err());
+    }
+
+    #[test]
+    fn test_initialize_populates_workspace_roots() {
+        let dir = tempfile::TempDir::new().unwrap();
+        let uri = crate::uri_ext::file_path_to_uri(dir.path()).unwrap();
+
+        // From workspace folders.
+        let mut session = create_test_session();
+        #[allow(deprecated)]
+        let params = InitializeParams {
+            workspace_folders: Some(vec![lsp_types::WorkspaceFolder {
+                uri: uri.clone(),
+                name: "root".to_string(),
+            }]),
+            ..Default::default()
+        };
+        session.initialize(params).unwrap();
+        assert_eq!(session.workspace_roots(), [dir.path().to_path_buf()]);
+
+        // From a single root URI.
+        let mut session = create_test_session();
+        #[allow(deprecated)]
+        let params = InitializeParams { root_uri: Some(uri), ..Default::default() };
+        session.initialize(params).unwrap();
+        assert_eq!(session.workspace_roots(), [dir.path().to_path_buf()]);
     }
 
     #[test]

--- a/crates/jarl-lsp/src/uri_ext.rs
+++ b/crates/jarl-lsp/src/uri_ext.rs
@@ -1,0 +1,45 @@
+//! Conversions between `lsp_types::Uri` and filesystem paths.
+//!
+//! Since lsp-types 0.97, the URI type is `lsp_types::Uri` (a thin wrapper
+//! around `fluent_uri::Uri`) which, unlike the `url::Url` used by older
+//! versions, does not provide `to_file_path` / `from_file_path`. We round-trip
+//! through `url::Url`, which implements the platform-aware `file://`
+//! conversions (drive letters, percent-encoding, UNC paths, ...).
+
+use lsp_types::Uri;
+use std::path::{Path, PathBuf};
+
+/// Convert a `file://` URI into a filesystem path, if it denotes a local file.
+pub fn uri_to_file_path(uri: &Uri) -> Option<PathBuf> {
+    url::Url::parse(uri.as_str()).ok()?.to_file_path().ok()
+}
+
+/// Build a `file://` URI from a filesystem path.
+pub fn file_path_to_uri(path: &Path) -> Option<Uri> {
+    let url = url::Url::from_file_path(path).ok()?;
+    url.as_str().parse().ok()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn round_trips_file_path_through_uri() {
+        let dir = tempfile::tempdir().unwrap();
+        // The space exercises percent-encoding on the way out and decoding back.
+        let path = dir.path().join("test file.R");
+
+        let uri = file_path_to_uri(&path).expect("path should convert to a file URI");
+        assert!(uri.as_str().starts_with("file://"));
+
+        let back = uri_to_file_path(&uri).expect("file URI should convert back to a path");
+        assert_eq!(back, path);
+    }
+
+    #[test]
+    fn non_file_uri_has_no_file_path() {
+        let uri: Uri = "untitled:Untitled-1".parse().unwrap();
+        assert!(uri_to_file_path(&uri).is_none());
+    }
+}

--- a/crates/jarl/Cargo.toml
+++ b/crates/jarl/Cargo.toml
@@ -42,9 +42,9 @@ air_fs.workspace = true
 
 # Additional utilities
 regex.workspace = true
-tracing-subscriber = "0.3.20"
+tracing-subscriber = "0.3.23"
 
-annotate-snippets = "0.11"
+annotate-snippets = "0.12"
 
 [dev-dependencies]
 insta.workspace = true

--- a/crates/jarl/tests/integration/toml.rs
+++ b/crates/jarl/tests/integration/toml.rs
@@ -678,8 +678,7 @@ select = ["any_is_na"
       |
     2 | [lint
       |      ^
-    invalid table header
-    expected `.`, `]`
+    unclosed table, expected `]`
     "
     );
 

--- a/editors/zed/Cargo.toml
+++ b/editors/zed/Cargo.toml
@@ -9,4 +9,4 @@ publish = false
 crate-type = ["cdylib"]
 
 [dependencies]
-zed_extension_api = "0.2.0"
+zed_extension_api = "0.7.0"

--- a/xtask/codegen/Cargo.toml
+++ b/xtask/codegen/Cargo.toml
@@ -6,7 +6,7 @@ publish = false
 
 [dependencies]
 anyhow = { workspace = true }
-bpaf = { version = "0.9.15", features = ["derive"] }
+bpaf = { version = "0.9.26", features = ["derive"] }
 schemars = { workspace = true }
 serde_json = { workspace = true }
 xtask = { version = "0.0", path = "../" }


### PR DESCRIPTION
## Context

I am building a multi-language linting tool and want to depend on `jarl` (and `air`) directly. The blocker was the pinned `tree-sitter` version: the `air` dependency held it at 0.24, which conflicts with the rest of my toolchain that needs tree-sitter 0.26+. To unblock this I updated `air` to build on a newer tree-sitter, then updated `jarl` to consume it.

This PR brings `jarl`'s dependencies up to date and lifts tree-sitter to 0.26.9.

## What changed

- `cargo upgrade --incompatible` plus `cargo update` across the workspace.
- The `air` git dependencies now point at a fork (`Goldziher/r-air-fork`) that builds on tree-sitter 0.26.9. This is the only way to move tree-sitter off 0.24 today, since it is a transitive dependency of `air`.
- `annotate-snippets` 0.11 to 0.12: `render_diagnostic` was rewritten for the new Group/Element API. The rendered diagnostic output is preserved (Context annotation, trailing Padding, in-group help footer), so user-facing output is unchanged.
- `lsp-types` 0.95 to 0.97: `Url` was replaced by `Uri` (fluent-uri), which has no file-path conversions. A small `uri_ext` helper round-trips through the `url` crate for those conversions.
- A few snapshots were updated where the new `annotate-snippets` line-folding shows slightly more context, and one toml parse-error message changed with `toml` 1.1.

## Status

This depends on the corresponding `air` change landing upstream first. Until `air` merges and a stable rev is available, the `air` dependency here points at the fork. Once `air` is merged I will repoint these dependencies at the upstream rev. Opening as a regular (non-draft) PR so CI runs against the current state.