### PR TITLE
feat: Implement `nonportable_path_linter`

### DIFF
--- a/crates/jarl-core/src/analyze/anyvalue.rs
+++ b/crates/jarl-core/src/analyze/anyvalue.rs
@@ -2,10 +2,14 @@ use crate::checker::Checker;
 use crate::rule_set::Rule;
 use air_r_syntax::AnyRValue;
 
+use crate::lints::base::nonportable_path::nonportable_path::nonportable_path;
 use crate::lints::base::numeric_leading_zero::numeric_leading_zero::numeric_leading_zero;
 use crate::lints::base::quotes::quotes::quotes;
 
 pub fn anyvalue(r_expr: &AnyRValue, checker: &mut Checker) -> anyhow::Result<()> {
+    if checker.is_rule_enabled(Rule::NonportablePath) {
+        checker.report_diagnostic(nonportable_path(r_expr)?);
+    }
     if checker.is_rule_enabled(Rule::NumericLeadingZero) {
         checker.report_diagnostic(numeric_leading_zero(r_expr)?);
     }

--- a/crates/jarl-core/src/lints/base/mod.rs
+++ b/crates/jarl-core/src/lints/base/mod.rs
@@ -34,6 +34,7 @@ pub(crate) mod literal_coercion;
 pub(crate) mod matrix_apply;
 pub(crate) mod missing_argument;
 pub(crate) mod nested_pipe;
+pub(crate) mod nonportable_path;
 pub(crate) mod notin;
 pub(crate) mod numeric_leading_zero;
 pub(crate) mod nzchar;

--- a/crates/jarl-core/src/lints/base/nonportable_path/mod.rs
+++ b/crates/jarl-core/src/lints/base/nonportable_path/mod.rs
@@ -85,6 +85,29 @@ mod tests {
     }
 
     #[test]
+    fn test_nonportable_path_escaped_strings() {
+        assert_eq!(
+            check_code(r#""foo/ba\'r""#, "nonportable_path", None).len(),
+            1
+        );
+
+        expect_no_lint(r#""foo/ba\"r""#, "nonportable_path", None);
+        expect_no_lint(r#""foo/ba\ar""#, "nonportable_path", None);
+        expect_no_lint(r#""foo/ba\br""#, "nonportable_path", None);
+        expect_no_lint(r#""foo/ba\fr""#, "nonportable_path", None);
+        expect_no_lint(r#""foo/ba\nr""#, "nonportable_path", None);
+        expect_no_lint(r#""foo/ba\rr""#, "nonportable_path", None);
+        expect_no_lint(r#""foo/ba\tr""#, "nonportable_path", None);
+        expect_no_lint(r#""foo/ba\vr""#, "nonportable_path", None);
+
+        // Numeric and Unicode escapes are deliberately skipped rather than
+        // partially decoded by this rule.
+        expect_no_lint(r#""foo/ba\x61r""#, "nonportable_path", None);
+        expect_no_lint(r#""foo/ba\u0061r""#, "nonportable_path", None);
+        expect_no_lint(r#""foo/ba\141r""#, "nonportable_path", None);
+    }
+
+    #[test]
     fn test_no_lint_nonportable_path_contexts() {
         expect_no_lint(r#"grep("foo/bar", x)"#, "nonportable_path", None);
         expect_no_lint(r#"grep(paste0("foo/bar"), x)"#, "nonportable_path", None);

--- a/crates/jarl-core/src/lints/base/nonportable_path/mod.rs
+++ b/crates/jarl-core/src/lints/base/nonportable_path/mod.rs
@@ -1,0 +1,131 @@
+pub(crate) mod nonportable_path;
+
+#[cfg(test)]
+mod tests {
+    use crate::utils_test::*;
+    use insta::assert_snapshot;
+
+    fn snapshot_lint(code: &str) -> String {
+        format_diagnostics(code, "nonportable_path", None)
+    }
+
+    #[test]
+    fn test_lint_nonportable_path() {
+        assert_snapshot!(snapshot_lint(r#"path <- "foo/bar""#), @r#"
+        warning: nonportable_path
+         --> <test>:1:10
+          |
+        1 | path <- "foo/bar"
+          |          ------- Hard-coded path separators are not portable.
+          |
+          = help: Use `file.path()` to construct the path.
+        Found 1 error.
+        "#);
+
+        assert_eq!(check_code(r#""~/foo""#, "nonportable_path", None).len(), 1);
+        assert_eq!(check_code(r#""C:/foo""#, "nonportable_path", None).len(), 1);
+        assert_eq!(check_code(r#""../foo""#, "nonportable_path", None).len(), 1);
+        assert_eq!(
+            check_code(r#""/foo/bar""#, "nonportable_path", None).len(),
+            1
+        );
+        assert_eq!(
+            check_code(r#""foo\\bar""#, "nonportable_path", None).len(),
+            1
+        );
+        assert_eq!(
+            check_code(r#"r"(foo/bar)""#, "nonportable_path", None).len(),
+            1
+        );
+        assert_eq!(check_code(r#""a/bb""#, "nonportable_path", None).len(), 1);
+        assert_eq!(
+            check_code(r#""路径1/路径2/啊啊.txt""#, "nonportable_path", None).len(),
+            1
+        );
+        assert_eq!(
+            check_code(r#""资料/🚗/结果📈.txt""#, "nonportable_path", None).len(),
+            1
+        );
+        assert_eq!(
+            check_code(
+                r#"sprintf("output/%s/file.txt", x)"#,
+                "nonportable_path",
+                None
+            )
+            .len(),
+            1
+        );
+    }
+
+    #[test]
+    fn test_no_lint_nonportable_path() {
+        expect_no_lint(r#""foo""#, "nonportable_path", None);
+        expect_no_lint(
+            r#""https://cran.r-project.org/web/packages/lintr/""#,
+            "nonportable_path",
+            None,
+        );
+        expect_no_lint(r#""1://foo/bar""#, "nonportable_path", None);
+        expect_no_lint(r#""hello\nthere!""#, "nonportable_path", None);
+        expect_no_lint(r#""'/foo'""#, "nonportable_path", None);
+        expect_no_lint(r#""/""#, "nonportable_path", None);
+        expect_no_lint(r#""~""#, "nonportable_path", None);
+        expect_no_lint(r#""c:""#, "nonportable_path", None);
+        expect_no_lint(r#"".""#, "nonportable_path", None);
+
+        // These are intentionally skipped by the fixed `lax = TRUE` heuristic.
+        expect_no_lint(r#""/foo""#, "nonportable_path", None);
+        expect_no_lint(r#""foo/""#, "nonportable_path", None);
+        expect_no_lint(r#""~/""#, "nonportable_path", None);
+        expect_no_lint(r#""C:/""#, "nonportable_path", None);
+        expect_no_lint(r#""../""#, "nonportable_path", None);
+        expect_no_lint(r#""/a\nsdf/bar""#, "nonportable_path", None);
+        expect_no_lint(r#""/as:df/bar""#, "nonportable_path", None);
+        expect_no_lint(r#""aa/b""#, "nonportable_path", None);
+    }
+
+    #[test]
+    fn test_no_lint_nonportable_path_contexts() {
+        expect_no_lint(r#"grep("foo/bar", x)"#, "nonportable_path", None);
+        expect_no_lint(r#"grep(paste0("foo/bar"), x)"#, "nonportable_path", None);
+        expect_no_lint(r#"sub("foo/bar", "", x)"#, "nonportable_path", None);
+        expect_no_lint(r#"regexpr("foo/bar", x)"#, "nonportable_path", None);
+        expect_no_lint(
+            r#"stringr::str_detect(x, "foo/bar")"#,
+            "nonportable_path",
+            None,
+        );
+        expect_no_lint(
+            r#"strptime("2025/01/31", "%Y/%m/%d")"#,
+            "nonportable_path",
+            None,
+        );
+        expect_no_lint(r#"as.Date("2025/01/31")"#, "nonportable_path", None);
+        expect_no_lint(r#"grepv("foo/bar", x)"#, "nonportable_path", None);
+        expect_no_lint(r#"foo(pattern = "foo/bar")"#, "nonportable_path", None);
+        expect_no_lint(r#"foo(format = "%Y/%m/%d")"#, "nonportable_path", None);
+    }
+
+    #[test]
+    fn test_vectorized_nonportable_path() {
+        assert_snapshot!(snapshot_lint(
+            r#"paths <- c("foo/bar", "https://example.com/a/b", "one/two/three")"#
+        ), @r#"
+        warning: nonportable_path
+         --> <test>:1:13
+          |
+        1 | paths <- c("foo/bar", "https://example.com/a/b", "one/two/three")
+          |             ------- Hard-coded path separators are not portable.
+          |
+          = help: Use `file.path()` to construct the path.
+        warning: nonportable_path
+         --> <test>:1:51
+          |
+        1 | paths <- c("foo/bar", "https://example.com/a/b", "one/two/three")
+          |                                                   ------------- Hard-coded path separators are not portable.
+          |
+          = help: Use `file.path()` to construct the path.
+        Found 2 errors.
+        "#);
+    }
+}

--- a/crates/jarl-core/src/lints/base/nonportable_path/nonportable_path.rs
+++ b/crates/jarl-core/src/lints/base/nonportable_path/nonportable_path.rs
@@ -1,0 +1,249 @@
+use crate::diagnostic::*;
+use crate::utils::get_function_name;
+use air_r_syntax::*;
+use biome_rowan::AstNode;
+
+pub struct NonportablePath;
+
+const SKIPPED_ARGUMENT_NAMES: &[&str] = &["format", "pattern"];
+
+// These calls commonly use strings as regular-expression or date-format
+// specifications rather than file paths.
+const SKIPPED_FUNCTIONS: &[&str] = &[
+    "agrep",
+    "agrepl",
+    "as.Date",
+    "as.POSIXct",
+    "as.POSIXlt",
+    "format",
+    "grep",
+    "grepRaw",
+    "grepl",
+    "grepv",
+    "gregexec",
+    "gregexpr",
+    "gsub",
+    "regexec",
+    "regexpr",
+    "str_count",
+    "str_detect",
+    "str_ends",
+    "str_extract",
+    "str_extract_all",
+    "str_locate",
+    "str_locate_all",
+    "str_match",
+    "str_match_all",
+    "str_remove",
+    "str_remove_all",
+    "str_replace",
+    "str_replace_all",
+    "str_split",
+    "str_split_fixed",
+    "str_starts",
+    "str_subset",
+    "str_view",
+    "str_which",
+    "strftime",
+    "strptime",
+    "strsplit",
+    "sub",
+];
+
+/// Version added: 0.6.0
+///
+/// ## What it does
+///
+/// Checks for likely file paths constructed with hard-coded `/` or `\\`
+/// separators.
+///
+/// ## Why is this bad?
+///
+/// Hard-coded path separators may not work consistently across operating
+/// systems. Use `file.path()` to construct portable paths.
+///
+/// This rule is disabled by default because this heuristic can also match
+/// regular expressions and other strings that are not file paths.
+///
+/// This rule uses a conservative heuristic: a separator must be followed by a
+/// path component containing at least two characters. URLs, root paths, and
+/// strings containing characters that are generally invalid in paths are
+/// ignored. Strings inside known regular-expression and date-formatting
+/// functions, or arguments named `pattern` or `format`, are also ignored.
+///
+/// ## Example
+///
+/// ```r
+/// path <- "data/raw/input.csv"
+/// ```
+///
+/// Use instead:
+/// ```r
+/// path <- file.path("data", "raw", "input.csv")
+/// ```
+///
+/// ## References
+///
+/// See `?file.path`.
+impl Violation for NonportablePath {
+    fn name(&self) -> String {
+        "nonportable_path".to_string()
+    }
+
+    fn body(&self) -> String {
+        "Hard-coded path separators are not portable.".to_string()
+    }
+
+    fn suggestion(&self) -> Option<String> {
+        Some("Use `file.path()` to construct the path.".to_string())
+    }
+}
+
+pub fn nonportable_path(ast: &AnyRValue) -> anyhow::Result<Option<Diagnostic>> {
+    let string = unwrap_or_return_none!(ast.as_r_string_value());
+
+    // The path heuristic cannot distinguish these strings reliably from paths,
+    // so skip contexts whose arguments have a different, well-known meaning.
+    if is_skipped_context(string) {
+        return Ok(None);
+    }
+
+    let token = unwrap_or_return_none!(string.content_token());
+    let open = string.open_token()?;
+    let content = token.text_trimmed();
+
+    // Syntax tokens retain R's escape sequences. Decode them before checking
+    // separators so `\\` is treated as a path separator but `\n` is not.
+    let path = if open.text_trimmed().starts_with(['r', 'R']) {
+        content.to_string()
+    } else {
+        unwrap_or_return_none!(decode_standard_string(content))
+    };
+
+    if !is_nonportable_path(&path) {
+        return Ok(None);
+    }
+
+    Ok(Some(Diagnostic::new(
+        NonportablePath,
+        token.text_range(),
+        Fix::empty(),
+    )))
+}
+
+fn decode_standard_string(content: &str) -> Option<String> {
+    let mut decoded = String::with_capacity(content.len());
+    let mut chars = content.chars();
+
+    while let Some(character) = chars.next() {
+        if character != '\\' {
+            decoded.push(character);
+            continue;
+        }
+
+        let escaped = chars.next()?;
+        decoded.push(match escaped {
+            // A doubled backslash represents the actual separator in a
+            // Windows path; the other branches below represent non-separator
+            // characters or control characters.
+            '\\' => '\\',
+            '/' => '/',
+            '\'' => '\'',
+            '"' => '"',
+            'a' => '\x07',
+            'b' => '\x08',
+            'f' => '\x0c',
+            'n' => '\n',
+            'r' => '\r',
+            't' => '\t',
+            'v' => '\x0b',
+            // Skip uncommon numeric and Unicode escapes rather than guessing
+            // their decoded value and risking a false positive.
+            _ => return None,
+        });
+    }
+
+    Some(decoded)
+}
+
+fn is_nonportable_path(path: &str) -> bool {
+    // URLs and nested quoted strings are not useful candidates for this rule.
+    if path.starts_with(['\'', '"']) || has_url_scheme(path) {
+        return false;
+    }
+
+    // Match lintr's `lax = TRUE` heuristic: require a separator followed by
+    // at least two valid characters, while still allowing arbitrary Unicode.
+    let mut component_count = 0;
+    let mut has_long_component = false;
+    for component in path
+        .split(['/', '\\'])
+        .filter(|component| !component.is_empty())
+    {
+        if !is_valid_component(component, component_count == 0) {
+            return false;
+        }
+
+        if component_count > 0 && component.chars().count() >= 2 {
+            has_long_component = true;
+        }
+
+        component_count += 1;
+    }
+
+    component_count >= 2 && has_long_component
+}
+
+fn is_skipped_context(string: &RStringValue) -> bool {
+    // Walk all ancestors so a string nested in `paste0()` inside `grep()` is
+    // still recognized as part of a regular-expression argument.
+    for ancestor in string.syntax().ancestors() {
+        if let Some(argument) = RArgument::cast(ancestor.clone())
+            && argument
+                .name_clause()
+                .and_then(|clause| clause.name().ok())
+                .is_some_and(|name| {
+                    SKIPPED_ARGUMENT_NAMES.contains(&name.to_trimmed_string().as_str())
+                })
+        {
+            return true;
+        }
+
+        if let Some(call) = RCall::cast(ancestor)
+            && let Ok(function) = call.function()
+            && SKIPPED_FUNCTIONS.contains(&get_function_name(function).as_str())
+        {
+            return true;
+        }
+    }
+
+    false
+}
+
+fn has_url_scheme(path: &str) -> bool {
+    let Some((scheme, _)) = path.split_once("://") else {
+        return false;
+    };
+    !scheme.is_empty()
+        && scheme
+            .chars()
+            .all(|character| character.is_ascii_alphabetic())
+}
+
+fn is_valid_component(component: &str, first: bool) -> bool {
+    if first
+        && component.len() == 2
+        && component.ends_with(':')
+        && component.starts_with(|character: char| character.is_ascii_alphabetic())
+    {
+        return true;
+    }
+
+    component.chars().all(|character| {
+        !character.is_control()
+            && !matches!(
+                character,
+                '*' | '?' | '"' | '<' | '>' | '|' | ':' | '/' | '\\'
+            )
+    })
+}

--- a/crates/jarl-core/src/lints/base/nonportable_path/nonportable_path.rs
+++ b/crates/jarl-core/src/lints/base/nonportable_path/nonportable_path.rs
@@ -147,7 +147,6 @@ fn decode_standard_string(content: &str) -> Option<String> {
             // Windows path; the other branches below represent non-separator
             // characters or control characters.
             '\\' => '\\',
-            '/' => '/',
             '\'' => '\'',
             '"' => '"',
             'a' => '\x07',

--- a/crates/jarl-core/src/rule_set.rs
+++ b/crates/jarl-core/src/rule_set.rs
@@ -496,6 +496,13 @@ declare_rules! {
         fix: None,
         min_r_version: None,
     },
+    NonportablePath => {
+        name: "nonportable_path",
+        categories: [Susp],
+        default: Disabled,
+        fix: None,
+        min_r_version: None,
+    },
     NotIn => {
         name: "notin",
         categories: [Read],

--- a/docs/_quarto.yml
+++ b/docs/_quarto.yml
@@ -135,6 +135,7 @@ website:
       - rules/misplaced_suppression.md
       - rules/missing_argument.md
       - rules/nested_pipe.md
+      - rules/nonportable_path.md
       - rules/notin.md
       - rules/numeric_leading_zero.md
       - rules/nzchar.md

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -15,7 +15,7 @@
   * `literal_coercion` (#504)
   * `missing_argument` (#506)
   * `nested_pipe` (#516)
-  * `nonportable_path` (@Yousa-Mirage)
+  * `nonportable_path` (#573, @Yousa-Mirage)
   * `notin` (#459, @Yousa-Mirage)
   * `pipe_consistency` (#482)
   * `pipe_return` (#502)

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -15,6 +15,7 @@
   * `literal_coercion` (#504)
   * `missing_argument` (#506)
   * `nested_pipe` (#516)
+  * `nonportable_path` (@Yousa-Mirage)
   * `notin` (#459, @Yousa-Mirage)
   * `pipe_consistency` (#482)
   * `pipe_return` (#502)

--- a/docs/rules.qmd
+++ b/docs/rules.qmd
@@ -103,6 +103,7 @@ dat <- as.data.frame(
     c("misplaced_suppression", "comments", "❌", ""),
     c("missing_argument", "suspicious", "❌", ""),
     c("nested_pipe", "readability", "❌", "Disabled by default"),
+    c("nonportable_path", "suspicious", "❌", "Disabled by default"),
     c("notin", "readability", "✅", "R >= 4.6"),
     c("numeric_leading_zero", "readability", "✅", ""),
     c("nzchar", "performance", "❗", "Disabled by default"),

--- a/docs/rules/nonportable_path.md
+++ b/docs/rules/nonportable_path.md
@@ -1,0 +1,37 @@
+# nonportable_path
+::: {.callout-note title="Added in 0.6.0" .low-opacity}
+:::
+
+## What it does
+
+Checks for likely file paths constructed with hard-coded `/` or `\\`
+separators.
+
+## Why is this bad?
+
+Hard-coded path separators may not work consistently across operating
+systems. Use `file.path()` to construct portable paths.
+
+This rule is disabled by default because this heuristic can also match
+regular expressions and other strings that are not file paths.
+
+This rule uses a conservative heuristic: a separator must be followed by a
+path component containing at least two characters. URLs, root paths, and
+strings containing characters that are generally invalid in paths are
+ignored. Strings inside known regular-expression and date-formatting
+functions, or arguments named `pattern` or `format`, are also ignored.
+
+## Example
+
+```r
+path <- "data/raw/input.csv"
+```
+
+Use instead:
+```r
+path <- file.path("data", "raw", "input.csv")
+```
+
+## References
+
+See `?file.path`.


### PR DESCRIPTION
Part of #8 . This rule is from https://lintr.r-lib.org/reference/nonportable_path_linter.html .

This rule is disabled by default because it can produce many false positives for strings containing "/" such as regular expressions. The problem of false positives also exists in `lintr`. If you feel it is inappropriate, we do not need to implement this linter.