### PR TITLE
feat: Improve `expect_s3_class_linter`

### DIFF
--- a/crates/jarl-core/src/lints/testthat/expect_s3_class/expect_s3_class.rs
+++ b/crates/jarl-core/src/lints/testthat/expect_s3_class/expect_s3_class.rs
@@ -28,7 +28,10 @@ use biome_rowan::{AstNode, AstSeparatedList};
 /// This rule is **disabled by default**. Select it either with the rule name
 /// `"expect_s3_class"` or with the rule group `"TESTTHAT"`.
 ///
-/// This rule has a safe automatic fix but doesn't report cases where:
+/// This rule has a safe automatic fix for statically supported class names.
+/// Dynamic class expressions are reported without an automatic fix.
+///
+/// This rule doesn't report cases where:
 ///
 /// * an `is.*()` predicate is not known to test an S3 class. For example,
 ///   `is.matrix(x)` does not imply that `x` is an S3 object.
@@ -39,12 +42,6 @@ use biome_rowan::{AstNode, AstSeparatedList};
 ///   testthat::expect_s3_class(1L, "integer")
 ///   ```
 ///   For those cases, it is recommended to use `expect_type()` instead.
-///
-/// * the `expected` object could have multiple values, such as:
-///   ```r
-///   testthat::expect_equal(class(x), c("foo", "bar"))
-///   testthat::expect_equal(class(x), vec_of_classes)
-///   ```
 ///
 /// Finally, the intent of the test cannot be inferred with the code only, so
 /// the user will have to add `exact = TRUE` if necessary.
@@ -87,10 +84,8 @@ fn check_expect_class_comparison(
         return Ok(None);
     }
 
-    let object_argument =
-        unwrap_or_return_none!(get_arg_by_name_then_position(&arguments, "object", 1));
-    let expected_argument =
-        unwrap_or_return_none!(get_arg_by_name_then_position(&arguments, "expected", 2));
+    let (object_argument, expected_argument) =
+        unwrap_or_return_none!(get_two_arguments(&arguments, "object", "expected"));
 
     let object_value = unwrap_or_return_none!(object_argument.value());
     let expected_value = unwrap_or_return_none!(expected_argument.value());
@@ -109,9 +104,11 @@ fn check_expect_class_comparison(
         return Ok(None);
     };
 
-    if !is_supported_class_literal(&class_expression) {
-        return Ok(None);
-    }
+    let can_fix = match classify_class_expression(&class_expression) {
+        ClassExpressionKind::SupportedLiteral => true,
+        ClassExpressionKind::UnsupportedLiteral => return Ok(None),
+        ClassExpressionKind::Dynamic => false,
+    };
 
     // Extract the argument of class()
     let class_arguments = class_call.arguments()?.items();
@@ -136,14 +133,18 @@ fn check_expect_class_comparison(
             Some(format!("Use `{replacement}` instead.")),
         ),
         range,
-        Fix {
-            content: format!(
-                "{}expect_s3_class({}, {})",
-                namespace_prefix, object_text, class_text
-            ),
-            start: range.start().into(),
-            end: range.end().into(),
-            to_skip: node_contains_comments(ast.syntax()),
+        if can_fix {
+            Fix {
+                content: format!(
+                    "{}expect_s3_class({}, {})",
+                    namespace_prefix, object_text, class_text
+                ),
+                start: range.start().into(),
+                end: range.end().into(),
+                to_skip: node_contains_comments(ast.syntax()),
+            }
+        } else {
+            Fix::empty()
         },
     )))
 }
