### PR TITLE
fix: Parse R version constraints in `DESCRIPTION`

### DIFF
--- a/crates/jarl-core/src/config.rs
+++ b/crates/jarl-core/src/config.rs
@@ -658,9 +658,14 @@ fn determine_minimum_r_version(
         if desc_path.exists() {
             let desc = fs::read_to_string(&desc_path)?;
             if let Ok(versions) = Description::get_depend_r_version(&desc)
-                && let Some(version_str) = versions.first()
+                // A DESCRIPTION can contain several constraints or an R-devel
+                // revision, so use the strictest numeric lower bound available.
+                && let Some(version) = versions
+                    .into_iter()
+                    .filter_map(|version| parse_r_version(version).ok())
+                    .max()
             {
-                return Ok(Some(parse_r_version(version_str.to_string())?));
+                return Ok(Some(version));
             }
         }
     }

--- a/crates/jarl-core/src/description.rs
+++ b/crates/jarl-core/src/description.rs
@@ -62,23 +62,19 @@ impl Description {
     }
 }
 
-/// Extract version number from an R dependency string like "R (>= 4.3.0)"
+/// Extract a minimum version from an R dependency string like "R (>= 4.3.0)".
 fn extract_version_from_dependency(dep: &str) -> Option<String> {
-    // Look for version requirement in parentheses
-    if let Some(start) = dep.find('(')
-        && let Some(end) = dep.find(')')
-    {
-        let version_part = &dep[start + 1..end];
-        // Remove >= operator and extract just the version number
-        let version = version_part.replace(">=", "").trim().to_string();
+    let start = dep.find('(')?;
+    let end = dep[start + 1..].find(')')? + start + 1;
+    let requirement = dep[start + 1..end].trim();
 
-        if !version.is_empty() {
-            return Some(version);
-        }
-    }
+    // Upper bounds do not establish the minimum R version of a project.
+    let version = [">=", ">", "=="]
+        .into_iter()
+        .find_map(|operator| requirement.strip_prefix(operator))?
+        .trim();
 
-    // R dependency exists but no version specified
-    unreachable!("DESCRIPTION cannot have 'R' without version in Depends field.")
+    (!version.is_empty()).then(|| version.to_string())
 }
 
 /// Parse a DCF (Debian Control File) format string into a key-value map
@@ -179,6 +175,50 @@ Depends: R (>= 4.2.0)
 "#;
         let result = Description::get_depend_r_version(description).unwrap();
         assert_eq!(result, vec!["4.2.0"]);
+    }
+
+    #[test]
+    fn test_depends_r_with_strict_lower_bound() {
+        let description = r#"
+Package: mypackage
+Version: 1.0.0
+Depends: R (> 4.0)
+"#;
+        let result = Description::get_depend_r_version(description).unwrap();
+        assert_eq!(result, vec!["4.0"]);
+    }
+
+    #[test]
+    fn test_depends_r_with_exact_version() {
+        let description = r#"
+Package: mypackage
+Version: 1.0.0
+Depends: R (== 4.2.0)
+"#;
+        let result = Description::get_depend_r_version(description).unwrap();
+        assert_eq!(result, vec!["4.2.0"]);
+    }
+
+    #[test]
+    fn test_depends_r_with_upper_bound() {
+        let description = r#"
+Package: mypackage
+Version: 1.0.0
+Depends: R (< 4.2.0), R (<= 4.3.0)
+"#;
+        let result = Description::get_depend_r_version(description).unwrap();
+        assert!(result.is_empty());
+    }
+
+    #[test]
+    fn test_depends_r_with_malformed_constraint() {
+        let description = r#"
+Package: mypackage
+Version: 1.0.0
+Depends: R ()
+"#;
+        let result = Description::get_depend_r_version(description).unwrap();
+        assert!(result.is_empty());
     }
 
     #[test]

--- a/crates/jarl/tests/integration/min_r_version.rs
+++ b/crates/jarl/tests/integration/min_r_version.rs
@@ -155,3 +155,136 @@ Depends: R (>= 4.6.0), utils, stats"#,
 
     Ok(())
 }
