### PR TITLE
fix: Ensure that `--fix-only` doesn't apply unsafe fixes

### DIFF
--- a/crates/jarl-core/src/config.rs
+++ b/crates/jarl-core/src/config.rs
@@ -64,7 +64,7 @@ pub struct Config {
     /// field `rules`. If we apply fixes too, then this might be different from
     /// `rules` because it may filter out rules that have unsafe fixes.
     pub rules_to_apply: RuleSet,
-    /// Did the user pass the --fix flag?
+    /// Whether safe fixes should be applied.
     pub apply_fixes: bool,
     /// Did the user pass the --unsafe-fixes flag?
     pub apply_unsafe_fixes: bool,
@@ -118,9 +118,10 @@ pub fn build_config(
     // These will be stored in Config and checked when applying fixes.
     let (fixable_toml, unfixable_toml) = parse_fixable_toml(toml_settings)?;
 
-    // Resolve the interaction between --fix and --unsafe-fixes first. Using
-    // --unsafe-fixes implies using --fix, but the opposite is not true.
-    let rules_to_apply = match (check_config.fix, check_config.unsafe_fixes) {
+    // --fix-only implies --fix, while --unsafe-fixes controls which fixes can
+    // be applied independently of how fix mode was enabled.
+    let apply_fixes = check_config.fix || check_config.fix_only;
+    let rules_to_apply = match (apply_fixes, check_config.unsafe_fixes) {
         (false, false) => rules.clone(),
 
         (true, false) => rules
@@ -138,7 +139,7 @@ pub fn build_config(
     // --fix-only. This could maybe be done above but dealing with the three
     // args at the same time makes it much more complex.
     let rules_to_apply = if check_config.fix_only {
-        rules
+        rules_to_apply
             .iter()
             .filter(|r| !r.has_no_fix())
             .collect::<RuleSet>()
@@ -171,7 +172,7 @@ pub fn build_config(
         paths,
         rules,
         rules_to_apply,
-        apply_fixes: check_config.fix,
+        apply_fixes,
         apply_unsafe_fixes: check_config.unsafe_fixes,
         minimum_r_version,
         allow_dirty: check_config.allow_dirty,

--- a/crates/jarl/tests/integration/jarl.rs
+++ b/crates/jarl/tests/integration/jarl.rs
@@ -491,14 +491,16 @@ fn test_corner_case() -> anyhow::Result<()> {
 #[test]
 fn test_fix_options() -> anyhow::Result<()> {
     // File with 3 lints:
-    // - any_is_na (has fix)
-    // - class_equals (has unsafe fix)
+    // - any_is_na (has safe fix)
+    // - all_equal (has unsafe fix)
     // - duplicated_arguments (has no fix)
     let case = CliTest::with_file(
         "test.R",
-        "any(is.na(x))\nclass(x) == 'foo'\nlist(x = 1, x = 2)",
+        "any(is.na(x))\n!all.equal(x, y)\nlist(x = 1, x = 2)",
     )?;
-    let test_contents = "any(is.na(x))\nclass(x) == 'foo'\nlist(x = 1, x = 2)";
+    let test_contents = "any(is.na(x))\n!all.equal(x, y)\nlist(x = 1, x = 2)";
+    let safe_fixed_contents = "anyNA(x)\n!all.equal(x, y)\nlist(x = 1, x = 2)";
+    let all_fixed_contents = "anyNA(x)\n!isTRUE(all.equal(x, y))\nlist(x = 1, x = 2)";
 
     insta::assert_snapshot!(
         &mut case
@@ -528,6 +530,7 @@ fn test_fix_options() -> anyhow::Result<()> {
     ----- stderr -----
     "#
     );
+    assert_eq!(case.read_file("test.R")?, safe_fixed_contents);
 
     case.write_file("test.R", test_contents)?;
     insta::assert_snapshot!(
@@ -559,6 +562,7 @@ fn test_fix_options() -> anyhow::Result<()> {
     ----- stderr -----
     "#
     );
+    assert_eq!(case.read_file("test.R")?, all_fixed_contents);
 
     case.write_file("test.R", test_contents)?;
     insta::assert_snapshot!(
@@ -583,6 +587,7 @@ fn test_fix_options() -> anyhow::Result<()> {
     ----- stderr -----
     "
     );
+    assert_eq!(case.read_file("test.R")?, all_fixed_contents);
 
     case.write_file("test.R", test_contents)?;
     insta::assert_snapshot!(
@@ -606,6 +611,30 @@ fn test_fix_options() -> anyhow::Result<()> {
     ----- stderr -----
     "
     );
+    assert_eq!(case.read_file("test.R")?, safe_fixed_contents);
+
+    case.write_file("test.R", test_contents)?;
+    insta::assert_snapshot!(
+        &mut case
+            .command()
+            .arg("check")
+            .arg(".")
+            .arg("--fix-only")
+            .arg("--allow-no-vcs")
+            .run()
+            .normalize_os_executable_name(),
+        @"
+
+    success: true
+    exit_code: 0
+    ----- stdout -----
+    ── Summary ──────────────────────────────────────
+    All checks passed!
+
+    ----- stderr -----
+    "
+    );
+    assert_eq!(case.read_file("test.R")?, safe_fixed_contents);
 
     case.write_file("test.R", test_contents)?;
     insta::assert_snapshot!(
@@ -629,6 +658,7 @@ fn test_fix_options() -> anyhow::Result<()> {
     ----- stderr -----
     "
     );
+    assert_eq!(case.read_file("test.R")?, all_fixed_contents);
 
     Ok(())
 }

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -83,7 +83,7 @@
 
 ### Bug fixes
 
-* `--fix-only` now implies `--fix` and no longer applies unsafe fixes by default.
+* `--fix-only` now implies `--fix` and no longer applies unsafe fixes by default (#579, @Yousa-Mirage).
 
 * `implicit_assignment` no longer flags chained assignments like
   `if (TRUE) a <- b <- 1`, aligning with `lintr` behavior (#480, @atsyplenkov).

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -83,6 +83,8 @@
 
 ### Bug fixes
 
+* `--fix-only` now implies `--fix` and no longer applies unsafe fixes by default.
+
 * `implicit_assignment` no longer flags chained assignments like
   `if (TRUE) a <- b <- 1`, aligning with `lintr` behavior (#480, @atsyplenkov).
 


### PR DESCRIPTION
The behavior of `--fix-only` is incorrect. When only `jarl check . --fix-only` is used, the fix isn't actually applied. However, when use `jarl check . --fix --fix-only`, unsafe fixes are applied accidentally. For example:

```r
!all.equal(x, y)  # Have an unsafe fix
!(x > y)  # Have a safe fix
```

After `jarl check . --fix-only`, jarl just reports lints without auto-fix. But after `jarl check . --fix --fix-only`, both are fixed:

```r
!isTRUE(all.equal(x, y))  # Have an unsafe fix
x <= y  # Have a safe fix
```

This PR fixed this issue by using `check_config.fix || check_config.fix_only`.