@@ -163,63 +164,15 @@ fn check_expect_true_class(ast: &RCall) -> anyhow::Result<Option<Diagnostic>> {
     let predicate_name = get_function_name(predicate_call.function()?);
 
     let predicate_arguments = predicate_call.arguments()?.items();
-
-    let (object_text, class_text) = if predicate_name == "inherits" {
-        // Check for `expect_true(inherits(x, "foo"))`
-        if predicate_arguments.iter().count() != 2 {
-            return Ok(None);
+    let class_check = match predicate_name.as_str() {
+        "inherits" => unwrap_or_return_none!(extract_inherits_check(&predicate_arguments)?),
+        name if S3_CLASS_PREDICATES.contains(&name) => {
+            unwrap_or_return_none!(extract_predicate_check(name, &predicate_arguments)?)
         }
-
-        let named_object = get_arg_by_name(&predicate_arguments, "x");
-        let named_class = get_arg_by_name(&predicate_arguments, "what");
-
-        // The arguments can be named or unnamed, so we need to handle all combinations.
-        let (object_argument, class_argument) = match (named_object, named_class) {
-            (Some(object), Some(class)) => (object, class),
-            (Some(object), None) => (
-                object,
-                unwrap_or_return_none!(get_unnamed_arg_by_position(&predicate_arguments, 1)),
-            ),
-            (None, Some(class)) => (
-                unwrap_or_return_none!(get_unnamed_arg_by_position(&predicate_arguments, 1)),
-                class,
-            ),
-            (None, None) => (
-                unwrap_or_return_none!(get_unnamed_arg_by_position(&predicate_arguments, 1)),
-                unwrap_or_return_none!(get_unnamed_arg_by_position(&predicate_arguments, 2)),
-            ),
-        };
-        let object = unwrap_or_return_none!(object_argument.value());
-        let class = unwrap_or_return_none!(class_argument.value());
-
-        if !is_supported_class_literal(&class) {
-            return Ok(None);
-        }
-
-        (
-            object.to_trimmed_text().to_string(),
-            class.to_trimmed_text().to_string(),
-        )
-    } else if S3_CLASS_PREDICATES.contains(&predicate_name.as_str()) {
-        // Check for `expect_true(is.<class>(x))`
-        if predicate_arguments.iter().count() != 1 {
-            return Ok(None);
-        }
-
-        let predicate_argument =
-            unwrap_or_return_none!(get_arg_by_position(&predicate_arguments, 1));
-        let object = unwrap_or_return_none!(predicate_argument.value());
-
-        // For example, "is.data.frame" -> "data.frame"
-        let class_name = unwrap_or_return_none!(predicate_name.strip_prefix("is."));
-        (
-            object.to_trimmed_text().to_string(),
-            format!("\"{class_name}\""),
-        )
-    } else {
-        return Ok(None);
+        _ => return Ok(None),
     };
 
+    let ClassCheck { object_text, class_text, can_fix } = class_check;
     let replacement = format!("expect_s3_class({object_text}, {class_text})");
     let linted_text = format!("expect_true({})", predicate_call.to_trimmed_text());
 
@@ -234,13 +187,83 @@ fn check_expect_true_class(ast: &RCall) -> anyhow::Result<Option<Diagnostic>> {
             Some(format!("Use `{replacement}` instead.")),
         ),
         range,
-        Fix {
-            content: format!("{namespace_prefix}{replacement}"),
-            start: range.start().into(),
-            end: range.end().into(),
-            to_skip: node_contains_comments(ast.syntax()),
+        if can_fix {
+            Fix {
+                content: format!("{namespace_prefix}{replacement}"),
+                start: range.start().into(),
+                end: range.end().into(),
+                to_skip: node_contains_comments(ast.syntax()),
+            }
+        } else {
+            Fix::empty()
         },
     )))
+}
+
+struct ClassCheck {
+    object_text: String,
+    class_text: String,
+    can_fix: bool,
+}
+
+fn extract_inherits_check(arguments: &RArgumentList) -> anyhow::Result<Option<ClassCheck>> {
+    if arguments.iter().count() != 2 {
+        return Ok(None);
+    }
+
+    let (object_argument, class_argument) =
+        unwrap_or_return_none!(get_two_arguments(arguments, "x", "what"));
+    let object = unwrap_or_return_none!(object_argument.value());
+    let class = unwrap_or_return_none!(class_argument.value());
+    let can_fix = match classify_class_expression(&class) {
+        ClassExpressionKind::SupportedLiteral => true,
+        ClassExpressionKind::UnsupportedLiteral => return Ok(None),
+        ClassExpressionKind::Dynamic => false,
+    };
+
+    Ok(Some(ClassCheck {
+        object_text: object.to_trimmed_text().to_string(),
+        class_text: class.to_trimmed_text().to_string(),
+        can_fix,
+    }))
+}
+
+fn get_two_arguments(
+    arguments: &RArgumentList,
+    first_name: &str,
+    second_name: &str,
+) -> Option<(RArgument, RArgument)> {
+    match (
+        get_arg_by_name(arguments, first_name),
+        get_arg_by_name(arguments, second_name),
+    ) {
+        (Some(first), Some(second)) => Some((first, second)),
+        (Some(first), None) => Some((first, get_unnamed_arg_by_position(arguments, 1)?)),
+        (None, Some(second)) => Some((get_unnamed_arg_by_position(arguments, 1)?, second)),
+        (None, None) => Some((
+            get_unnamed_arg_by_position(arguments, 1)?,
+            get_unnamed_arg_by_position(arguments, 2)?,
+        )),
+    }
+}
+
+fn extract_predicate_check(
+    predicate_name: &str,
+    arguments: &RArgumentList,
+) -> anyhow::Result<Option<ClassCheck>> {
+    if arguments.iter().count() != 1 {
+        return Ok(None);
+    }
+
+    let argument = unwrap_or_return_none!(get_arg_by_position(arguments, 1));
+    let object = unwrap_or_return_none!(argument.value());
+    let class_name = unwrap_or_return_none!(predicate_name.strip_prefix("is."));
+
+    Ok(Some(ClassCheck {
+        object_text: object.to_trimmed_text().to_string(),
+        class_text: format!("\"{class_name}\""),
+        can_fix: true,
+    }))
 }
 
 fn as_class_call(expression: &AnyRExpression) -> anyhow::Result<Option<&RCall>> {
@@ -310,16 +333,30 @@ const NON_S3_CLASSES: &[&str] = &[
     "function",
 ];
 
-fn is_supported_class_literal(expression: &AnyRExpression) -> bool {
+/// Classifies a class expression according to whether the rule can safely fix it.
+enum ClassExpressionKind {
+    /// A string literal naming a class supported by `expect_s3_class()`.
+    SupportedLiteral,
+    /// A string literal naming a class that is not an S3 class.
+    UnsupportedLiteral,
+    /// An expression whose class value cannot be determined statically.
+    Dynamic,
+}
+
+fn classify_class_expression(expression: &AnyRExpression) -> ClassExpressionKind {
     let Some(string) = expression
         .as_any_r_value()
         .and_then(|value| value.as_r_string_value())
     else {
-        return false;
+        return ClassExpressionKind::Dynamic;
     };
 
     let content = string.content_token();
     let class_name = content.as_ref().map_or("", |token| token.text_trimmed());
 
-    !NON_S3_CLASSES.contains(&class_name)
+    if NON_S3_CLASSES.contains(&class_name) {
+        ClassExpressionKind::UnsupportedLiteral
+    } else {
+        ClassExpressionKind::SupportedLiteral
+    }
 }

--- a/crates/jarl-core/src/lints/testthat/expect_s3_class/expect_s3_class.rs
+++ b/crates/jarl-core/src/lints/testthat/expect_s3_class/expect_s3_class.rs
@@ -1,7 +1,7 @@
 use crate::diagnostic::*;
 use crate::utils::{
-    get_arg_by_name_then_position, get_function_name, get_function_namespace_prefix,
-    node_contains_comments,
+    get_arg_by_name_then_position, get_arg_by_position, get_function_name,
+    get_function_namespace_prefix, node_contains_comments,
 };
 use air_r_syntax::*;
 use biome_rowan::{AstNode, AstSeparatedList};
@@ -10,8 +10,9 @@ use biome_rowan::{AstNode, AstSeparatedList};
 ///
 /// ## What it does
 ///
-/// Checks for usage of `expect_equal(class(x), "y")` and
-/// `expect_identical(class(x), "y")`.
+/// Checks for usage of `expect_equal(class(x), "y")`,
+/// `expect_identical(class(x), "y")`, and selected
+/// `expect_true(is.<class>(x))` calls.
 ///
 /// ## Why is this bad?
 ///
@@ -28,6 +29,9 @@ use biome_rowan::{AstNode, AstSeparatedList};
 /// `"expect_s3_class"` or with the rule group `"TESTTHAT"`.
 ///
 /// This rule has a safe automatic fix but doesn't report cases where:
+///
+/// * an `is.*()` predicate is not known to test an S3 class. For example,
+///   `is.matrix(x)` does not imply that `x` is an S3 object.
 ///
 /// * `expect_s3_class()` would fail, such as:
 ///   ```r
@@ -50,101 +54,183 @@ use biome_rowan::{AstNode, AstSeparatedList};
 /// ```r
 /// expect_equal(class(x), "data.frame")
 /// expect_identical(class(x), "Date")
+/// expect_true(is.factor(x))
 /// ```
 ///
 /// Use instead:
 /// ```r
 /// expect_s3_class(x, "data.frame")
 /// expect_s3_class(x, "Date")
+/// expect_s3_class(x, "factor")
 /// ```
 pub fn expect_s3_class(ast: &RCall) -> anyhow::Result<Option<Diagnostic>> {
     let function = ast.function()?;
-    let function_name = get_function_name(function.clone());
+    let function_name = get_function_name(function);
 
-    // Only check expect_equal and expect_identical
-    if function_name != "expect_equal" && function_name != "expect_identical" {
+    match function_name.as_str() {
+        "expect_equal" | "expect_identical" => check_expect_class_comparison(ast, &function_name),
+        "expect_true" => check_expect_true_is_class(ast),
+        _ => Ok(None),
+    }
+}
+
+fn check_expect_class_comparison(
+    ast: &RCall,
+    function_name: &str,
+) -> anyhow::Result<Option<Diagnostic>> {
+    let arguments = ast.arguments()?.items();
+
+    // The replacement cannot preserve additional expectation arguments.
+    if arguments.iter().count() != 2 {
         return Ok(None);
     }
 
-    let args = ast.arguments()?.items();
+    let object_argument =
+        unwrap_or_return_none!(get_arg_by_name_then_position(&arguments, "object", 1));
+    let expected_argument =
+        unwrap_or_return_none!(get_arg_by_name_then_position(&arguments, "expected", 2));
 
-    let object = unwrap_or_return_none!(get_arg_by_name_then_position(&args, "object", 1));
-    let expected = unwrap_or_return_none!(get_arg_by_name_then_position(&args, "expected", 2));
-
-    // Don't know how to handle argument `label` for instance.
-    if args.iter().count() > 2 {
-        return Ok(None);
-    }
-
-    let object_value = unwrap_or_return_none!(object.value());
-    let expected_value = unwrap_or_return_none!(expected.value());
+    let object_value = unwrap_or_return_none!(object_argument.value());
+    let expected_value = unwrap_or_return_none!(expected_argument.value());
+    let linted_text = format!(
+        "{function_name}({}, {})",
+        object_value.to_trimmed_text(),
+        expected_value.to_trimmed_text()
+    );
 
     // Find patterns like `expect_equal(class(x), 'y')` and `expect_equal('y', class(x))`.
-    let (class_arg, other_arg) = if let Some(object_call) = object_value.as_r_call() {
-        let obj_fn = object_call.function()?;
-        let obj_fn_name = get_function_name(obj_fn);
-
-        if obj_fn_name == "class" {
-            (object_call, expected_value)
-        } else {
-            return Ok(None);
-        }
-    } else if let Some(expected_call) = expected_value.as_r_call() {
-        let exp_fn = expected_call.function()?;
-        let exp_fn_name = get_function_name(exp_fn);
-
-        if exp_fn_name == "class" {
-            (expected_call, object_value)
-        } else {
-            return Ok(None);
-        }
+    let (class_call, class_expression) = if let Some(call) = as_class_call(&object_value)? {
+        (call, expected_value)
+    } else if let Some(call) = as_class_call(&expected_value)? {
+        (call, object_value)
     } else {
         return Ok(None);
     };
 
-    if !check_class_is_s3(&other_arg) {
+    if !is_supported_class_literal(&class_expression) {
         return Ok(None);
     }
 
     // Extract the argument of class()
-    let class_args = class_arg.arguments()?.items();
-    let class_x_arg = unwrap_or_return_none!(get_arg_by_name_then_position(&class_args, "x", 1));
-    let class_x_value = unwrap_or_return_none!(class_x_arg.value());
+    let class_arguments = class_call.arguments()?.items();
+    let class_object_argument =
+        unwrap_or_return_none!(get_arg_by_name_then_position(&class_arguments, "x", 1));
+    let class_object = unwrap_or_return_none!(class_object_argument.value());
 
-    let x_text = class_x_value.to_trimmed_text();
-    let n_text = other_arg.to_trimmed_text();
+    let object_text = class_object.to_trimmed_text();
+    let class_text = class_expression.to_trimmed_text();
+    let replacement = format!("expect_s3_class({object_text}, {class_text})");
 
     // Preserve namespace prefix if present
+    let function = ast.function()?;
     let namespace_prefix = get_function_namespace_prefix(function).unwrap_or_default();
 
     let range = ast.syntax().text_trimmed_range();
-    let diagnostic = Diagnostic::new(
+
+    Ok(Some(Diagnostic::new(
         ViolationData::new(
             "expect_s3_class".to_string(),
-            format!(
-                "`{}(class(x), 'y')` may fail if `x` gets more classes in the future.",
-                function_name
-            ),
-            Some("Use `expect_s3_class(x, 'y')` instead.".to_string()),
+            format!("`{linted_text}` may fail if `{object_text}` gets more classes in the future."),
+            Some(format!("Use `{replacement}` instead.")),
         ),
         range,
         Fix {
             content: format!(
                 "{}expect_s3_class({}, {})",
-                namespace_prefix, x_text, n_text
+                namespace_prefix, object_text, class_text
             ),
             start: range.start().into(),
             end: range.end().into(),
             to_skip: node_contains_comments(ast.syntax()),
         },
-    );
-
-    Ok(Some(diagnostic))
+    )))
 }
+
+fn check_expect_true_is_class(ast: &RCall) -> anyhow::Result<Option<Diagnostic>> {
+    let arguments = ast.arguments()?.items();
+
+    // skip patterns like `expect_true(is.data.frame(x), info = "context")`
+    if arguments.iter().count() != 1 {
+        return Ok(None);
+    }
+
+    let object_argument =
+        unwrap_or_return_none!(get_arg_by_name_then_position(&arguments, "object", 1));
+    let object_value = unwrap_or_return_none!(object_argument.value());
+    let predicate_call = unwrap_or_return_none!(object_value.as_r_call());
+    let predicate_name = get_function_name(predicate_call.function()?);
+
+    if !S3_CLASS_PREDICATES.contains(&predicate_name.as_str()) {
+        return Ok(None);
+    }
+
+    let predicate_arguments = predicate_call.arguments()?.items();
+    if predicate_arguments.iter().count() != 1 {
+        return Ok(None);
+    }
+
+    let predicate_argument = unwrap_or_return_none!(get_arg_by_position(&predicate_arguments, 1));
+    let object = unwrap_or_return_none!(predicate_argument.value());
+
+    // For example, "is.data.frame" -> "data.frame"
+    let object_text = object.to_trimmed_text();
+    let class_name = unwrap_or_return_none!(predicate_name.strip_prefix("is."));
+    let replacement = format!("expect_s3_class({object_text}, \"{class_name}\")");
+    let linted_text = format!("expect_true({})", predicate_call.to_trimmed_text());
+
+    let function = ast.function()?;
+    let namespace_prefix = get_function_namespace_prefix(function).unwrap_or_default();
+    let range = ast.syntax().text_trimmed_range();
+
+    Ok(Some(Diagnostic::new(
+        ViolationData::new(
+            "expect_s3_class".to_string(),
+            format!("`{replacement}` is better than `{linted_text}`."),
+            Some(format!("Use `{replacement}` instead.")),
+        ),
+        range,
+        Fix {
+            content: format!("{namespace_prefix}{replacement}"),
+            start: range.start().into(),
+            end: range.end().into(),
+            to_skip: node_contains_comments(ast.syntax()),
+        },
+    )))
+}
+
+fn as_class_call(expression: &AnyRExpression) -> anyhow::Result<Option<&RCall>> {
+    let Some(call) = expression.as_r_call() else {
+        return Ok(None);
+    };
+
+    Ok((get_function_name(call.function()?) == "class").then_some(call))
+}
+
+// This list follows lintr's manually curated set of predicates that test S3 classes.
+// See https://github.com/r-lib/lintr/blob/main/R/expect_s3_class_linter.R
+const S3_CLASS_PREDICATES: &[&str] = &[
+    "is.data.frame",
+    "is.factor",
+    "is.numeric_version",
+    "is.ordered",
+    "is.package_version",
+    "is.qr",
+    "is.table",
+    "is.relistable",
+    "is.raster",
+    "is.tclObj",
+    "is.tkwin",
+    "is.grob",
+    "is.unit",
+    "is.mts",
+    "is.stepfun",
+    "is.ts",
+    "is.tskernel",
+];
 
 // https://github.com/wch/r-source/blob/e945946d165f3d9d2afa2e214a39aa4af61be45c/src/main/util.c#L209-L240
 // Link provided in https://github.com/etiennebacher/jarl/issues/232#issuecomment-3632266565
-pub static IGNORED_CLASSES: &[&str] = &[
+const NON_S3_CLASSES: &[&str] = &[
     "NULL",
     "symbol",
     "pairlist",
@@ -163,7 +249,6 @@ pub static IGNORED_CLASSES: &[&str] = &[
     "...",
     "any",
     "expression",
-    "list",
     "externalptr",
     "bytecode",
     "weakref",
@@ -180,18 +265,16 @@ pub static IGNORED_CLASSES: &[&str] = &[
     "function",
 ];
 
-fn check_class_is_s3(x: &AnyRExpression) -> bool {
-    if let Some(x) = x.as_any_r_value()
-        && let Some(x) = x.as_r_string_value()
-    {
-        !IGNORED_CLASSES.contains(
-            &x.to_trimmed_text()
-                .to_string()
-                .replace("\"", "")
-                .replace("'", "")
-                .as_str(),
-        )
-    } else {
-        false
-    }
+fn is_supported_class_literal(expression: &AnyRExpression) -> bool {
+    let Some(string) = expression
+        .as_any_r_value()
+        .and_then(|value| value.as_r_string_value())
+    else {
+        return false;
+    };
+
+    let content = string.content_token();
+    let class_name = content.as_ref().map_or("", |token| token.text_trimmed());
+
+    !NON_S3_CLASSES.contains(&class_name)
 }

--- a/crates/jarl-core/src/lints/testthat/expect_s3_class/expect_s3_class.rs
+++ b/crates/jarl-core/src/lints/testthat/expect_s3_class/expect_s3_class.rs
@@ -33,8 +33,8 @@ use biome_rowan::{AstNode, AstSeparatedList};
 ///
 /// This rule doesn't report cases where:
 ///
-/// * an `is.*()` predicate is not known to test an S3 class. For example,
-///   `is.matrix(x)` does not imply that `x` is an S3 object.
+/// * the `is.*()` predicate does not test an S3 class. For example, `is.matrix(x)` does 
+///   not imply that `x` is an S3 object.
 ///
 /// * `expect_s3_class()` would fail, such as:
 ///   ```r

--- a/crates/jarl-core/src/lints/testthat/expect_s3_class/expect_s3_class.rs
+++ b/crates/jarl-core/src/lints/testthat/expect_s3_class/expect_s3_class.rs
@@ -29,7 +29,8 @@ use biome_rowan::{AstNode, AstSeparatedList};
 /// `"expect_s3_class"` or with the rule group `"TESTTHAT"`.
 ///
 /// This rule has a safe automatic fix for statically supported class names.
-/// Dynamic class expressions are reported without an automatic fix.
+/// Dynamic class expressions are reported without an automatic fix because they
+/// could contain classes that are not supported by `expect_s3_class()`.
 ///
 /// This rule doesn't report cases where:
 ///
@@ -341,6 +342,10 @@ const NON_S3_CLASSES: &[&str] = &[
     "list",
     // See `?class`
     "matrix",
+    "dgCMatrix",
+    "dgRMatrix",
+    "dgeMatrix",
+    "dgTMatrix",
     "array",
     "function",
 ];

--- a/crates/jarl-core/src/lints/testthat/expect_s3_class/expect_s3_class.rs
+++ b/crates/jarl-core/src/lints/testthat/expect_s3_class/expect_s3_class.rs
@@ -33,7 +33,7 @@ use biome_rowan::{AstNode, AstSeparatedList};
 ///
 /// This rule doesn't report cases where:
 ///
-/// * the `is.*()` predicate does not test an S3 class. For example, `is.matrix(x)` does 
+/// * the `is.*()` predicate does not test an S3 class. For example, `is.matrix(x)` does
 ///   not imply that `x` is an S3 object.
 ///
 /// * `expect_s3_class()` would fail, such as:

--- a/crates/jarl-core/src/lints/testthat/expect_s3_class/expect_s3_class.rs
+++ b/crates/jarl-core/src/lints/testthat/expect_s3_class/expect_s3_class.rs
@@ -1,7 +1,7 @@
 use crate::diagnostic::*;
 use crate::utils::{
-    get_arg_by_name_then_position, get_arg_by_position, get_function_name,
-    get_function_namespace_prefix, node_contains_comments,
+    get_arg_by_name, get_arg_by_name_then_position, get_arg_by_position, get_function_name,
+    get_function_namespace_prefix, get_unnamed_arg_by_position, node_contains_comments,
 };
 use air_r_syntax::*;
 use biome_rowan::{AstNode, AstSeparatedList};
@@ -11,8 +11,8 @@ use biome_rowan::{AstNode, AstSeparatedList};
 /// ## What it does
 ///
 /// Checks for usage of `expect_equal(class(x), "y")`,
-/// `expect_identical(class(x), "y")`, and selected
-/// `expect_true(is.<class>(x))` calls.
+/// `expect_identical(class(x), "y")`, selected
+/// `expect_true(is.<class>(x))`, and `expect_true(inherits(x, "y"))` calls.
 ///
 /// ## Why is this bad?
 ///
@@ -55,6 +55,7 @@ use biome_rowan::{AstNode, AstSeparatedList};
 /// expect_equal(class(x), "data.frame")
 /// expect_identical(class(x), "Date")
 /// expect_true(is.factor(x))
+/// expect_true(inherits(x, "foo"))
 /// ```
 ///
 /// Use instead:
@@ -62,6 +63,7 @@ use biome_rowan::{AstNode, AstSeparatedList};
 /// expect_s3_class(x, "data.frame")
 /// expect_s3_class(x, "Date")
 /// expect_s3_class(x, "factor")
+/// expect_s3_class(x, "foo")
 /// ```
 pub fn expect_s3_class(ast: &RCall) -> anyhow::Result<Option<Diagnostic>> {
     let function = ast.function()?;
@@ -69,7 +71,7 @@ pub fn expect_s3_class(ast: &RCall) -> anyhow::Result<Option<Diagnostic>> {
 
     match function_name.as_str() {
         "expect_equal" | "expect_identical" => check_expect_class_comparison(ast, &function_name),
-        "expect_true" => check_expect_true_is_class(ast),
+        "expect_true" => check_expect_true_class(ast),
         _ => Ok(None),
     }
 }
@@ -146,7 +148,7 @@ fn check_expect_class_comparison(
     )))
 }
 
-fn check_expect_true_is_class(ast: &RCall) -> anyhow::Result<Option<Diagnostic>> {
+fn check_expect_true_class(ast: &RCall) -> anyhow::Result<Option<Diagnostic>> {
     let arguments = ast.arguments()?.items();
 
     // skip patterns like `expect_true(is.data.frame(x), info = "context")`
@@ -160,22 +162,65 @@ fn check_expect_true_is_class(ast: &RCall) -> anyhow::Result<Option<Diagnostic>>
     let predicate_call = unwrap_or_return_none!(object_value.as_r_call());
     let predicate_name = get_function_name(predicate_call.function()?);
 
-    if !S3_CLASS_PREDICATES.contains(&predicate_name.as_str()) {
-        return Ok(None);
-    }
-
     let predicate_arguments = predicate_call.arguments()?.items();
-    if predicate_arguments.iter().count() != 1 {
+
+    let (object_text, class_text) = if predicate_name == "inherits" {
+        // Check for `expect_true(inherits(x, "foo"))`
+        if predicate_arguments.iter().count() != 2 {
+            return Ok(None);
+        }
+
+        let named_object = get_arg_by_name(&predicate_arguments, "x");
+        let named_class = get_arg_by_name(&predicate_arguments, "what");
+
+        // The arguments can be named or unnamed, so we need to handle all combinations.
+        let (object_argument, class_argument) = match (named_object, named_class) {
+            (Some(object), Some(class)) => (object, class),
+            (Some(object), None) => (
+                object,
+                unwrap_or_return_none!(get_unnamed_arg_by_position(&predicate_arguments, 1)),
+            ),
+            (None, Some(class)) => (
+                unwrap_or_return_none!(get_unnamed_arg_by_position(&predicate_arguments, 1)),
+                class,
+            ),
+            (None, None) => (
+                unwrap_or_return_none!(get_unnamed_arg_by_position(&predicate_arguments, 1)),
+                unwrap_or_return_none!(get_unnamed_arg_by_position(&predicate_arguments, 2)),
+            ),
+        };
+        let object = unwrap_or_return_none!(object_argument.value());
+        let class = unwrap_or_return_none!(class_argument.value());
+
+        if !is_supported_class_literal(&class) {
+            return Ok(None);
+        }
+
+        (
+            object.to_trimmed_text().to_string(),
+            class.to_trimmed_text().to_string(),
+        )
+    } else if S3_CLASS_PREDICATES.contains(&predicate_name.as_str()) {
+        // Check for `expect_true(is.<class>(x))`
+        if predicate_arguments.iter().count() != 1 {
+            return Ok(None);
+        }
+
+        let predicate_argument =
+            unwrap_or_return_none!(get_arg_by_position(&predicate_arguments, 1));
+        let object = unwrap_or_return_none!(predicate_argument.value());
+
+        // For example, "is.data.frame" -> "data.frame"
+        let class_name = unwrap_or_return_none!(predicate_name.strip_prefix("is."));
+        (
+            object.to_trimmed_text().to_string(),
+            format!("\"{class_name}\""),
+        )
+    } else {
         return Ok(None);
-    }
+    };
 
-    let predicate_argument = unwrap_or_return_none!(get_arg_by_position(&predicate_arguments, 1));
-    let object = unwrap_or_return_none!(predicate_argument.value());
-
-    // For example, "is.data.frame" -> "data.frame"
-    let object_text = object.to_trimmed_text();
-    let class_name = unwrap_or_return_none!(predicate_name.strip_prefix("is."));
-    let replacement = format!("expect_s3_class({object_text}, \"{class_name}\")");
+    let replacement = format!("expect_s3_class({object_text}, {class_text})");
     let linted_text = format!("expect_true({})", predicate_call.to_trimmed_text());
 
     let function = ast.function()?;

--- a/crates/jarl-core/src/lints/testthat/expect_s3_class/expect_s3_class.rs
+++ b/crates/jarl-core/src/lints/testthat/expect_s3_class/expect_s3_class.rs
@@ -1,7 +1,7 @@
 use crate::diagnostic::*;
 use crate::utils::{
-    get_arg_by_name, get_arg_by_name_then_position, get_arg_by_position, get_function_name,
-    get_function_namespace_prefix, get_unnamed_arg_by_position, node_contains_comments,
+    get_arg_by_name_then_position, get_arg_by_position, get_function_name,
+    get_function_namespace_prefix, node_contains_comments,
 };
 use air_r_syntax::*;
 use biome_rowan::{AstNode, AstSeparatedList};
@@ -73,6 +73,7 @@ pub fn expect_s3_class(ast: &RCall) -> anyhow::Result<Option<Diagnostic>> {
     }
 }
 
+/// Checks comparisons such as `expect_equal(class(x), "data.frame")`.
 fn check_expect_class_comparison(
     ast: &RCall,
     function_name: &str,
@@ -84,8 +85,18 @@ fn check_expect_class_comparison(
         return Ok(None);
     }
 
-    let (object_argument, expected_argument) =
-        unwrap_or_return_none!(get_two_arguments(&arguments, "object", "expected"));
+    let object_argument =
+        unwrap_or_return_none!(get_arg_by_name_then_position(&arguments, "object", 1));
+    let expected_position = if object_argument.name_clause().is_some() {
+        1
+    } else {
+        2
+    };
+    let expected_argument = unwrap_or_return_none!(get_arg_by_name_then_position(
+        &arguments,
+        "expected",
+        expected_position,
+    ));
 
     let object_value = unwrap_or_return_none!(object_argument.value());
     let expected_value = unwrap_or_return_none!(expected_argument.value());
@@ -149,6 +160,8 @@ fn check_expect_class_comparison(
     )))
 }
 
+/// Checks `expect_true()` calls containing `inherits()` or a known S3 predicate,
+/// such as `expect_true(inherits(x, "foo"))` and `expect_true(is.factor(x))`.
 fn check_expect_true_class(ast: &RCall) -> anyhow::Result<Option<Diagnostic>> {
     let arguments = ast.arguments()?.items();
 
@@ -200,19 +213,32 @@ fn check_expect_true_class(ast: &RCall) -> anyhow::Result<Option<Diagnostic>> {
     )))
 }
 
+/// The object, expected class, and fix safety extracted from a class check.
+///
+/// For example, `inherits(x, "foo")` produces `x`, `"foo"`, and a safe fix.
 struct ClassCheck {
     object_text: String,
     class_text: String,
     can_fix: bool,
 }
 
+/// Extracts the object and class from a call such as `inherits(x, "foo")`.
 fn extract_inherits_check(arguments: &RArgumentList) -> anyhow::Result<Option<ClassCheck>> {
     if arguments.iter().count() != 2 {
         return Ok(None);
     }
 
-    let (object_argument, class_argument) =
-        unwrap_or_return_none!(get_two_arguments(arguments, "x", "what"));
+    let object_argument = unwrap_or_return_none!(get_arg_by_name_then_position(arguments, "x", 1));
+    let class_position = if object_argument.name_clause().is_some() {
+        1
+    } else {
+        2
+    };
+    let class_argument = unwrap_or_return_none!(get_arg_by_name_then_position(
+        arguments,
+        "what",
+        class_position,
+    ));
     let object = unwrap_or_return_none!(object_argument.value());
     let class = unwrap_or_return_none!(class_argument.value());
     let can_fix = match classify_class_expression(&class) {
@@ -228,25 +254,8 @@ fn extract_inherits_check(arguments: &RArgumentList) -> anyhow::Result<Option<Cl
     }))
 }
 
-fn get_two_arguments(
-    arguments: &RArgumentList,
-    first_name: &str,
-    second_name: &str,
-) -> Option<(RArgument, RArgument)> {
-    match (
-        get_arg_by_name(arguments, first_name),
-        get_arg_by_name(arguments, second_name),
-    ) {
-        (Some(first), Some(second)) => Some((first, second)),
-        (Some(first), None) => Some((first, get_unnamed_arg_by_position(arguments, 1)?)),
-        (None, Some(second)) => Some((get_unnamed_arg_by_position(arguments, 1)?, second)),
-        (None, None) => Some((
-            get_unnamed_arg_by_position(arguments, 1)?,
-            get_unnamed_arg_by_position(arguments, 2)?,
-        )),
-    }
-}
-
+/// Converts a known predicate such as `is.factor(x)` into object `x` and class
+/// `"factor"`.
 fn extract_predicate_check(
     predicate_name: &str,
     arguments: &RArgumentList,
@@ -266,12 +275,15 @@ fn extract_predicate_check(
     }))
 }
 
