### PR TITLE
refactor: Handle `..` in sourced paths in semantic analysis

### DIFF
--- a/crates/jarl-core/src/lints/base/unused_object/mod.rs
+++ b/crates/jarl-core/src/lints/base/unused_object/mod.rs
@@ -1850,7 +1850,7 @@ while (cond) {
             @"All checks passed!"
         );
     }
-  
+
     #[test]
     fn test_lint_shadowed_source_does_not_read_the_file() {
         // `source` is a local function here, so the call runs that function,
@@ -1878,7 +1878,8 @@ while (cond) {
         assert_snapshot!(
             snapshot_lint_with_sourced_files(
                 "x <- 1\nsource(\"sub/../main.R\")\n",
-                &[("sub/other.R", "print(1)")],
+                &[("sub/other.R", "print(1)")]
+            ),
             @r"
         warning: unused_object
          --> <test>:1:1
@@ -1890,7 +1891,7 @@ while (cond) {
         "
         );
     }
-    
+
     #[test]
     fn test_lint_sourced_file_in_its_own_environment() {
         // A non-literal `local =` runs the helper in an environment that

--- a/crates/jarl-core/src/lints/base/unused_object/mod.rs
+++ b/crates/jarl-core/src/lints/base/unused_object/mod.rs
@@ -63,7 +63,8 @@ mod tests {
     /// Lints `main.R` inside a fresh tempdir after populating that directory
     /// with the named (filename, content) pairs, and renders diagnostics as
     /// a snapshot string. Used for `source()` resolution tests where the
-    /// sourced file lives next to the linted file.
+    /// sourced file lives next to the linted file. A name may contain
+    /// directories (`sub/helper.R`), which are created as needed.
     fn snapshot_lint_with_sourced_files(main: &str, files: &[(&str, &str)]) -> String {
         use std::fs;
 
@@ -71,7 +72,11 @@ mod tests {
         let main_path = dir.path().join("main.R");
         fs::write(&main_path, main).expect("write main.R");
         for (name, content) in files {
-            fs::write(dir.path().join(name), content).expect("write sourced file");
+            let path = dir.path().join(name);
+            if let Some(parent) = path.parent() {
+                fs::create_dir_all(parent).expect("create sourced file directory");
+            }
+            fs::write(path, content).expect("write sourced file");
         }
         snapshot_unused_object_at(&main_path, main)
     }
@@ -1830,6 +1835,41 @@ while (cond) {
                 &[("helper.R", "print(x + 1)")],
             ),
             @"All checks passed!"
+        );
+    }
+
+    #[test]
+    fn test_no_lint_sourced_file_reached_through_parent_dir() {
+        // `sub/../helper.R` names the same file as `helper.R`; normalizing the
+        // path must not stop it from resolving.
+        assert_snapshot!(
+            snapshot_lint_with_sourced_files(
+                "x <- 1\nsource(\"sub/../helper.R\")\n",
+                &[("helper.R", "print(x + 1)"), ("sub/other.R", "print(1)")],
+            ),
+            @"All checks passed!"
+        );
+    }
+
+    #[test]
+    fn test_self_source_through_parent_dir_stops_at_the_cycle_guard() {
+        // A file sourcing itself through `..` used to mint a new cycle key at
+        // every level (`sub/..` appended again and again), so the chain only
+        // stopped at PATH_MAX after hundreds of redundant parses.
+        assert_snapshot!(
+            snapshot_lint_with_sourced_files(
+                "x <- 1\nsource(\"sub/../main.R\")\n",
+                &[("sub/other.R", "print(1)")],
+            ),
+            @r"
+        warning: unused_object
+         --> <test>:1:1
+          |
+        1 | x <- 1
+          | - Object `x` is defined but never used.
+          |
+        Found 1 error.
+        "
         );
     }
 

--- a/crates/jarl-core/src/lints/base/unused_object/mod.rs
+++ b/crates/jarl-core/src/lints/base/unused_object/mod.rs
@@ -1618,13 +1618,13 @@ x",
         // Also the case if y was defined before
         assert_snapshot!(
             snapshot_lint("
-y <- 2 
+y <- 2
 if (x && (y <- 1) > 2) {}"),
             @"
         warning: unused_object
          --> <test>:2:1
           |
-        2 | y <- 2 
+        2 | y <- 2
           | - Object `y` is defined but never used.
           |
         warning: unused_object
@@ -1853,9 +1853,7 @@ while (cond) {
 
     #[test]
     fn test_self_source_through_parent_dir_stops_at_the_cycle_guard() {
-        // A file sourcing itself through `..` used to mint a new cycle key at
-        // every level (`sub/..` appended again and again), so the chain only
-        // stopped at PATH_MAX after hundreds of redundant parses.
+        // Ensure that a file sourcing itself through `..`  doesn't stack overflow.
         assert_snapshot!(
             snapshot_lint_with_sourced_files(
                 "x <- 1\nsource(\"sub/../main.R\")\n",

--- a/crates/jarl-semantic/src/lib.rs
+++ b/crates/jarl-semantic/src/lib.rs
@@ -1201,8 +1201,9 @@ pub fn assignment_lhs_name(node: &RSyntaxNode) -> Option<String> {
 /// invoked — trying every level catches layouts like `jarl check foo` where
 /// `foo/sub/a.R` sources a file at `foo/` (the same reason oak's salsa
 /// resolver anchors at the workspace root). Lint paths are CWD-relative, so
-/// walking their ancestors down to `""` is exactly that chain and never
-/// escapes the CWD.
+/// walking their ancestors down to `""` is exactly that chain of anchors. The
+/// `source()` argument itself is unconstrained: a `../` in it resolves above
+/// the CWD, the same as it would when R runs the script.
 fn resolve_sourced_path(current_file: &std::path::Path, path: &str) -> Option<std::path::PathBuf> {
     let candidate = std::path::Path::new(path);
     if candidate.is_absolute() {
@@ -1373,6 +1374,46 @@ impl oak_semantic::ImportsResolver for JarlImportsResolver {
 /// Absolutize `path` against the process CWD, without touching the
 /// filesystem. Gives `source()` targets a canonical key so cycle detection
 /// and URL construction agree regardless of how the path was spelled.
+///
+/// `std::path::absolute` drops `.` but keeps `..`, so `sub/../a.R` and `a.R`
+/// would key differently and a self-`source()` spelled with `..` would slip
+/// past the cycle guard, minting a fresh key at every level of the chain.
+/// Popping `..` lexically makes both spellings collapse to the same key.
+///
+/// Lexical, not `canonicalize`: the key doubles as the `file://` URL the
+/// cross-file pass round-trips back to a lint path, so it has to stay the
+/// path as spelled rather than a symlink-resolved one (and it must work for
+/// targets that don't exist on disk). The trade-off is that `..` crossing a
+/// symlinked directory normalises to a path the OS wouldn't — the file is
+/// still read through the un-normalised path, so this only affects keying.
 fn absolutize_path(path: &std::path::Path) -> std::path::PathBuf {
-    std::path::absolute(path).unwrap_or_else(|_| path.to_path_buf())
+    let absolute = std::path::absolute(path).unwrap_or_else(|_| path.to_path_buf());
+    normalize_parent_dirs(&absolute)
+}
+
+/// Resolve `.` and `..` components lexically, without consulting the
+/// filesystem. A `..` with nothing to pop is kept: it's either a relative path
+/// climbing above its own root, or the filesystem root, where `..` is a no-op
+/// R would resolve the same way.
+fn normalize_parent_dirs(path: &std::path::Path) -> std::path::PathBuf {
+    use std::path::Component;
+
+    let mut normalized = std::path::PathBuf::new();
+    for component in path.components() {
+        match component {
+            Component::CurDir => {}
+            Component::ParentDir => {
+                if matches!(
+                    normalized.components().next_back(),
+                    Some(Component::Normal(_))
+                ) {
+                    normalized.pop();
+                } else if !normalized.has_root() {
+                    normalized.push(component);
+                }
+            }
+            other => normalized.push(other),
+        }
+    }
+    normalized
 }


### PR DESCRIPTION
If I have a folder `foo` that contains nothing and a file `foo.R` at the top level, doing `source("foo/../foo.R")` is valid but was wrongly handled.