### PR TITLE
feat: Skip three more functions from `implicit_assignment`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,7 +40,9 @@
 
 * Jarl now reports rule violations in files that contain syntax errors (#538).
 
-* Three more functions skipped by default from `implicit_assignment`: `expect_silent` (from testthat), `expect_defunct` (from lifecycle) and `expect_deprecated` (from lifecycle) (#543).
+* Three more functions skipped by default from `implicit_assignment`: `expect_silent` (from
+  `testthat`), `expect_defunct` (from lifecycle) and `expect_deprecated` (from `lifecycle`)
+  (#543, @maelle).
 
 ### Bug fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,8 @@
 
 * Jarl now reports rule violations in files that contain syntax errors (#538).
 
+* Three more functions skipped by default from `implicit_assignment`: `expect_silent` (from testthat), `expect_defunct` (from lifecycle) and `expect_deprecated` (from lifecycle) (#543).
+
 ### Bug fixes
 
 * `implicit_assignment` no longer flags chained assignments like

--- a/crates/jarl-core/src/lints/base/implicit_assignment/mod.rs
+++ b/crates/jarl-core/src/lints/base/implicit_assignment/mod.rs
@@ -189,8 +189,16 @@ mod tests {
         expect_no_lint("expect_warning(x <- 1)", "implicit_assignment", None);
         expect_no_lint("expect_error(x <- 1)", "implicit_assignment", None);
         expect_no_lint("expect_silent(x <- 1)", "implicit_assignment", None);
-        expect_no_lint("expect_defunct(x <- defunct(1))", "implicit_assignment", None);
-        expect_no_lint("expect_deprecated(x <- deprecated(1))", "implicit_assignment", None);
+        expect_no_lint(
+            "expect_defunct(x <- defunct(1))",
+            "implicit_assignment",
+            None,
+        );
+        expect_no_lint(
+            "expect_deprecated(x <- deprecated(1))",
+            "implicit_assignment",
+            None,
+        );
         expect_no_lint("expect_snapshot(x <- 1)", "implicit_assignment", None);
         expect_no_lint("quote(x <- 1)", "implicit_assignment", None);
         expect_no_lint("suppressMessages(x <- 1)", "implicit_assignment", None);

--- a/crates/jarl-core/src/lints/base/implicit_assignment/mod.rs
+++ b/crates/jarl-core/src/lints/base/implicit_assignment/mod.rs
@@ -188,6 +188,9 @@ mod tests {
         expect_no_lint("expect_message(x <- 1)", "implicit_assignment", None);
         expect_no_lint("expect_warning(x <- 1)", "implicit_assignment", None);
         expect_no_lint("expect_error(x <- 1)", "implicit_assignment", None);
+        expect_no_lint("expect_silent(x <- 1)", "implicit_assignment", None);
+        expect_no_lint("expect_defunct(x <- defunct(1))", "implicit_assignment", None);
+        expect_no_lint("expect_deprecated(x <- deprecated(1))", "implicit_assignment", None);
         expect_no_lint("expect_snapshot(x <- 1)", "implicit_assignment", None);
         expect_no_lint("quote(x <- 1)", "implicit_assignment", None);
         expect_no_lint("suppressMessages(x <- 1)", "implicit_assignment", None);

--- a/crates/jarl-core/src/lints/base/implicit_assignment/options.rs
+++ b/crates/jarl-core/src/lints/base/implicit_assignment/options.rs
@@ -8,6 +8,9 @@ const DEFAULT_SKIPPED_FUNCTIONS: &[&str] = &[
     "expect_error",
     "expect_warning",
     "expect_message",
+    "expect_silent",
+    "expect_defunct",    // from {lifecycle}
+    "expect_deprecated", // from {lifecycle}
     "expect_snapshot",
     "quote",
     "suppressMessages",

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -40,7 +40,9 @@
 
 * Jarl now reports rule violations in files that contain syntax errors (#538).
 
-* Three more functions skipped by default from `implicit_assignment`: `expect_silent` (from testthat), `expect_defunct` (from lifecycle) and `expect_deprecated` (from lifecycle) (#543).
+* Three more functions skipped by default from `implicit_assignment`: `expect_silent` (from
+  `testthat`), `expect_defunct` (from lifecycle) and `expect_deprecated` (from `lifecycle`)
+  (#543, @maelle).
 
 ### Bug fixes
 

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -40,6 +40,8 @@
 
 * Jarl now reports rule violations in files that contain syntax errors (#538).
 
+* Three more functions skipped by default from `implicit_assignment`: `expect_silent` (from testthat), `expect_defunct` (from lifecycle) and `expect_deprecated` (from lifecycle) (#543).
+
 ### Bug fixes
 
 * `implicit_assignment` no longer flags chained assignments like

--- a/docs/reference/config-file.md
+++ b/docs/reference/config-file.md
@@ -341,7 +341,8 @@ namespaced calls, e.g. `skipped-functions = ["list2"]` will ignore `list2()` and
 Default: `skipped-functions = ["alist", "expect_error", "expect_warning", "expect_message",
 "expect_silent", "expect_defunct", "expect_deprecated",
 "expect_snapshot", "quote", "suppressMessages", "suppressWarnings"]`
-(`expect_`functions from the testthat package, as well as `expect_defunct` and `expect_deprecated` from the lifecycle package)
+(`expect_`functions come from the `testthat` package, except `expect_defunct` and
+`expect_deprecated` which come from the `lifecycle` package)
 
 ```toml
 [lint]

--- a/docs/reference/config-file.md
+++ b/docs/reference/config-file.md
@@ -339,7 +339,9 @@ namespaced calls, e.g. `skipped-functions = ["list2"]` will ignore `list2()` and
 `rlang::list2()`.
 
 Default: `skipped-functions = ["alist", "expect_error", "expect_warning", "expect_message",
+"expect_silent", "expect_defunct", "expect_deprecated",
 "expect_snapshot", "quote", "suppressMessages", "suppressWarnings"]`
+(`expect_`functions from the testthat package, as well as `expect_defunct` and `expect_deprecated` from the lifecycle package)
 
 ```toml
 [lint]


### PR DESCRIPTION
Fix #534

I'm not sure how to change the docs: I have the impression the default value is used automatically, but how do I make it show where `expect_defunct()` and `expect_deprecated()` come from?