+
+#[test]
+fn test_min_r_version_from_description_constraints() -> anyhow::Result<()> {
+    let case = CliTest::with_file("test.R", "grep('a.*', x, value = TRUE)")?;
+
+    // A strict lower bound still guarantees that grepv() is available.
+    case.write_file(
+        "DESCRIPTION",
+        r#"Package: mypackage
+Version: 1.0.0
+Depends: R (> 4.5.0)"#,
+    )?;
+    insta::assert_snapshot!(
+        &mut case
+            .command()
+            .arg("check")
+            .arg(".")
+            .run()
+            .normalize_os_executable_name(),
+        @"
+
+    success: false
+    exit_code: 1
+    ----- stdout -----
+    warning: grepv
+     --> test.R:1:1
+      |
+    1 | grep('a.*', x, value = TRUE)
+      | ---------------------------- `grep(..., value = TRUE)` can be simplified.
+      |
+      = help: Use `grepv(...)` instead.
+
+
+    ── Summary ──────────────────────────────────────
+    Found 1 error.
+    1 fixable with the `--fix` option.
+
+    ----- stderr -----
+    "
+    );
+
+    // Multiple lower bounds use the strictest version, regardless of order.
+    case.write_file(
+        "DESCRIPTION",
+        r#"Package: mypackage
+Version: 1.0.0
+Depends: R (>= 4.4.0), R (>= 4.6.0)"#,
+    )?;
+    insta::assert_snapshot!(
+        &mut case
+            .command()
+            .arg("check")
+            .arg(".")
+            .run()
+            .normalize_os_executable_name(),
+        @"
+
+    success: false
+    exit_code: 1
+    ----- stdout -----
+    warning: grepv
+     --> test.R:1:1
+      |
+    1 | grep('a.*', x, value = TRUE)
+      | ---------------------------- `grep(..., value = TRUE)` can be simplified.
+      |
+      = help: Use `grepv(...)` instead.
+
+
+    ── Summary ──────────────────────────────────────
+    Found 1 error.
+    1 fixable with the `--fix` option.
+
+    ----- stderr -----
+    "
+    );
+
+    // An upper bound cannot establish a minimum version, so version-gated
+    // rules remain disabled without aborting the check.
+    case.write_file(
+        "DESCRIPTION",
+        r#"Package: mypackage
+Version: 1.0.0
+Depends: R (< 5.0.0)"#,
+    )?;
+    insta::assert_snapshot!(
+        &mut case
+            .command()
+            .arg("check")
+            .arg(".")
+            .run()
+            .normalize_os_executable_name(),
+        @"
+
+    success: true
+    exit_code: 0
+    ----- stdout -----
+    ── Summary ──────────────────────────────────────
+    All checks passed!
+
+    ----- stderr -----
+    "
+    );
+
+    // R-devel revision constraints cannot be represented by Jarl's numeric
+    // version tuple and are ignored rather than causing the command to fail.
+    case.write_file(
+        "DESCRIPTION",
+        r#"Package: mypackage
+Version: 1.0.0
+Depends: R (>= r56550)"#,
+    )?;
+    insta::assert_snapshot!(
+        &mut case
+            .command()
+            .arg("check")
+            .arg(".")
+            .run()
+            .normalize_os_executable_name(),
+        @"
+
+    success: true
+    exit_code: 0
+    ----- stdout -----
+    ── Summary ──────────────────────────────────────
+    All checks passed!
+
+    ----- stderr -----
+    "
+    );
+
+    Ok(())
+}

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -84,7 +84,7 @@
 ### Bug fixes
 
 * Valid R version constraints in `DESCRIPTION`, such as `R (> 4.0)`, no longer
-  cause Jarl to fail while determining which version-specific rules to enable.
+  cause Jarl to fail (#578, @Yousa-Mirage).
 
 * `implicit_assignment` no longer flags chained assignments like
   `if (TRUE) a <- b <- 1`, aligning with `lintr` behavior (#480, @atsyplenkov).

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -83,6 +83,9 @@
 
 ### Bug fixes
 
+* Valid R version constraints in `DESCRIPTION`, such as `R (> 4.0)`, no longer
+  cause Jarl to fail while determining which version-specific rules to enable.
+
 * `implicit_assignment` no longer flags chained assignments like
   `if (TRUE) a <- b <- 1`, aligning with `lintr` behavior (#480, @atsyplenkov).
 


### PR DESCRIPTION
`Depends: R (> 4.0)` is a legal R version constraint. But now this will cause jarl failure:

```r
# tmp/DESCRIPTION
Package: repro
Version: 1.0.0
Depends: R (> 4.0)

# tmp/dev.r
x <- 1
```

```bash
$ jarl check tmp
# jarl failed
#   Cause: Major version should be a valid integer
```

This PR added support to `>=, >, ==`. Returns None if the format is abnormal.