+/// Returns the call when an expression has the form `class(x)`.
 fn as_class_call(expression: &AnyRExpression) -> anyhow::Result<Option<&RCall>> {
-    let Some(call) = expression.as_r_call() else {
-        return Ok(None);
-    };
-
-    Ok((get_function_name(call.function()?) == "class").then_some(call))
+    if let Some(call) = expression.as_r_call()
+        && get_function_name(call.function()?) == "class"
+    {
+        Ok(Some(call))
+    } else {
+        Ok(None)
+    }
 }
 
 // This list follows lintr's manually curated set of predicates that test S3 classes.
@@ -334,6 +346,9 @@ const NON_S3_CLASSES: &[&str] = &[
 ];
 
 /// Classifies a class expression according to whether the rule can safely fix it.
+///
+/// For example, `"Date"` is supported, `"integer"` is unsupported, and a
+/// variable such as `expected_class` is dynamic.
 enum ClassExpressionKind {
     /// A string literal naming a class supported by `expect_s3_class()`.
     SupportedLiteral,
@@ -343,6 +358,7 @@ enum ClassExpressionKind {
     Dynamic,
 }
 
+/// Classifies the class argument used by `expect_s3_class()`.
 fn classify_class_expression(expression: &AnyRExpression) -> ClassExpressionKind {
     let Some(string) = expression
         .as_any_r_value()

--- a/crates/jarl-core/src/lints/testthat/expect_s3_class/mod.rs
+++ b/crates/jarl-core/src/lints/testthat/expect_s3_class/mod.rs
@@ -33,15 +33,6 @@ mod tests {
         expect_no_lint("expect_equal(class(x), 'logical')", "expect_s3_class", None);
         expect_no_lint("expect_equal(class(x), 'matrix')", "expect_s3_class", None);
 
-        // Not sure if those should be fixed here because if it's an object then
-        // it could contain classes that don't work in `expect_s3_class()`.
-        expect_no_lint("expect_equal(class(x), k)", "expect_s3_class", None);
-        expect_no_lint(
-            "expect_equal(class(x), c('a', 'b'))",
-            "expect_s3_class",
-            None,
-        );
-
         // Wrong code but no panic
         expect_no_lint("expect_equal(class(x))", "expect_s3_class", None);
         expect_no_lint("expect_equal(class())", "expect_s3_class", None);
@@ -61,12 +52,6 @@ mod tests {
         expect_no_lint("expect_true(is.data.frame(x, y))", "expect_s3_class", None);
         expect_no_lint("expect_true(is.data.frame(x =))", "expect_s3_class", None);
         expect_no_lint("expect_true(inherits(x))", "expect_s3_class", None);
-        expect_no_lint("expect_true(inherits(x, classes))", "expect_s3_class", None);
-        expect_no_lint(
-            "expect_true(inherits(x, c('foo', 'bar')))",
-            "expect_s3_class",
-            None,
-        );
         expect_no_lint(
             "expect_true(inherits(x, 'matrix'))",
             "expect_s3_class",
@@ -159,6 +144,50 @@ mod tests {
                     "expect_equal(class(x), \"data.frame\")",
                     "testthat::expect_equal(class(x), 'data.frame')",
                     "expect_equal('data.frame', class(x))",
+                    "expect_equal(object = class(x), 'data.frame')",
+                ],
+                "expect_s3_class",
+                None,
+            )
+        );
+    }
+
+    #[test]
+    fn test_lint_expect_s3_class_dynamic_class() {
+        assert_snapshot!(
+            snapshot_lint("expect_equal(class(x), classes)"),
+            @"
+        warning: expect_s3_class
+         --> <test>:1:1
+          |
+        1 | expect_equal(class(x), classes)
+          | ------------------------------- `expect_equal(class(x), classes)` may fail if `x` gets more classes in the future.
+          |
+          = help: Use `expect_s3_class(x, classes)` instead.
+        Found 1 error.
+        "
+        );
+        assert_snapshot!(
+            snapshot_lint("expect_true(inherits(x, classes))"),
+            @"
+        warning: expect_s3_class
+         --> <test>:1:1
+          |
+        1 | expect_true(inherits(x, classes))
+          | --------------------------------- `expect_s3_class(x, classes)` is better than `expect_true(inherits(x, classes))`.
+          |
+          = help: Use `expect_s3_class(x, classes)` instead.
+        Found 1 error.
+        "
+        );
+        assert_snapshot!(
+            "dynamic_class_no_fix",
+            get_fixed_text(
+                vec![
+                    "expect_equal(class(x), classes)",
+                    "expect_equal(classes, class(x))",
+                    "expect_true(inherits(x, classes))",
+                    "expect_true(inherits(x, c('foo', 'bar')))",
                 ],
                 "expect_s3_class",
                 None,
@@ -258,6 +287,7 @@ mod tests {
                     "expect_true(inherits(foo$bar, \"Date\"))",
                     "testthat::expect_true(base::inherits(what = 'factor', x = foo(x)))",
                     "expect_true(inherits(x = foo(x), 'factor'))",
+                    "expect_true(inherits(what = 'factor', foo(x)))",
                 ],
                 "expect_s3_class",
                 None,

--- a/crates/jarl-core/src/lints/testthat/expect_s3_class/mod.rs
+++ b/crates/jarl-core/src/lints/testthat/expect_s3_class/mod.rs
@@ -50,6 +50,16 @@ mod tests {
             "expect_s3_class",
             None,
         );
+        expect_no_lint("expect_true(is.matrix(x))", "expect_s3_class", None);
+        expect_no_lint("expect_true(is.nan(x))", "expect_s3_class", None);
+        expect_no_lint(
+            "expect_true(is.data.frame(x), info = 'context')",
+            "expect_s3_class",
+            None,
+        );
+        expect_no_lint("expect_true(is.data.frame())", "expect_s3_class", None);
+        expect_no_lint("expect_true(is.data.frame(x, y))", "expect_s3_class", None);
+        expect_no_lint("expect_true(is.data.frame(x =))", "expect_s3_class", None);
     }
 
     #[test]
@@ -61,9 +71,9 @@ mod tests {
          --> <test>:1:1
           |
         1 | expect_equal(class(x), 'data.frame')
-          | ------------------------------------ `expect_equal(class(x), 'y')` may fail if `x` gets more classes in the future.
+          | ------------------------------------ `expect_equal(class(x), 'data.frame')` may fail if `x` gets more classes in the future.
           |
-          = help: Use `expect_s3_class(x, 'y')` instead.
+          = help: Use `expect_s3_class(x, 'data.frame')` instead.
         Found 1 error.
         "
         );
@@ -74,9 +84,9 @@ mod tests {
          --> <test>:1:1
           |
         1 | expect_equal(class(x), "data.frame")
-          | ------------------------------------ `expect_equal(class(x), 'y')` may fail if `x` gets more classes in the future.
+          | ------------------------------------ `expect_equal(class(x), "data.frame")` may fail if `x` gets more classes in the future.
           |
-          = help: Use `expect_s3_class(x, 'y')` instead.
+          = help: Use `expect_s3_class(x, "data.frame")` instead.
         Found 1 error.
         "#
         );
@@ -87,9 +97,9 @@ mod tests {
          --> <test>:1:1
           |
         1 | testthat::expect_equal(class(x), 'data.frame')
-          | ---------------------------------------------- `expect_equal(class(x), 'y')` may fail if `x` gets more classes in the future.
+          | ---------------------------------------------- `expect_equal(class(x), 'data.frame')` may fail if `x` gets more classes in the future.
           |
-          = help: Use `expect_s3_class(x, 'y')` instead.
+          = help: Use `expect_s3_class(x, 'data.frame')` instead.
         Found 1 error.
         "
         );
@@ -100,11 +110,24 @@ mod tests {
          --> <test>:1:1
           |
         1 | expect_equal('data.frame', class(x))
-          | ------------------------------------ `expect_equal(class(x), 'y')` may fail if `x` gets more classes in the future.
+          | ------------------------------------ `expect_equal('data.frame', class(x))` may fail if `x` gets more classes in the future.
           |
-          = help: Use `expect_s3_class(x, 'y')` instead.
+          = help: Use `expect_s3_class(x, 'data.frame')` instead.
         Found 1 error.
         "
+        );
+        assert_snapshot!(
+            snapshot_lint("expect_identical(class(foo$bar), \"Date\")"),
+            @r#"
+        warning: expect_s3_class
+         --> <test>:1:1
+          |
+        1 | expect_identical(class(foo$bar), "Date")
+          | ---------------------------------------- `expect_identical(class(foo$bar), "Date")` may fail if `foo$bar` gets more classes in the future.
+          |
+          = help: Use `expect_s3_class(foo$bar, "Date")` instead.
+        Found 1 error.
+        "#
         );
         assert_snapshot!(
             "fix_output",
@@ -114,6 +137,63 @@ mod tests {
                     "expect_equal(class(x), \"data.frame\")",
                     "testthat::expect_equal(class(x), 'data.frame')",
                     "expect_equal('data.frame', class(x))",
+                ],
+                "expect_s3_class",
+                None,
+            )
+        );
+    }
+
+    #[test]
+    fn test_lint_expect_s3_class_predicates() {
+        assert_snapshot!(
+            snapshot_lint("expect_true(is.data.frame(x))"),
+            @r#"
+        warning: expect_s3_class
+         --> <test>:1:1
+          |
+        1 | expect_true(is.data.frame(x))
+          | ----------------------------- `expect_s3_class(x, "data.frame")` is better than `expect_true(is.data.frame(x))`.
+          |
+          = help: Use `expect_s3_class(x, "data.frame")` instead.
+        Found 1 error.
+        "#
+        );
+        assert_snapshot!(
+            snapshot_lint("testthat::expect_true(utils::is.relistable(foo(x)))"),
+            @r#"
+        warning: expect_s3_class
+         --> <test>:1:1
+          |
+        1 | testthat::expect_true(utils::is.relistable(foo(x)))
+          | --------------------------------------------------- `expect_s3_class(foo(x), "relistable")` is better than `expect_true(utils::is.relistable(foo(x)))`.
+          |
+          = help: Use `expect_s3_class(foo(x), "relistable")` instead.
+        Found 1 error.
+        "#
+        );
+        assert_snapshot!(
+            snapshot_lint("expect_true(is.tskernel(k = x))"),
+            @r#"
+        warning: expect_s3_class
+         --> <test>:1:1
+          |
+        1 | expect_true(is.tskernel(k = x))
+          | ------------------------------- `expect_s3_class(x, "tskernel")` is better than `expect_true(is.tskernel(k = x))`.
+          |
+          = help: Use `expect_s3_class(x, "tskernel")` instead.
+        Found 1 error.
+        "#
+        );
+        assert_snapshot!(
+            "predicate_fix_output",
+            get_fixed_text(
+                vec![
+                    "expect_true(is.data.frame(x))",
+                    "testthat::expect_true(utils::is.relistable(foo(x)))",
+                    "expect_true(is.tskernel(k = x))",
+                    "expect_true(is.numeric_version(x))",
+                    "expect_true(is.tclObj(x))",
                 ],
                 "expect_s3_class",
                 None,
@@ -133,9 +213,9 @@ mod tests {
         1 | / expect_equal(class(x),
         2 | |  # a comment 
         3 | | 'data.frame')
-          | |_____________- `expect_equal(class(x), 'y')` may fail if `x` gets more classes in the future.
+          | |_____________- `expect_equal(class(x), 'data.frame')` may fail if `x` gets more classes in the future.
           |
-          = help: Use `expect_s3_class(x, 'y')` instead.
+          = help: Use `expect_s3_class(x, 'data.frame')` instead.
         Found 1 error.
         "
         );
@@ -146,6 +226,7 @@ mod tests {
                     "# leading comment\nexpect_equal(class(x), 'data.frame')",
                     "expect_equal(class(x),\n # a comment \n'data.frame')",
                     "expect_equal(class(x), 'data.frame') # trailing comment",
+                    "expect_true(is.data.frame(\n # a comment\n x))",
                 ],
                 "expect_s3_class",
                 None

--- a/crates/jarl-core/src/lints/testthat/expect_s3_class/mod.rs
+++ b/crates/jarl-core/src/lints/testthat/expect_s3_class/mod.rs
@@ -37,7 +37,7 @@ mod tests {
         // it could contain classes that don't work in `expect_s3_class()`.
         expect_no_lint("expect_equal(class(x), k)", "expect_s3_class", None);
         expect_no_lint(
-            "expect_equal(class(x), c('a', 'b')",
+            "expect_equal(class(x), c('a', 'b'))",
             "expect_s3_class",
             None,
         );

--- a/crates/jarl-core/src/lints/testthat/expect_s3_class/mod.rs
+++ b/crates/jarl-core/src/lints/testthat/expect_s3_class/mod.rs
@@ -60,6 +60,28 @@ mod tests {
         expect_no_lint("expect_true(is.data.frame())", "expect_s3_class", None);
         expect_no_lint("expect_true(is.data.frame(x, y))", "expect_s3_class", None);
         expect_no_lint("expect_true(is.data.frame(x =))", "expect_s3_class", None);
+        expect_no_lint("expect_true(inherits(x))", "expect_s3_class", None);
+        expect_no_lint("expect_true(inherits(x, classes))", "expect_s3_class", None);
+        expect_no_lint(
+            "expect_true(inherits(x, c('foo', 'bar')))",
+            "expect_s3_class",
+            None,
+        );
+        expect_no_lint(
+            "expect_true(inherits(x, 'matrix'))",
+            "expect_s3_class",
+            None,
+        );
+        expect_no_lint(
+            "expect_true(inherits(x, 'foo', which = TRUE))",
+            "expect_s3_class",
+            None,
+        );
+        expect_no_lint(
+            "expect_true(inherits(x, 'foo'), info = 'context')",
+            "expect_s3_class",
+            None,
+        );
     }
 
     #[test]
@@ -202,6 +224,48 @@ mod tests {
     }
 
     #[test]
+    fn test_lint_expect_s3_class_inherits() {
+        assert_snapshot!(
+            snapshot_lint("expect_true(inherits(foo$bar, \"Date\"))"),
+            @r#"
+        warning: expect_s3_class
+         --> <test>:1:1
+          |
+        1 | expect_true(inherits(foo$bar, "Date"))
+          | -------------------------------------- `expect_s3_class(foo$bar, "Date")` is better than `expect_true(inherits(foo$bar, "Date"))`.
+          |
+          = help: Use `expect_s3_class(foo$bar, "Date")` instead.
+        Found 1 error.
+        "#
+        );
+        assert_snapshot!(
+            snapshot_lint("testthat::expect_true(base::inherits(what = 'factor', x = foo(x)))"),
+            @"
+        warning: expect_s3_class
+         --> <test>:1:1
+          |
+        1 | testthat::expect_true(base::inherits(what = 'factor', x = foo(x)))
+          | ------------------------------------------------------------------ `expect_s3_class(foo(x), 'factor')` is better than `expect_true(base::inherits(what = 'factor', x = foo(x)))`.
+          |
+          = help: Use `expect_s3_class(foo(x), 'factor')` instead.
+        Found 1 error.
+        "
+        );
+        assert_snapshot!(
+            "inherits_fix_output",
+            get_fixed_text(
+                vec![
+                    "expect_true(inherits(foo$bar, \"Date\"))",
+                    "testthat::expect_true(base::inherits(what = 'factor', x = foo(x)))",
+                    "expect_true(inherits(x = foo(x), 'factor'))",
+                ],
+                "expect_s3_class",
+                None,
+            )
+        );
+    }
+
+    #[test]
     fn test_expect_s3_class_with_comments_no_fix() {
         // Should detect lint but skip fix when comments are present
         assert_snapshot!(
@@ -227,6 +291,7 @@ mod tests {
                     "expect_equal(class(x),\n # a comment \n'data.frame')",
                     "expect_equal(class(x), 'data.frame') # trailing comment",
                     "expect_true(is.data.frame(\n # a comment\n x))",
+                    "expect_true(inherits(x,\n # a comment\n 'factor'))",
                 ],
                 "expect_s3_class",
                 None

--- a/crates/jarl-core/src/lints/testthat/expect_s3_class/snapshots/jarl_core__lints__testthat__expect_s3_class__tests__dynamic_class_no_fix.snap
+++ b/crates/jarl-core/src/lints/testthat/expect_s3_class/snapshots/jarl_core__lints__testthat__expect_s3_class__tests__dynamic_class_no_fix.snap
@@ -1,0 +1,31 @@
+---
+source: crates/jarl-core/src/lints/testthat/expect_s3_class/mod.rs
+expression: "get_fixed_text(vec![\"expect_equal(class(x), classes)\",\n\"expect_equal(classes, class(x))\", \"expect_true(inherits(x, classes))\",\n\"expect_true(inherits(x, c('foo', 'bar')))\",], \"expect_s3_class\", None,)"
+---
+OLD:
+====
+expect_equal(class(x), classes)
+NEW:
+====
+expect_equal(class(x), classes)
+
+OLD:
+====
+expect_equal(classes, class(x))
+NEW:
+====
+expect_equal(classes, class(x))
+
+OLD:
+====
+expect_true(inherits(x, classes))
+NEW:
+====
+expect_true(inherits(x, classes))
+
+OLD:
+====
+expect_true(inherits(x, c('foo', 'bar')))
+NEW:
+====
+expect_true(inherits(x, c('foo', 'bar')))

--- a/crates/jarl-core/src/lints/testthat/expect_s3_class/snapshots/jarl_core__lints__testthat__expect_s3_class__tests__fix_output.snap
+++ b/crates/jarl-core/src/lints/testthat/expect_s3_class/snapshots/jarl_core__lints__testthat__expect_s3_class__tests__fix_output.snap
@@ -1,6 +1,6 @@
 ---
 source: crates/jarl-core/src/lints/testthat/expect_s3_class/mod.rs
-expression: "get_fixed_text(vec![\"expect_equal(class(x), 'data.frame')\",\n\"expect_equal(class(x), \\\"data.frame\\\")\",\n\"testthat::expect_equal(class(x), 'data.frame')\",\n\"expect_equal('data.frame', class(x))\",], \"expect_s3_class\", None,)"
+expression: "get_fixed_text(vec![\"expect_equal(class(x), 'data.frame')\",\n\"expect_equal(class(x), \\\"data.frame\\\")\",\n\"testthat::expect_equal(class(x), 'data.frame')\",\n\"expect_equal('data.frame', class(x))\",\n\"expect_equal(object = class(x), 'data.frame')\",], \"expect_s3_class\", None,)"
 ---
 OLD:
 ====
@@ -26,6 +26,13 @@ testthat::expect_s3_class(x, 'data.frame')
 OLD:
 ====
 expect_equal('data.frame', class(x))
+NEW:
+====
+expect_s3_class(x, 'data.frame')
+
+OLD:
+====
+expect_equal(object = class(x), 'data.frame')
 NEW:
 ====
 expect_s3_class(x, 'data.frame')

--- a/crates/jarl-core/src/lints/testthat/expect_s3_class/snapshots/jarl_core__lints__testthat__expect_s3_class__tests__inherits_fix_output.snap
+++ b/crates/jarl-core/src/lints/testthat/expect_s3_class/snapshots/jarl_core__lints__testthat__expect_s3_class__tests__inherits_fix_output.snap
@@ -1,6 +1,6 @@
 ---
 source: crates/jarl-core/src/lints/testthat/expect_s3_class/mod.rs
-expression: "get_fixed_text(vec![\"expect_true(inherits(foo$bar, \\\"Date\\\"))\",\n\"testthat::expect_true(base::inherits(what = 'factor', x = foo(x)))\",\n\"expect_true(inherits(x = foo(x), 'factor'))\",], \"expect_s3_class\", None,)"
+expression: "get_fixed_text(vec![\"expect_true(inherits(foo$bar, \\\"Date\\\"))\",\n\"testthat::expect_true(base::inherits(what = 'factor', x = foo(x)))\",\n\"expect_true(inherits(x = foo(x), 'factor'))\",\n\"expect_true(inherits(what = 'factor', foo(x)))\",], \"expect_s3_class\", None,)"
 ---
 OLD:
 ====
@@ -19,6 +19,13 @@ testthat::expect_s3_class(foo(x), 'factor')
 OLD:
 ====
 expect_true(inherits(x = foo(x), 'factor'))
+NEW:
+====
+expect_s3_class(foo(x), 'factor')
+
+OLD:
+====
+expect_true(inherits(what = 'factor', foo(x)))
 NEW:
 ====
 expect_s3_class(foo(x), 'factor')

--- a/crates/jarl-core/src/lints/testthat/expect_s3_class/snapshots/jarl_core__lints__testthat__expect_s3_class__tests__inherits_fix_output.snap
+++ b/crates/jarl-core/src/lints/testthat/expect_s3_class/snapshots/jarl_core__lints__testthat__expect_s3_class__tests__inherits_fix_output.snap
@@ -1,0 +1,24 @@
+---
+source: crates/jarl-core/src/lints/testthat/expect_s3_class/mod.rs
+expression: "get_fixed_text(vec![\"expect_true(inherits(foo$bar, \\\"Date\\\"))\",\n\"testthat::expect_true(base::inherits(what = 'factor', x = foo(x)))\",\n\"expect_true(inherits(x = foo(x), 'factor'))\",], \"expect_s3_class\", None,)"
+---
+OLD:
+====
+expect_true(inherits(foo$bar, "Date"))
+NEW:
+====
+expect_s3_class(foo$bar, "Date")
+
+OLD:
+====
+testthat::expect_true(base::inherits(what = 'factor', x = foo(x)))
+NEW:
+====
+testthat::expect_s3_class(foo(x), 'factor')
+
+OLD:
+====
+expect_true(inherits(x = foo(x), 'factor'))
+NEW:
+====
+expect_s3_class(foo(x), 'factor')

--- a/crates/jarl-core/src/lints/testthat/expect_s3_class/snapshots/jarl_core__lints__testthat__expect_s3_class__tests__no_fix_with_comments.snap
+++ b/crates/jarl-core/src/lints/testthat/expect_s3_class/snapshots/jarl_core__lints__testthat__expect_s3_class__tests__no_fix_with_comments.snap
@@ -1,6 +1,6 @@
 ---
 source: crates/jarl-core/src/lints/testthat/expect_s3_class/mod.rs
-expression: "get_fixed_text(vec![\"# leading comment\\nexpect_equal(class(x), 'data.frame')\",\n\"expect_equal(class(x),\\n # a comment \\n'data.frame')\",\n\"expect_equal(class(x), 'data.frame') # trailing comment\",],\n\"expect_s3_class\", None)"
+expression: "get_fixed_text(vec![\"# leading comment\\nexpect_equal(class(x), 'data.frame')\",\n\"expect_equal(class(x),\\n # a comment \\n'data.frame')\",\n\"expect_equal(class(x), 'data.frame') # trailing comment\",\n\"expect_true(is.data.frame(\\n # a comment\\n x))\",], \"expect_s3_class\", None)"
 ---
 OLD:
 ====
@@ -28,3 +28,14 @@ expect_equal(class(x), 'data.frame') # trailing comment
 NEW:
 ====
 expect_s3_class(x, 'data.frame') # trailing comment
+
+OLD:
+====
+expect_true(is.data.frame(
+ # a comment
+ x))
+NEW:
+====
+expect_true(is.data.frame(
+ # a comment
+ x))

--- a/crates/jarl-core/src/lints/testthat/expect_s3_class/snapshots/jarl_core__lints__testthat__expect_s3_class__tests__no_fix_with_comments.snap
+++ b/crates/jarl-core/src/lints/testthat/expect_s3_class/snapshots/jarl_core__lints__testthat__expect_s3_class__tests__no_fix_with_comments.snap
@@ -1,6 +1,6 @@
 ---
 source: crates/jarl-core/src/lints/testthat/expect_s3_class/mod.rs
-expression: "get_fixed_text(vec![\"# leading comment\\nexpect_equal(class(x), 'data.frame')\",\n\"expect_equal(class(x),\\n # a comment \\n'data.frame')\",\n\"expect_equal(class(x), 'data.frame') # trailing comment\",\n\"expect_true(is.data.frame(\\n # a comment\\n x))\",], \"expect_s3_class\", None)"
+expression: "get_fixed_text(vec![\"# leading comment\\nexpect_equal(class(x), 'data.frame')\",\n\"expect_equal(class(x),\\n # a comment \\n'data.frame')\",\n\"expect_equal(class(x), 'data.frame') # trailing comment\",\n\"expect_true(is.data.frame(\\n # a comment\\n x))\",\n\"expect_true(inherits(x,\\n # a comment\\n 'factor'))\",], \"expect_s3_class\",\nNone)"
 ---
 OLD:
 ====
@@ -39,3 +39,14 @@ NEW:
 expect_true(is.data.frame(
  # a comment
  x))
+
+OLD:
+====
+expect_true(inherits(x,
+ # a comment
+ 'factor'))
+NEW:
+====
+expect_true(inherits(x,
+ # a comment
+ 'factor'))

--- a/crates/jarl-core/src/lints/testthat/expect_s3_class/snapshots/jarl_core__lints__testthat__expect_s3_class__tests__predicate_fix_output.snap
+++ b/crates/jarl-core/src/lints/testthat/expect_s3_class/snapshots/jarl_core__lints__testthat__expect_s3_class__tests__predicate_fix_output.snap
@@ -1,0 +1,38 @@
+---
+source: crates/jarl-core/src/lints/testthat/expect_s3_class/mod.rs
+expression: "get_fixed_text(vec![\"expect_true(is.data.frame(x))\",\n\"testthat::expect_true(utils::is.relistable(foo(x)))\",\n\"expect_true(is.tskernel(k = x))\", \"expect_true(is.numeric_version(x))\",\n\"expect_true(is.tclObj(x))\",], \"expect_s3_class\", None,)"
+---
+OLD:
+====
+expect_true(is.data.frame(x))
+NEW:
+====
+expect_s3_class(x, "data.frame")
+
+OLD:
+====
+testthat::expect_true(utils::is.relistable(foo(x)))
+NEW:
+====
+testthat::expect_s3_class(foo(x), "relistable")
+
+OLD:
+====
+expect_true(is.tskernel(k = x))
+NEW:
+====
+expect_s3_class(x, "tskernel")
+
+OLD:
+====
+expect_true(is.numeric_version(x))
+NEW:
+====
+expect_s3_class(x, "numeric_version")
+
+OLD:
+====
+expect_true(is.tclObj(x))
+NEW:
+====
+expect_s3_class(x, "tclObj")

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -35,6 +35,10 @@
   to list functions whose arguments are allowed to contain the `T` and `F`
   symbols (#542).
 
+* `expect_s3_class` now also reports selected `expect_true(is.<class>(x))`,
+  `expect_true(inherits(x, class))`, and dynamic class expressions. Dynamic
+  class expressions are reported without an automatic fix (#555, @Yousa-Mirage).
+
 * The CLI now suggests close rule names when some rule names don't exist (#501).
 
 * New `--output-format sarif` to export to [SARIF](https://sarifweb.azurewebsites.net/) (#508, @dieghernan).

--- a/docs/rules/expect_s3_class.md
+++ b/docs/rules/expect_s3_class.md
@@ -5,8 +5,8 @@
 ## What it does
 
 Checks for usage of `expect_equal(class(x), "y")`,
-`expect_identical(class(x), "y")`, and selected
-`expect_true(is.<class>(x))` calls.
+`expect_identical(class(x), "y")`, selected
+`expect_true(is.<class>(x))`, and `expect_true(inherits(x, "y"))` calls.
 
 ## Why is this bad?
 
@@ -49,6 +49,7 @@ the user will have to add `exact = TRUE` if necessary.
 expect_equal(class(x), "data.frame")
 expect_identical(class(x), "Date")
 expect_true(is.factor(x))
+expect_true(inherits(x, "foo"))
 ```
 
 Use instead:
@@ -56,4 +57,5 @@ Use instead:
 expect_s3_class(x, "data.frame")
 expect_s3_class(x, "Date")
 expect_s3_class(x, "factor")
+expect_s3_class(x, "foo")
 ```

--- a/docs/rules/expect_s3_class.md
+++ b/docs/rules/expect_s3_class.md
@@ -23,12 +23,13 @@ This rule is **disabled by default**. Select it either with the rule name
 `"expect_s3_class"` or with the rule group `"TESTTHAT"`.
 
 This rule has a safe automatic fix for statically supported class names.
-Dynamic class expressions are reported without an automatic fix.
+Dynamic class expressions are reported without an automatic fix because they
+could contain classes that are not supported by `expect_s3_class()`.
 
 This rule doesn't report cases where:
 
-* an `is.*()` predicate is not known to test an S3 class. For example,
-  `is.matrix(x)` does not imply that `x` is an S3 object.
+* the `is.*()` predicate does not test an S3 class. For example, `is.matrix(x)` does
+  not imply that `x` is an S3 object.
 
 * `expect_s3_class()` would fail, such as:
   ```r

--- a/docs/rules/expect_s3_class.md
+++ b/docs/rules/expect_s3_class.md
@@ -4,8 +4,9 @@
 
 ## What it does
 
-Checks for usage of `expect_equal(class(x), "y")` and
-`expect_identical(class(x), "y")`.
+Checks for usage of `expect_equal(class(x), "y")`,
+`expect_identical(class(x), "y")`, and selected
+`expect_true(is.<class>(x))` calls.
 
 ## Why is this bad?
 
@@ -22,6 +23,9 @@ This rule is **disabled by default**. Select it either with the rule name
 `"expect_s3_class"` or with the rule group `"TESTTHAT"`.
 
 This rule has a safe automatic fix but doesn't report cases where:
+
+* an `is.*()` predicate is not known to test an S3 class. For example,
+  `is.matrix(x)` does not imply that `x` is an S3 object.
 
 * `expect_s3_class()` would fail, such as:
   ```r
@@ -44,10 +48,12 @@ the user will have to add `exact = TRUE` if necessary.
 ```r
 expect_equal(class(x), "data.frame")
 expect_identical(class(x), "Date")
+expect_true(is.factor(x))
 ```
 
 Use instead:
 ```r
 expect_s3_class(x, "data.frame")
 expect_s3_class(x, "Date")
+expect_s3_class(x, "factor")
 ```

--- a/docs/rules/expect_s3_class.md
+++ b/docs/rules/expect_s3_class.md
@@ -22,7 +22,10 @@ To test that `x` only has the class `"y"`, then one can use
 This rule is **disabled by default**. Select it either with the rule name
 `"expect_s3_class"` or with the rule group `"TESTTHAT"`.
 
-This rule has a safe automatic fix but doesn't report cases where:
+This rule has a safe automatic fix for statically supported class names.
+Dynamic class expressions are reported without an automatic fix.
+
+This rule doesn't report cases where:
 
 * an `is.*()` predicate is not known to test an S3 class. For example,
   `is.matrix(x)` does not imply that `x` is an S3 object.
@@ -33,12 +36,6 @@ This rule has a safe automatic fix but doesn't report cases where:
   testthat::expect_s3_class(1L, "integer")
   ```
   For those cases, it is recommended to use `expect_type()` instead.
-
-* the `expected` object could have multiple values, such as:
-  ```r
-  testthat::expect_equal(class(x), c("foo", "bar"))
-  testthat::expect_equal(class(x), vec_of_classes)
-  ```
 
 Finally, the intent of the test cannot be inferred with the code only, so
 the user will have to add `exact = TRUE` if necessary.


### PR DESCRIPTION
## Summary

Part of #8 . Related to #232 .

This PR expands and refactors the `expect_s3_class` rule to cover the additional patterns supported by `lintr::expect_s3_class_linter()`, while preserving the safeguards discussed in #232.

## Changes

- Refactored the rule into separate branches for:
  - `expect_equal()` and `expect_identical()`
  - `expect_true(is.<class>(x))`
  - `expect_true(inherits(x, class))`
- Added support for `expect_true(is.<class>(x))` using the same curated S3 predicate allowlist as [`lintr`](https://github.com/r-lib/lintr/blob/main/R/expect_s3_class_linter.R).
- Added support for `expect_true(inherits(x, class))`.
- Added support for dynamic class expressions such as:
  - `expect_equal(class(x), classes)`
  - `expect_equal(classes, class(x))`
  - `expect_true(inherits(x, classes))`
- Dynamic class expressions now produce a diagnostic but do not receive an automatic fix because their value cannot be determined statically.
- Diagnostics and suggestions now include the actual expressions instead of generic `x` and `k` placeholders.
- Added some new tests and fixed a misspelled test.

## Remain

- Existing `expect_equal(class(x), class)` and `expect_identical(class(x), class)` matches retain their lint ranges and automatic fixes.
- Predicates that do not reliably test an S3 class, such as `is.matrix()` and `is.nan()`, remain ignored as #232 .
- Calls with additional expectation arguments such as `info`, `label`, or `expected.label` remain ignored.
- The rule does not add `exact = TRUE` automatically. Whether exact class equality is intended cannot be inferred statically, so users must add it when appropriate.
- Automatic fixes for statically supported class literals remain safe.
- Namespace and comment-preservation behavior remains unchanged.
- The original tests remains unchanged.