### PR TITLE
feat: Add `skipped-functions` argument in `jarl.toml` for `true_false_symbol`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,10 @@
 * New argument `[lint.per-file-ignores]` in `jarl.toml` to deactivate rules on
   specific files (#500).
 
+* New argument `skipped-functions` for the `true_false_symbol` rule in `jarl.toml`
+  to list functions whose arguments are allowed to contain the `T` and `F`
+  symbols (#542).
+
 * The CLI now suggests close rule names when some rule names don't exist (#501).
 
 * New `--output-format sarif` to export to [SARIF](https://sarifweb.azurewebsites.net/) (#508, @dieghernan).

--- a/artifacts/jarl.schema.json
+++ b/artifacts/jarl.schema.json
@@ -301,6 +301,18 @@
             "type": "string"
           }
         },
+        "true_false_symbol": {
+          "title": "Options for the `true_false_symbol` rule",
+          "description": "Use `skipped-functions` to list functions whose arguments are allowed to\ncontain the `T` and `F` symbols. This list is empty by default.",
+          "anyOf": [
+            {
+              "$ref": "#/$defs/TrueFalseSymbolOptions"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
         "undesirable_function": {
           "title": "Options for the `undesirable_function` rule",
           "description": "Use `functions` to fully replace the default list of undesirable functions.\nUse `extend-functions` to add to the default list.\nSpecifying both is an error.",
@@ -422,6 +434,22 @@
             "string",
             "null"
           ]
+        }
+      },
+      "additionalProperties": false
+    },
+    "TrueFalseSymbolOptions": {
+      "description": "TOML options for `[lint.true_false_symbol]`.\n\nUse `skipped-functions` to list functions whose arguments are allowed to\ncontain the `T` and `F` symbols. This list is empty by default.",
+      "type": "object",
+      "properties": {
+        "skipped-functions": {
+          "type": [
+            "array",
+            "null"
+          ],
+          "items": {
+            "type": "string"
+          }
         }
       },
       "additionalProperties": false

--- a/crates/jarl-core/src/analyze/identifier.rs
+++ b/crates/jarl-core/src/analyze/identifier.rs
@@ -6,7 +6,7 @@ use crate::lints::base::true_false_symbol::true_false_symbol::true_false_symbol;
 
 pub fn identifier(r_expr: &RIdentifier, checker: &mut Checker) -> anyhow::Result<()> {
     if checker.is_rule_enabled(Rule::TrueFalseSymbol) {
-        checker.report_diagnostic(true_false_symbol(r_expr)?);
+        checker.report_diagnostic(true_false_symbol(r_expr, checker)?);
     }
     Ok(())
 }

--- a/crates/jarl-core/src/lints/base/true_false_symbol/mod.rs
+++ b/crates/jarl-core/src/lints/base/true_false_symbol/mod.rs
@@ -1,8 +1,27 @@
+pub(crate) mod options;
 pub(crate) mod true_false_symbol;
 
 #[cfg(test)]
 mod tests {
+    use crate::lints::base::true_false_symbol::options::ResolvedTrueFalseSymbolOptions;
+    use crate::lints::base::true_false_symbol::options::TrueFalseSymbolOptions;
+    use crate::rule_options::ResolvedRuleOptions;
+    use crate::settings::{LinterSettings, Settings};
     use crate::utils_test::*;
+
+    /// Build a `Settings` with custom `TrueFalseSymbolOptions`.
+    fn settings_with_options(options: TrueFalseSymbolOptions) -> Settings {
+        Settings {
+            linter: LinterSettings {
+                rule_options: ResolvedRuleOptions {
+                    true_false_symbol: ResolvedTrueFalseSymbolOptions::resolve(Some(&options))
+                        .unwrap(),
+                    ..Default::default()
+                },
+                ..Default::default()
+            },
+        }
+    }
 
     // TODO: I guess this should only be linted if --unsafe-fixes is passed?
     // #[test]
@@ -54,6 +73,26 @@ mod tests {
         //     "true_false_symbol", None
         // );
         expect_no_lint("lm(T ~ weight, data)", "true_false_symbol", None);
+    }
+
+    #[test]
+    fn test_true_false_symbol_skipped_functions() {
+        let settings = settings_with_options(TrueFalseSymbolOptions {
+            skipped_functions: Some(vec!["foo".to_string()]),
+        });
+        expect_no_lint_with_settings("foo(T)", "true_false_symbol", None, settings.clone());
+        expect_no_lint_with_settings("foo(x, y = F)", "true_false_symbol", None, settings.clone());
+        // Nested inside a skipped call is also allowed.
+        expect_no_lint_with_settings("foo(bar(T))", "true_false_symbol", None, settings);
+
+        // Calls that are not skipped are still linted.
+        let settings = settings_with_options(TrueFalseSymbolOptions {
+            skipped_functions: Some(vec!["foo".to_string()]),
+        });
+        assert!(
+            format_diagnostics_with_settings("bar(T)", "true_false_symbol", None, Some(settings))
+                .contains("true_false_symbol")
+        );
     }
 
     // TODO

--- a/crates/jarl-core/src/lints/base/true_false_symbol/options.rs
+++ b/crates/jarl-core/src/lints/base/true_false_symbol/options.rs
@@ -1,0 +1,30 @@
+use std::collections::HashSet;
+
+/// TOML options for `[lint.true_false_symbol]`.
+///
+/// Use `skipped-functions` to list functions whose arguments are allowed to
+/// contain the `T` and `F` symbols. This list is empty by default.
+#[derive(Clone, Debug, PartialEq, Eq, Default, serde::Deserialize)]
+#[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
+#[serde(deny_unknown_fields, rename_all = "kebab-case")]
+pub struct TrueFalseSymbolOptions {
+    pub skipped_functions: Option<Vec<String>>,
+}
+
+/// Resolved options for the `true_false_symbol` rule, ready for use during
+/// linting.
+#[derive(Clone, Debug)]
+pub struct ResolvedTrueFalseSymbolOptions {
+    pub skipped_functions: HashSet<String>,
+}
+
+impl ResolvedTrueFalseSymbolOptions {
+    pub fn resolve(options: Option<&TrueFalseSymbolOptions>) -> anyhow::Result<Self> {
+        let skipped_functions = options
+            .and_then(|opts| opts.skipped_functions.as_ref())
+            .map(|values| values.iter().cloned().collect())
+            .unwrap_or_default();
+
+        Ok(Self { skipped_functions })
+    }
+}

--- a/crates/jarl-core/src/lints/base/true_false_symbol/true_false_symbol.rs
+++ b/crates/jarl-core/src/lints/base/true_false_symbol/true_false_symbol.rs
@@ -1,4 +1,6 @@
+use crate::check::Checker;
 use crate::diagnostic::*;
+use crate::utils::get_function_name;
 use air_r_syntax::*;
 use biome_rowan::AstNode;
 
@@ -43,7 +45,10 @@ impl Violation for TrueFalseSymbol {
     }
 }
 
-pub fn true_false_symbol(ast: &RIdentifier) -> anyhow::Result<Option<Diagnostic>> {
+pub fn true_false_symbol(
+    ast: &RIdentifier,
+    checker: &Checker,
+) -> anyhow::Result<Option<Diagnostic>> {
     let token = ast.name_token()?;
     let name = token.text_trimmed();
     if name != "T" && name != "F" {
@@ -53,6 +58,19 @@ pub fn true_false_symbol(ast: &RIdentifier) -> anyhow::Result<Option<Diagnostic>
     // Allow T(), F()
     if ast.parent::<RCall>().is_some() {
         return Ok(None);
+    }
+
+    // Allow `T` and `F` inside a call to one of the skipped functions.
+    let skipped_functions = &checker.rule_options.true_false_symbol.skipped_functions;
+    if !skipped_functions.is_empty() {
+        for ancestor in ast.syntax().ancestors() {
+            if let Some(call) = RCall::cast(ancestor) {
+                let function_name = get_function_name(call.function()?);
+                if skipped_functions.contains(&function_name) {
+                    return Ok(None);
+                }
+            }
+        }
     }
 
     // Allow df$T, df$F

--- a/crates/jarl-core/src/rule_options.rs
+++ b/crates/jarl-core/src/rule_options.rs
@@ -14,6 +14,8 @@ use crate::lints::base::pipe_consistency::options::PipeConsistencyOptions;
 use crate::lints::base::pipe_consistency::options::ResolvedPipeConsistencyOptions;
 use crate::lints::base::quotes::options::QuotesOptions;
 use crate::lints::base::quotes::options::ResolvedQuotesOptions;
+use crate::lints::base::true_false_symbol::options::ResolvedTrueFalseSymbolOptions;
+use crate::lints::base::true_false_symbol::options::TrueFalseSymbolOptions;
 use crate::lints::base::undesirable_function::options::ResolvedUndesirableFunctionOptions;
 use crate::lints::base::undesirable_function::options::UndesirableFunctionOptions;
 use crate::lints::base::unreachable_code::options::ResolvedUnreachableCodeOptions;
@@ -74,6 +76,7 @@ pub struct ResolvedRuleOptions {
     pub nested_pipe: ResolvedNestedPipeOptions,
     pub pipe_consistency: ResolvedPipeConsistencyOptions,
     pub quotes: ResolvedQuotesOptions,
+    pub true_false_symbol: ResolvedTrueFalseSymbolOptions,
     pub undesirable_function: ResolvedUndesirableFunctionOptions,
     pub unreachable_code: ResolvedUnreachableCodeOptions,
     pub unused_function: ResolvedUnusedFunctionOptions,
@@ -89,6 +92,7 @@ impl ResolvedRuleOptions {
         nested_pipe: Option<&NestedPipeOptions>,
         pipe_consistency: Option<&PipeConsistencyOptions>,
         quotes: Option<&QuotesOptions>,
+        true_false_symbol: Option<&TrueFalseSymbolOptions>,
         undesirable_function: Option<&UndesirableFunctionOptions>,
         unreachable_code: Option<&UnreachableCodeOptions>,
         unused_function: Option<&UnusedFunctionOptions>,
@@ -103,6 +107,7 @@ impl ResolvedRuleOptions {
             nested_pipe: ResolvedNestedPipeOptions::resolve(nested_pipe)?,
             pipe_consistency: ResolvedPipeConsistencyOptions::resolve(pipe_consistency)?,
             quotes: ResolvedQuotesOptions::resolve(quotes)?,
+            true_false_symbol: ResolvedTrueFalseSymbolOptions::resolve(true_false_symbol)?,
             undesirable_function: ResolvedUndesirableFunctionOptions::resolve(
                 undesirable_function,
             )?,
@@ -114,7 +119,9 @@ impl ResolvedRuleOptions {
 
 impl Default for ResolvedRuleOptions {
     fn default() -> Self {
-        Self::resolve(None, None, None, None, None, None, None, None, None, None)
-            .expect("default rule options should always resolve")
+        Self::resolve(
+            None, None, None, None, None, None, None, None, None, None, None,
+        )
+        .expect("default rule options should always resolve")
     }
 }

--- a/crates/jarl-core/src/toml.rs
+++ b/crates/jarl-core/src/toml.rs
@@ -23,6 +23,7 @@ use crate::lints::base::missing_argument::options::MissingArgumentOptions;
 use crate::lints::base::nested_pipe::options::NestedPipeOptions;
 use crate::lints::base::pipe_consistency::options::PipeConsistencyOptions;
 use crate::lints::base::quotes::options::QuotesOptions;
+use crate::lints::base::true_false_symbol::options::TrueFalseSymbolOptions;
 use crate::lints::base::undesirable_function::options::UndesirableFunctionOptions;
 use crate::lints::base::unreachable_code::options::UnreachableCodeOptions;
 use crate::lints::base::unused_function::options::UnusedFunctionOptions;
@@ -300,6 +301,13 @@ pub struct LinterTomlOptions {
     #[serde(rename = "quotes")]
     pub quotes: Option<QuotesOptions>,
 
+    /// # Options for the `true_false_symbol` rule
+    ///
+    /// Use `skipped-functions` to list functions whose arguments are allowed to
+    /// contain the `T` and `F` symbols. This list is empty by default.
+    #[serde(rename = "true_false_symbol")]
+    pub true_false_symbol: Option<TrueFalseSymbolOptions>,
+
     /// # Options for the `undesirable_function` rule
     ///
     /// Use `functions` to fully replace the default list of undesirable functions.
@@ -411,6 +419,7 @@ impl TomlOptions {
                 linter.nested_pipe.as_ref(),
                 linter.pipe_consistency.as_ref(),
                 linter.quotes.as_ref(),
+                linter.true_false_symbol.as_ref(),
                 linter.undesirable_function.as_ref(),
                 linter.unreachable_code.as_ref(),
                 linter.unused_function.as_ref(),

--- a/crates/jarl/tests/integration/toml_rule_args.rs
+++ b/crates/jarl/tests/integration/toml_rule_args.rs
@@ -213,6 +213,94 @@ unknown-option = ["list"]
     Ok(())
 }
 
+// true_false_symbol ----------------------------------------
+
+#[test]
+fn test_true_false_symbol_wrong_type() -> anyhow::Result<()> {
+    let case = CliTest::with_files([
+        (
+            "jarl.toml",
+            r#"
+[lint]
+
+[lint.true_false_symbol]
+skipped-functions = 1
+"#,
+        ),
+        ("test.R", "foo(T)"),
+    ])?;
+
+    insta::assert_snapshot!(
+        &mut case
+            .command()
+            .arg("check")
+            .arg(".")
+            .run()
+            .normalize_os_executable_name()
+            .normalize_temp_paths(),
+        @"
+
+    success: false
+    exit_code: 255
+    ----- stdout -----
+
+    ----- stderr -----
+    jarl failed
+      Cause: Failed to parse [TEMP_DIR]/jarl.toml:
+    TOML parse error at line 5, column 21
+      |
+    5 | skipped-functions = 1
+      |                     ^
+    invalid type: integer `1`, expected a sequence
+    "
+    );
+
+    Ok(())
+}
+
+#[test]
+fn test_true_false_symbol_unknown_field_is_error() -> anyhow::Result<()> {
+    let case = CliTest::with_files([
+        (
+            "jarl.toml",
+            r#"
+[lint]
+
+[lint.true_false_symbol]
+unknown-option = ["list"]
+"#,
+        ),
+        ("test.R", "foo(T)"),
+    ])?;
+
+    insta::assert_snapshot!(
+        &mut case
+            .command()
+            .arg("check")
+            .arg(".")
+            .run()
+            .normalize_os_executable_name()
+            .normalize_temp_paths(),
+        @r#"
+
+    success: false
+    exit_code: 255
+    ----- stdout -----
+
+    ----- stderr -----
+    jarl failed
+      Cause: Failed to parse [TEMP_DIR]/jarl.toml:
+    TOML parse error at line 5, column 1
+      |
+    5 | unknown-option = ["list"]
+      | ^^^^^^^^^^^^^^
+    unknown field `unknown-option`, expected `skipped-functions`
+    "#
+    );
+
+    Ok(())
+}
+
 // missing_argument ----------------------------------------
 
 #[test]

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -25,6 +25,10 @@
 * New argument `[lint.per-file-ignores]` in `jarl.toml` to deactivate rules on
   specific files (#500).
 
+* New argument `skipped-functions` for the `true_false_symbol` rule in `jarl.toml`
+  to list functions whose arguments are allowed to contain the `T` and `F`
+  symbols (#542).
+
 * The CLI now suggests close rule names when some rule names don't exist (#501).
 
 * New `--output-format sarif` to export to [SARIF](https://sarifweb.azurewebsites.net/) (#508, @dieghernan).

--- a/docs/reference/config-file.md
+++ b/docs/reference/config-file.md
@@ -411,6 +411,24 @@ Default: `double`
 quote = "single" # or "double"
 ```
 
+### `true_false_symbol`
+
+Use `skipped-functions` to list functions whose arguments are allowed to contain
+the `T` and `F` symbols.
+
+Function names in `skipped-functions` also match namespaced calls, e.g.
+`skipped-functions = ["foo"]` will ignore `foo(T)` and `pkg::foo(T)`.
+
+Default: `skipped-functions = []`
+
+```toml
+[lint]
+...
+
+[lint.true_false_symbol]
+skipped-functions = ["foo"]
+```
+
 ### `unreachable_code`
 
 Use `stopping-functions` to fully replace the default list of functions that are


### PR DESCRIPTION
Fixes #492 