### PR TITLE
feat: Implement `list_comparison_linter`

### DIFF
--- a/crates/jarl-core/src/analyze/binary_expression.rs
+++ b/crates/jarl-core/src/analyze/binary_expression.rs
@@ -11,6 +11,7 @@ use crate::lints::base::equals_nan::equals_nan::equals_nan;
 use crate::lints::base::equals_null::equals_null::equals_null;
 use crate::lints::base::implicit_assignment::implicit_assignment::implicit_assignment;
 use crate::lints::base::is_numeric::is_numeric::is_numeric;
+use crate::lints::base::list_comparison::list_comparison::list_comparison;
 use crate::lints::base::nested_pipe::nested_pipe::nested_pipe;
 use crate::lints::base::nzchar::nzchar::nzchar;
 use crate::lints::base::pipe_consistency::pipe_consistency::pipe_consistency;
@@ -53,6 +54,9 @@ pub fn binary_expression(r_expr: &RBinaryExpression, checker: &mut Checker) -> a
     }
     if checker.is_rule_enabled(Rule::IsNumeric) {
         checker.report_diagnostic(is_numeric(r_expr)?);
+    }
+    if checker.is_rule_enabled(Rule::ListComparison) {
+        checker.report_diagnostic(list_comparison(r_expr)?);
     }
     if checker.is_rule_enabled(Rule::NestedPipe) {
         checker.report_diagnostic(nested_pipe(r_expr, checker)?);

--- a/crates/jarl-core/src/lints/base/list_comparison/list_comparison.rs
+++ b/crates/jarl-core/src/lints/base/list_comparison/list_comparison.rs
@@ -1,0 +1,92 @@
+use crate::diagnostic::*;
+use crate::utils::get_function_name;
+use air_r_syntax::*;
+use biome_rowan::AstNode;
+
+/// Version added: 0.6.0
+///
+/// ## What it does
+///
+/// Checks for comparisons involving functions that are known to return lists,
+/// such as `lapply(x, sum) > 10`.
+///
+/// ## Why is this bad?
+///
+/// These functions return lists, so R must coerce their results to vectors
+/// before comparing them. This can hide the intended output type. Prefer a
+/// mapper that returns a vector of the intended type directly, such as
+/// `vapply()` or one of the typed `purrr::map_*()` functions.
+///
+/// This rule doesn't have an automatic fix because the expected output type
+/// cannot be determined reliably from static analysis.
+///
+/// ## Example
+///
+/// ```r
+/// lapply(x, sum) > 10
+/// map(x, as.character) == "a"
+/// ```
+///
+/// Use instead:
+/// ```r
+/// vapply(x, sum, numeric(1L)) > 10
+/// map_chr(x, as.character) == "a"
+/// ```
+///
+/// ## References
+///
+/// See `?lapply` and `?Comparison`.
+pub fn list_comparison(ast: &RBinaryExpression) -> anyhow::Result<Option<Diagnostic>> {
+    let operator = ast.operator()?;
+    if !matches!(
+        operator.kind(),
+        RSyntaxKind::EQUAL2
+            | RSyntaxKind::NOT_EQUAL
+            | RSyntaxKind::GREATER_THAN
+            | RSyntaxKind::GREATER_THAN_OR_EQUAL_TO
+            | RSyntaxKind::LESS_THAN
+            | RSyntaxKind::LESS_THAN_OR_EQUAL_TO
+    ) {
+        return Ok(None);
+    }
+
+    let left = ast.left()?;
+    let right = ast.right()?;
+    let mut mapper = None;
+
+    for expression in [&left, &right] {
+        let Some(call) = expression.as_r_call() else {
+            continue;
+        };
+
+        let name = get_function_name(call.function()?);
+        let suggestion = match name.as_str() {
+            "lapply" => "Use `vapply()` with an explicit output type instead.",
+            "map" => "Use a typed mapper such as `map_chr()` or `map_dbl()` instead.",
+            "Map" | ".mapply" => "Use `mapply()` to return a vector directly.",
+            _ => continue,
+        };
+
+        mapper = Some((name, suggestion));
+        break;
+    }
+
+    let Some((mapper, suggestion)) = mapper else {
+        return Ok(None);
+    };
+
+    let diagnostic = Diagnostic::new(
+        ViolationData::new(
+            "list_comparison".to_string(),
+            format!(
+                "`{mapper}()` returns a list, so R must convert it to a vector before applying `{}`.",
+                operator.text_trimmed()
+            ),
+            Some(suggestion.to_string()),
+        ),
+        ast.syntax().text_trimmed_range(),
+        Fix::empty(),
+    );
+
+    Ok(Some(diagnostic))
+}

--- a/crates/jarl-core/src/lints/base/list_comparison/mod.rs
+++ b/crates/jarl-core/src/lints/base/list_comparison/mod.rs
@@ -1,0 +1,94 @@
+pub(crate) mod list_comparison;
+
+#[cfg(test)]
+mod tests {
+    use crate::utils_test::*;
+    use insta::assert_snapshot;
+
+    fn snapshot_lint(code: &str) -> String {
+        format_diagnostics(code, "list_comparison", None)
+    }
+
+    #[test]
+    fn test_no_lint_list_comparison() {
+        expect_no_lint("sapply(x, sum) > 10", "list_comparison", None);
+        expect_no_lint("unlist(lapply(x, sum)) > 10", "list_comparison", None);
+        expect_no_lint("lapply(x, sum) + 10", "list_comparison", None);
+        expect_no_lint("length(lapply(x, sum)) > 10", "list_comparison", None);
+    }
+
+    #[test]
+    fn test_lintr_cases_list_comparison() {
+        for mapper in ["lapply", "map", "Map", ".mapply"] {
+            for comparator in ["==", "!=", ">=", "<=", ">", "<"] {
+                let code = format!("{mapper}(x, sum) {comparator} 10");
+                assert_eq!(
+                    check_code(&code, "list_comparison", None).len(),
+                    1,
+                    "expected a lint for `{code}`"
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn test_lint_list_comparison() {
+        assert_snapshot!(
+            snapshot_lint("lapply(x, sum) > 10"),
+            @"
+        warning: list_comparison
+         --> <test>:1:1
+          |
+        1 | lapply(x, sum) > 10
+          | ------------------- `lapply()` returns a list, so R must convert it to a vector before applying `>`.
+          |
+          = help: Use `vapply()` with an explicit output type instead.
+        Found 1 error.
+        "
+        );
+
+        assert_snapshot!(
+            snapshot_lint("10 < purrr::map(x, sum)"),
+            @"
+        warning: list_comparison
+         --> <test>:1:1
+          |
+        1 | 10 < purrr::map(x, sum)
+          | ----------------------- `map()` returns a list, so R must convert it to a vector before applying `<`.
+          |
+          = help: Use a typed mapper such as `map_chr()` or `map_dbl()` instead.
+        Found 1 error.
+        "
+        );
+    }
+
+    #[test]
+    fn test_vectorizes_list_comparison() {
+        assert_snapshot!(
+            snapshot_lint(
+                "{
+  sapply(x, sum) > 10
+  .mapply(`+`, list(1:10, 1:10), NULL) == 2
+  lapply(x, sum) < 5
+}"
+            ),
+            @"
+        warning: list_comparison
+         --> <test>:3:3
+          |
+        3 |   .mapply(`+`, list(1:10, 1:10), NULL) == 2
+          |   ----------------------------------------- `.mapply()` returns a list, so R must convert it to a vector before applying `==`.
+          |
+          = help: Use `mapply()` to return a vector directly.
+        warning: list_comparison
+         --> <test>:4:3
+          |
+        4 |   lapply(x, sum) < 5
+          |   ------------------ `lapply()` returns a list, so R must convert it to a vector before applying `<`.
+          |
+          = help: Use `vapply()` with an explicit output type instead.
+        Found 2 errors.
+        "
+        );
+    }
+}

--- a/crates/jarl-core/src/lints/base/mod.rs
+++ b/crates/jarl-core/src/lints/base/mod.rs
@@ -30,6 +30,7 @@ pub(crate) mod length_levels;
 pub(crate) mod length_test;
 pub(crate) mod lengths;
 pub(crate) mod list2df;
+pub(crate) mod list_comparison;
 pub(crate) mod literal_coercion;
 pub(crate) mod matrix_apply;
 pub(crate) mod missing_argument;

--- a/crates/jarl-core/src/rule_set.rs
+++ b/crates/jarl-core/src/rule_set.rs
@@ -468,6 +468,13 @@ declare_rules! {
         fix: Safe,
         min_r_version: Some((4, 0, 0)),
     },
+    ListComparison => {
+        name: "list_comparison",
+        categories: [Susp],
+        default: Enabled,
+        fix: None,
+        min_r_version: None,
+    },
     LiteralCoercion => {
         name: "literal_coercion",
         categories: [Read],

--- a/docs/_quarto.yml
+++ b/docs/_quarto.yml
@@ -127,6 +127,7 @@ website:
       - rules/length_levels.md
       - rules/length_test.md
       - rules/lengths.md
+      - rules/list_comparison.md
       - rules/list2df.md
       - rules/literal_coercion.md
       - rules/matrix_apply.md

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -13,6 +13,7 @@
   * `glue` (#484, @novica)
   * `if_not_else` (#551)
   * `literal_coercion` (#504)
+  * `list_comparison` (#572, @Yousa-Mirage)
   * `missing_argument` (#506)
   * `nested_pipe` (#516)
   * `notin` (#459, @Yousa-Mirage)

--- a/docs/rules.qmd
+++ b/docs/rules.qmd
@@ -96,6 +96,7 @@ dat <- as.data.frame(
     c("length_test", "correctness", "✅", ""),
     c("lengths", "performance, readability", "✅", ""),
     c("list2df", "performance, readability", "✅", "R >= 4.0"),
+    c("list_comparison", "suspicious", "❌", ""),
     c("literal_coercion", "readability", "✅", ""),
     c("matrix_apply", "performance", "✅", ""),
     c("misnamed_suppression", "comments", "❌", ""),

--- a/docs/rules/list_comparison.md
+++ b/docs/rules/list_comparison.md
@@ -1,0 +1,35 @@
+# list_comparison
+::: {.callout-note title="Added in 0.6.0" .low-opacity}
+:::
+
+## What it does
+
+Checks for comparisons involving functions that are known to return lists,
+such as `lapply(x, sum) > 10`.
+
+## Why is this bad?
+
+These functions return lists, so R must coerce their results to vectors
+before comparing them. This can hide the intended output type. Prefer a
+mapper that returns a vector of the intended type directly, such as
+`vapply()` or one of the typed `purrr::map_*()` functions.
+
+This rule doesn't have an automatic fix because the expected output type
+cannot be determined reliably from static analysis.
+
+## Example
+
+```r
+lapply(x, sum) > 10
+map(x, as.character) == "a"
+```
+
+Use instead:
+```r
+vapply(x, sum, numeric(1L)) > 10
+map_chr(x, as.character) == "a"
+```
+
+## References
+
+See `?lapply` and `?Comparison`.


### PR DESCRIPTION
Part of #8 . The rule in `lintr` is https://lintr.r-lib.org/reference/list_comparison_linter.html. 
Currently this rule is enabled by default and has no auto-fix, because the data type in `list` cannot be inferred.