### PR TITLE
fix: Report syntax errors with `--statistics`

### DIFF
--- a/crates/jarl/src/commands/check.rs
+++ b/crates/jarl/src/commands/check.rs
@@ -242,8 +242,15 @@ pub fn check(args: CheckCommand) -> Result<ExitStatus> {
 
     all_diagnostics_flat.sort();
 
+    let has_errors = !all_errors.is_empty();
+
     if args.statistics {
-        return print_statistics(&all_diagnostics_flat, parent_config_path);
+        if has_errors {
+            let mut stdout = std::io::stdout();
+            FullEmitter.emit(&mut stdout, &[], &all_errors)?;
+        }
+
+        return print_statistics(&all_diagnostics_flat, has_errors, parent_config_path);
     }
 
     let mut stdout = std::io::stdout();

--- a/crates/jarl/src/commands/check.rs
+++ b/crates/jarl/src/commands/check.rs
@@ -245,6 +245,7 @@ pub fn check(args: CheckCommand) -> Result<ExitStatus> {
     let has_errors = !all_errors.is_empty();
 
     if args.statistics {
+        // Statistics must still report parse errors and preserve a failing exit status.
         if has_errors {
             let mut stdout = std::io::stdout();
             FullEmitter.emit(&mut stdout, &[], &all_errors)?;

--- a/crates/jarl/src/commands/check.rs
+++ b/crates/jarl/src/commands/check.rs
@@ -241,20 +241,17 @@ pub fn check(args: CheckCommand) -> Result<ExitStatus> {
         .collect();
 
     all_diagnostics_flat.sort();
-
-    let has_errors = !all_errors.is_empty();
+    let mut stdout = std::io::stdout();
 
     if args.statistics {
         // Statistics must still report parse errors and preserve a failing exit status.
+        let has_errors = !all_errors.is_empty();
         if has_errors {
-            let mut stdout = std::io::stdout();
             FullEmitter.emit(&mut stdout, &[], &all_errors)?;
         }
 
         return print_statistics(&all_diagnostics_flat, has_errors, parent_config_path);
     }
-
-    let mut stdout = std::io::stdout();
 
     match args.output_format {
         OutputFormat::Concise => {

--- a/crates/jarl/src/statistics.rs
+++ b/crates/jarl/src/statistics.rs
@@ -6,9 +6,14 @@ use crate::status::ExitStatus;
 
 pub fn print_statistics(
     diagnostics: &[&Diagnostic],
+    has_errors: bool,
     parent_config_path: Option<PathBuf>,
 ) -> anyhow::Result<ExitStatus> {
     if diagnostics.is_empty() {
+        if has_errors {
+            return Ok(ExitStatus::Error);
+        }
+
         println!("All checks passed!");
         return Ok(ExitStatus::Success);
     }
@@ -57,5 +62,9 @@ pub fn print_statistics(
         println!("\nUsed '{}'", config_path.display());
     }
 
-    Ok(ExitStatus::Failure)
+    if has_errors {
+        Ok(ExitStatus::Error)
+    } else {
+        Ok(ExitStatus::Failure)
+    }
 }

--- a/crates/jarl/src/statistics.rs
+++ b/crates/jarl/src/statistics.rs
@@ -9,6 +9,7 @@ pub fn print_statistics(
     has_errors: bool,
     parent_config_path: Option<PathBuf>,
 ) -> anyhow::Result<ExitStatus> {
+    // Parse errors are not rule diagnostics, but they still make the check fail.
     if diagnostics.is_empty() {
         if has_errors {
             return Ok(ExitStatus::Error);

--- a/crates/jarl/tests/integration/statistics.rs
+++ b/crates/jarl/tests/integration/statistics.rs
@@ -81,6 +81,74 @@ fn test_stats_no_violation() -> anyhow::Result<()> {
 }
 
 #[test]
+fn test_stats_with_syntax_error() -> anyhow::Result<()> {
+    let case = CliTest::with_file("test.R", "repeat")?;
+
+    insta::assert_snapshot!(
+        &mut case
+            .command()
+            .arg("check")
+            .arg(".")
+            .arg("--statistics")
+            .run()
+            .normalize_os_executable_name(),
+        @"
+
+    success: false
+    exit_code: 255
+    ----- stdout -----
+
+    ----- stderr -----
+    error: expected an expression
+     --> test.R:1:7
+      |
+    1 | repeat
+      |       ^
+      |
+    "
+    );
+
+    Ok(())
+}
+
+#[test]
+fn test_stats_with_diagnostic_and_syntax_error() -> anyhow::Result<()> {
+    let case = CliTest::with_file("test.R", "any(is.na(x))\nrepeat")?;
+
+    insta::assert_snapshot!(
+        &mut case
+            .command()
+            .arg("check")
+            .arg(".")
+            .arg("--select")
+            .arg("any_is_na")
+            .arg("--statistics")
+            .run()
+            .normalize_os_executable_name(),
+        @"
+
+    success: false
+    exit_code: 255
+    ----- stdout -----
+        1 [ ] any_is_na
+
+    Rules with `[*]` have an automatic safe fix.
+    Rules with `[^]` have an automatic unsafe fix.
+
+    ----- stderr -----
+    error: expected an expression
+     --> test.R:2:7
+      |
+    2 | repeat
+      |       ^
+      |
+    "
+    );
+
+    Ok(())
+}
+
+#[test]
 fn test_hint_stats_arg() -> anyhow::Result<()> {
     let case = CliTest::with_file(
         "test.R",

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -84,7 +84,7 @@
 ### Bug fixes
 
 * `--statistics` now reports syntax errors and returns a non-zero status instead
-  of incorrectly reporting `All checks passed!` when parsing fails.
+  of incorrectly reporting `All checks passed!` when parsing fails (#577, @Yousa-Mirage).
 
 * `implicit_assignment` no longer flags chained assignments like
   `if (TRUE) a <- b <- 1`, aligning with `lintr` behavior (#480, @atsyplenkov).

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -83,6 +83,9 @@
 
 ### Bug fixes
 
+* `--statistics` now reports syntax errors and returns a non-zero status instead
+  of incorrectly reporting `All checks passed!` when parsing fails.
+
 * `implicit_assignment` no longer flags chained assignments like
   `if (TRUE) a <- b <- 1`, aligning with `lintr` behavior (#480, @atsyplenkov).
 


### PR DESCRIPTION
Now `--statistics` will only output `All checks passed!` and exit successfully when there are syntax errors in the file, whether there is a lint warning or not.

I think this is a bug because `jarl check` will report both syntax errors and lint warnings. `--statistics` should only change the output behavior but not hide syntax errors.

```r
x <- 1

if (x > ) {
  y <- 2
}

$ jarl check test.R --statistics
> All checks passed!
```