### PR TITLE
fix: Clippy warnings in Rust 1.97.0

### DIFF
--- a/crates/jarl-core/src/directive.rs
+++ b/crates/jarl-core/src/directive.rs
@@ -147,10 +147,8 @@ pub fn parse_comment_directive(text: &str) -> Option<DirectiveParseResult> {
         (rest, true)
     } else if let Some(rest) = text.strip_prefix("# ") {
         (rest, false)
-    } else if let Some(rest) = text.strip_prefix('#') {
-        (rest, false)
     } else {
-        return None;
+        (text.strip_prefix('#')?, false)
     };
 
     // Must start with "jarl-ignore"

--- a/crates/jarl-core/src/lints/base/class_equals/class_equals.rs
+++ b/crates/jarl-core/src/lints/base/class_equals/class_equals.rs
@@ -205,10 +205,9 @@ fn extract_class_and_string(
             return None;
         }
         left_is_class = true;
-    } else if let Some(left_val) = left.as_any_r_value() {
-        left_val.as_r_string_value()?;
     } else {
-        return None;
+        let left_val = left.as_any_r_value()?;
+        left_val.as_r_string_value()?;
     }
 
     // Check if right is a class() call or a string
@@ -219,10 +218,9 @@ fn extract_class_and_string(
             return None;
         }
         right_is_class = true;
-    } else if let Some(right_val) = right.as_any_r_value() {
-        right_val.as_r_string_value()?;
     } else {
-        return None;
+        let right_val = right.as_any_r_value()?;
+        right_val.as_r_string_value()?;
     }
 
     // We need exactly one class() and one string

--- a/crates/jarl-core/src/lints/base/condition_call/condition_call.rs
+++ b/crates/jarl-core/src/lints/base/condition_call/condition_call.rs
@@ -118,7 +118,7 @@ pub fn condition_call(ast: &RCall) -> anyhow::Result<Option<Diagnostic>> {
         }
         // `call.` is absent: it defaults to `TRUE`, so insert `call. = FALSE`.
         None => {
-            let last_arg = args.into_iter().filter_map(|x| x.ok()).last();
+            let last_arg = args.into_iter().filter_map(|x| x.ok()).next_back();
             let (start, content) = match last_arg {
                 Some(arg) => (
                     usize::from(arg.syntax().text_trimmed_range().end()),

--- a/crates/jarl-core/src/package_cache.rs
+++ b/crates/jarl-core/src/package_cache.rs
@@ -260,10 +260,7 @@ pub fn find_r_project_root(file_path: &Path) -> Option<PathBuf> {
         if dir.join("renv.lock").exists() {
             return Some(dir.to_path_buf());
         }
-        match dir.parent() {
-            Some(parent) => dir = parent,
-            None => return None,
-        }
+        dir = dir.parent()?;
     }
 }
 


### PR DESCRIPTION
As the title, this PR fixed some new clippy warnings in Rust 1.97.0