### PR TITLE
feat: Support `unused_object` in Rmd / qmd

### DIFF
--- a/crates/jarl-core/src/check.rs
+++ b/crates/jarl-core/src/check.rs
@@ -567,9 +567,10 @@ fn get_checks_roxygen(
 ///
 /// Neither is linted — inline code is never analyzed, and a chunk that doesn't
 /// parse has nothing to analyze — but both *run*, so an object they read is
-/// used. The scan deliberately over-collects (it is the same text scan
-/// `unused_function` uses): a name harvested here can only silence a
-/// diagnostic, never raise one.
+/// used. A dropped chunk that wouldn't have run either (`eval = FALSE`) is
+/// left out on both counts. The scan deliberately over-collects (it is the
+/// same text scan `unused_function` uses): a name harvested here can only
+/// silence a diagnostic, never raise one.
 fn outside_chunk_reads(
     contents: &str,
     chunks: &[crate::rmd::RCodeChunk],
@@ -578,7 +579,11 @@ fn outside_chunk_reads(
     use crate::lints::base::unused_function::unused_function::scan_symbols;
 
     let inline = crate::rmd::extract_inline_r_code(contents, chunks);
-    let dropped = skipped.iter().map(|i| chunks[*i].code.as_str());
+    let dropped = skipped
+        .iter()
+        .map(|i| &chunks[*i])
+        .filter(|chunk| chunk.evaluated)
+        .map(|chunk| chunk.code.as_str());
 
     inline
         .into_iter()
@@ -600,8 +605,11 @@ fn outside_chunk_reads(
 /// Knitr evaluates every chunk of a document in one R session, in document
 /// order, which is exactly what the concatenation models — so use-def rules
 /// like `unused_object` see an object assigned in one chunk and read in a
-/// later one as used. Reads that happen outside the chunks are collected
-/// separately (see [`outside_chunk_reads`]).
+/// later one as used. The two ways a document departs from that model are
+/// handled explicitly: code that runs but isn't in the virtual source
+/// contributes reads (see [`outside_chunk_reads`]), and code that is in the
+/// virtual source but doesn't run (`eval = FALSE` chunks) contributes
+/// neither reads nor definitions.
 fn get_checks_rmd(
     contents: &str,
     file: &Path,
@@ -609,8 +617,12 @@ fn get_checks_rmd(
     source_cache: jarl_semantic::SourceIndexCache,
 ) -> Result<Vec<Diagnostic>> {
     let chunks = crate::rmd::extract_r_chunks(contents);
-    let crate::rmd::VirtualSource { source: virtual_source, offset_map, skipped } =
-        crate::rmd::build_virtual_r_source(&chunks);
+    let crate::rmd::VirtualSource {
+        source: virtual_source,
+        offset_map,
+        skipped,
+        unevaluated,
+    } = crate::rmd::build_virtual_r_source(&chunks);
 
     if virtual_source.trim().is_empty() {
         return Ok(Vec::new());
@@ -626,6 +638,9 @@ fn get_checks_rmd(
     checker.minimum_r_version = config.minimum_r_version;
     checker.file_path = file.to_path_buf();
     checker.source_index_cache = source_cache.clone();
+    // A chunk marked `eval = FALSE` is still linted, but it never runs, so it
+    // defines nothing and reads nothing.
+    checker.unevaluated_ranges = unevaluated;
 
     // The document's own path anchors `source()` resolution, so a chunk
     // sourcing a helper next to the document resolves it there.

--- a/crates/jarl-core/src/check.rs
+++ b/crates/jarl-core/src/check.rs
@@ -211,7 +211,14 @@ pub fn get_checks(
     use_cached_index: bool,
 ) -> Result<Vec<Diagnostic>> {
     if crate::fs::has_rmd_extension(file) {
-        return get_checks_rmd(contents, file, config);
+        // Same cache validity rule as the per-file indices below: shareable
+        // while the run's caches match the disk, fresh when they may drift.
+        let source_cache = if use_cached_index {
+            pkg.source_index_cache.clone()
+        } else {
+            jarl_semantic::SourceIndexCache::new()
+        };
+        return get_checks_rmd(contents, file, config, source_cache);
     }
 
     let parser_options = RParserOptions::default();
@@ -457,16 +464,20 @@ fn get_package_info(
                 checker.namespace_exports = ctx.namespace_exports.clone();
             }
         }
-        _ => {
-            let mut packages: Vec<String> = crate::checker::DEFAULT_PACKAGES
-                .iter()
-                .map(|s| s.to_string())
-                .collect();
-            packages.extend(top_level_attached_packages(semantic));
-            checker.loaded_packages = packages;
-        }
+        _ => checker.loaded_packages = script_packages(semantic),
     }
     checker.package_cache = config.package_cache.clone();
+}
+
+/// The packages a file outside an R package can reach: the always-available
+/// defaults plus whatever it attaches itself.
+fn script_packages(semantic: &oak_semantic::semantic_index::SemanticIndex) -> Vec<String> {
+    let mut packages: Vec<String> = crate::checker::DEFAULT_PACKAGES
+        .iter()
+        .map(|s| s.to_string())
+        .collect();
+    packages.extend(top_level_attached_packages(semantic));
+    packages
 }
 
 /// Collect the packages a file attaches with `library()`/`require()`, in load
@@ -550,6 +561,32 @@ fn get_checks_roxygen(
     Ok(all_diagnostics)
 }
 
+/// Names read by R code that is part of the document but absent from the
+/// virtual source: inline spans in the prose (`` `r mean(x)` ``) and chunks
+/// dropped because they don't parse.
+///
+/// Neither is linted — inline code is never analyzed, and a chunk that doesn't
+/// parse has nothing to analyze — but both *run*, so an object they read is
+/// used. The scan deliberately over-collects (it is the same text scan
+/// `unused_function` uses): a name harvested here can only silence a
+/// diagnostic, never raise one.
+fn outside_chunk_reads(
+    contents: &str,
+    chunks: &[crate::rmd::RCodeChunk],
+    skipped: &[usize],
+) -> std::collections::HashSet<String> {
+    use crate::lints::base::unused_function::unused_function::scan_symbols;
+
+    let inline = crate::rmd::extract_inline_r_code(contents, chunks);
+    let dropped = skipped.iter().map(|i| chunks[*i].code.as_str());
+
+    inline
+        .into_iter()
+        .chain(dropped)
+        .flat_map(|code| scan_symbols(code).into_keys())
+        .collect()
+}
+
 /// Lint an Rmd/Qmd file by concatenating R code chunks into a virtual R
 /// string and running the normal linting pipeline on it.
 ///
@@ -557,11 +594,23 @@ fn get_checks_roxygen(
 /// - No autofix (Quarto code annotations make position-based edits unsafe)
 /// - `#| jarl-ignore-chunk:` YAML blocks are translated to `# jarl-ignore-start`
 ///   / `# jarl-ignore-end` pairs before linting
-/// - Chunks with parse errors are silently dropped
+/// - Chunks with parse errors are dropped, without a diagnostic of their own
 /// - Diagnostic ranges are remapped from virtual-string offsets to original file offsets
-fn get_checks_rmd(contents: &str, file: &Path, config: &Config) -> Result<Vec<Diagnostic>> {
+///
+/// Knitr evaluates every chunk of a document in one R session, in document
+/// order, which is exactly what the concatenation models — so use-def rules
+/// like `unused_object` see an object assigned in one chunk and read in a
+/// later one as used. Reads that happen outside the chunks are collected
+/// separately (see [`outside_chunk_reads`]).
+fn get_checks_rmd(
+    contents: &str,
+    file: &Path,
+    config: &Config,
+    source_cache: jarl_semantic::SourceIndexCache,
+) -> Result<Vec<Diagnostic>> {
     let chunks = crate::rmd::extract_r_chunks(contents);
-    let (virtual_source, offset_map) = crate::rmd::build_virtual_r_source(&chunks);
+    let crate::rmd::VirtualSource { source: virtual_source, offset_map, skipped } =
+        crate::rmd::build_virtual_r_source(&chunks);
 
     if virtual_source.trim().is_empty() {
         return Ok(Vec::new());
@@ -575,6 +624,19 @@ fn get_checks_rmd(contents: &str, file: &Path, config: &Config) -> Result<Vec<Di
     let mut checker = Checker::new(suppression, config.rule_options.clone());
     checker.rule_set = effective_rules_for_file(config, file);
     checker.minimum_r_version = config.minimum_r_version;
+    checker.file_path = file.to_path_buf();
+    checker.source_index_cache = source_cache.clone();
+
+    // The document's own path anchors `source()` resolution, so a chunk
+    // sourcing a helper next to the document resolves it there.
+    let semantic = oak_semantic::build_index(
+        &parsed.tree(),
+        jarl_semantic::JarlImportsResolver::with_cache(file, source_cache),
+    );
+    // A document is never package code, so it reaches the same packages a
+    // script does: the defaults plus what its chunks attach.
+    checker.loaded_packages = script_packages(&semantic);
+    checker.package_cache = config.package_cache.clone();
 
     let expressions = &parsed.tree().expressions();
     for expr in expressions {
@@ -582,13 +644,19 @@ fn get_checks_rmd(contents: &str, file: &Path, config: &Config) -> Result<Vec<Di
     }
     // check_document runs suppression filtering internally, so
     // checker.diagnostics is the post-suppression list after this call.
-    // Rmd chunks don't participate in package-level analysis.
+    // Rmd chunks don't participate in package-level analysis; the one
+    // package-level input that does apply is the set of names read outside the
+    // chunks, which keeps objects the prose uses from looking unused.
+    let package_file = PackageFileAnalysis {
+        cross_file_used: outside_chunk_reads(contents, &chunks, &skipped),
+        ..PackageFileAnalysis::default()
+    };
     check_document(
         expressions,
         &syntax,
         &mut checker,
-        &PackageFileAnalysis::default(),
-        None,
+        &package_file,
+        Some(&semantic),
     )?;
 
     // Remap ranges from virtual-string offsets to original Rmd file offsets.

--- a/crates/jarl-core/src/check.rs
+++ b/crates/jarl-core/src/check.rs
@@ -602,10 +602,10 @@ fn reads_outside_chunk_code(
     names
 }
 
-/// Every identifier-shaped word in `code`, whatever it stands for. The text
-/// scan `unused_function` uses, which over-collects by design.
+/// Every identifier-shaped word in `code`, whatever it stands for.
+/// [`scan_symbols`] over-collects by design; see there.
 fn all_symbols(code: &str) -> impl Iterator<Item = String> {
-    crate::lints::base::unused_function::unused_function::scan_symbols(code).into_keys()
+    scan_symbols(code).into_keys()
 }
 
 /// The names `code` *reads*, leaving out the names of named arguments — for

--- a/crates/jarl-core/src/check.rs
+++ b/crates/jarl-core/src/check.rs
@@ -561,22 +561,27 @@ fn get_checks_roxygen(
     Ok(all_diagnostics)
 }
 
-/// Names read by R code that is part of the document but absent from the
-/// virtual source: inline spans in the prose (`` `r mean(x)` ``) and chunks
-/// dropped because they don't parse.
+/// Names read by R code that belongs to the document but isn't in the virtual
+/// source, and so is invisible to the use-def analysis:
 ///
-/// Neither is linted — inline code is never analyzed, and a chunk that doesn't
-/// parse has nothing to analyze — but both *run*, so an object they read is
-/// used. A dropped chunk that wouldn't have run either (`eval = FALSE`) is
-/// left out on both counts. The scan deliberately over-collects (it is the
-/// same text scan `unused_function` uses): a name harvested here can only
-/// silence a diagnostic, never raise one.
-fn outside_chunk_reads(
+/// - inline spans in the prose (`` `r mean(x)` ``), which aren't linted but do
+///   run when the document is rendered;
+/// - chunks dropped because they don't parse, which have nothing to analyze
+///   but still run — unless they wouldn't have run anyway (`eval = FALSE`),
+///   in which case they are left out here too;
+/// - chunk options (`{r, fig.cap = my_caption}`, `#| eval: !expr run_it`),
+///   which knitr evaluates for *every* chunk, including one whose own code
+///   never runs.
+///
+/// An object named in any of them is used. Erring towards collecting too many
+/// names is deliberate: a name harvested here can only silence a diagnostic,
+/// whereas a read missed here invents one.
+fn reads_outside_chunk_code(
     contents: &str,
     chunks: &[crate::rmd::RCodeChunk],
     skipped: &[usize],
 ) -> std::collections::HashSet<String> {
-    use crate::lints::base::unused_function::unused_function::scan_symbols;
+    let mut names: std::collections::HashSet<String> = std::collections::HashSet::new();
 
     let inline = crate::rmd::extract_inline_r_code(contents, chunks);
     let dropped = skipped
@@ -584,11 +589,46 @@ fn outside_chunk_reads(
         .map(|i| &chunks[*i])
         .filter(|chunk| chunk.evaluated)
         .map(|chunk| chunk.code.as_str());
+    for code in inline.into_iter().chain(dropped) {
+        names.extend(all_symbols(code));
+    }
 
-    inline
-        .into_iter()
-        .chain(dropped)
-        .flat_map(|code| scan_symbols(code).into_keys())
+    for chunk in chunks {
+        for snippet in crate::rmd::chunk_option_code(chunk) {
+            names.extend(read_symbols(&snippet));
+        }
+    }
+
+    names
+}
+
+/// Every identifier-shaped word in `code`, whatever it stands for. The text
+/// scan `unused_function` uses, which over-collects by design.
+fn all_symbols(code: &str) -> impl Iterator<Item = String> {
+    crate::lints::base::unused_function::unused_function::scan_symbols(code).into_keys()
+}
+
+/// The names `code` *reads*, leaving out the names of named arguments — for
+/// chunk options, the difference between the object `fig.cap = my_caption`
+/// reads and the option it sets. Falls back to [`all_symbols`] when the
+/// snippet doesn't parse, since then the two can't be told apart and missing a
+/// read is the more damaging error.
+fn read_symbols(code: &str) -> Vec<String> {
+    let parsed = air_r_parser::parse(code, RParserOptions::default());
+    if parsed.has_error() {
+        return all_symbols(code).collect();
+    }
+
+    parsed
+        .syntax()
+        .descendants()
+        .filter(|node| node.kind() == air_r_syntax::RSyntaxKind::R_IDENTIFIER)
+        .filter(|node| {
+            node.parent().is_none_or(|parent| {
+                parent.kind() != air_r_syntax::RSyntaxKind::R_ARGUMENT_NAME_CLAUSE
+            })
+        })
+        .map(|node| node.text_trimmed().to_string())
         .collect()
 }
 
@@ -607,7 +647,7 @@ fn outside_chunk_reads(
 /// like `unused_object` see an object assigned in one chunk and read in a
 /// later one as used. The two ways a document departs from that model are
 /// handled explicitly: code that runs but isn't in the virtual source
-/// contributes reads (see [`outside_chunk_reads`]), and code that is in the
+/// contributes reads (see [`reads_outside_chunk_code`]), and code that is in the
 /// virtual source but doesn't run (`eval = FALSE` chunks) contributes
 /// neither reads nor definitions.
 fn get_checks_rmd(
@@ -663,7 +703,7 @@ fn get_checks_rmd(
     // package-level input that does apply is the set of names read outside the
     // chunks, which keeps objects the prose uses from looking unused.
     let package_file = PackageFileAnalysis {
-        cross_file_used: outside_chunk_reads(contents, &chunks, &skipped),
+        cross_file_used: reads_outside_chunk_code(contents, &chunks, &skipped),
         ..PackageFileAnalysis::default()
     };
     check_document(

--- a/crates/jarl-core/src/checker.rs
+++ b/crates/jarl-core/src/checker.rs
@@ -83,6 +83,10 @@ pub struct Checker {
     // consumer. Fresh (empty) when the on-disk contents may drift from the
     // run's caches (fix mode, LSP buffers).
     pub source_index_cache: jarl_semantic::SourceIndexCache,
+    // Ranges of the file that are parsed but never evaluated, so use-def
+    // rules must not read a definition or a use out of them. Only Rmd/Qmd
+    // documents have any: the chunks marked `eval = FALSE`.
+    pub unevaluated_ranges: Vec<biome_rowan::TextRange>,
 }
 
 impl Checker {
@@ -102,6 +106,7 @@ impl Checker {
             namespace_exports: HashSet::new(),
             file_path: std::path::PathBuf::new(),
             source_index_cache: jarl_semantic::SourceIndexCache::new(),
+            unevaluated_ranges: Vec::new(),
         }
     }
 

--- a/crates/jarl-core/src/lints/base/unused_function/mod.rs
+++ b/crates/jarl-core/src/lints/base/unused_function/mod.rs
@@ -96,60 +96,6 @@ mod tests {
         assert!(exports.contains("sort_by"));
     }
 
-    // ── scan_symbols ─────────────────────────────────────────────────────
-
-    #[test]
-    fn test_scan_symbols_from_calls() {
-        let syms = scan_symbols("foo(1)\nbar(x, y)\n");
-        assert!(syms.contains_key("foo"));
-        assert!(syms.contains_key("bar"));
-        assert!(syms.contains_key("x"));
-        assert!(syms.contains_key("y"));
-    }
-
-    #[test]
-    fn test_scan_symbols_from_assignments() {
-        let syms = scan_symbols("x <- 1\ny + z\n");
-        assert!(syms.contains_key("x"));
-        assert!(syms.contains_key("y"));
-        assert!(syms.contains_key("z"));
-    }
-
-    #[test]
-    fn test_scan_symbols_nested() {
-        let syms = scan_symbols("outer(inner(x))\n");
-        assert!(syms.contains_key("outer"));
-        assert!(syms.contains_key("inner"));
-        assert!(syms.contains_key("x"));
-    }
-
-    #[test]
-    fn test_scan_symbols_ignores_comments() {
-        let syms = scan_symbols("# foo(bar)\nreal()\n");
-        assert!(!syms.contains_key("foo"));
-        assert!(!syms.contains_key("bar"));
-        assert!(syms.contains_key("real"));
-    }
-
-    #[test]
-    fn test_scan_symbols_ignores_indented_comments() {
-        let syms = scan_symbols("  # foo(bar)\n");
-        assert!(!syms.contains_key("foo"));
-    }
-
-    #[test]
-    fn test_scan_symbols_includes_roxygen_comments() {
-        let syms = scan_symbols("#' \\Sexpr[stage=render]{dplyr:::methods_rd(\"rows_insert\")}\n");
-        assert!(syms.contains_key("methods_rd"));
-    }
-
-    #[test]
-    fn test_scan_symbols_ignores_numbers() {
-        let syms = scan_symbols("123 + foo\n");
-        assert!(syms.contains_key("foo"));
-        assert!(!syms.contains_key("123"));
-    }
-
     // ── compute_unused_from_shared ──────────────────────────────────
 
     fn default_options() -> ResolvedUnusedFunctionOptions {

--- a/crates/jarl-core/src/lints/base/unused_function/unused_function.rs
+++ b/crates/jarl-core/src/lints/base/unused_function/unused_function.rs
@@ -57,109 +57,12 @@ use crate::package::{FileScope, SharedFileData};
 /// # `check_length()` isn't exported but and isn't used anywhere, so it is
 /// # reported.
 /// ```
-pub fn scan_symbols(content: &str) -> HashMap<String, usize> {
-    // Scan source text for all R-style identifiers (symbols).
-    //
-    // Returns a map from identifier name to occurrence count. This intentionally
-    // over-counts (e.g. it will match inside comments and strings) — that is fine
-    // because false negatives (failing to flag truly unused functions) are
-    // preferable to false positives. By collecting all symbols rather than just
-    // `name(` call patterns, we also cover indirect references like
-    // `do.call("name", ...)`, `lapply(xs, name)`, `match.fun(name)`, etc.
-    let mut symbols: HashMap<&str, usize> = HashMap::new();
-
-    for line in content.lines() {
-        let trimmed = line.trim_start();
-        // Skip regular comments but keep roxygen comments (#') since they
-        // may reference internal functions (e.g. via \Sexpr).
-        if trimmed.starts_with('#') && !trimmed.starts_with("#'") {
-            continue;
-        }
-
-        let bytes = line.as_bytes();
-        let len = bytes.len();
-        let mut i = 0;
-
-        while i < len {
-            let b = bytes[i];
-
-            // R identifiers start with a letter, `.`, or `_`
-            if b.is_ascii_alphabetic() || b == b'.' || b == b'_' {
-                let start = i;
-                i += 1;
-                while i < len
-                    && (bytes[i].is_ascii_alphanumeric() || bytes[i] == b'.' || bytes[i] == b'_')
-                {
-                    i += 1;
-                }
-                let name = &line[start..i];
-                *symbols.entry(name).or_insert(0) += 1;
-            } else {
-                i += 1;
-            }
-        }
-    }
-
-    symbols
-        .into_iter()
-        .map(|(k, v)| (k.to_string(), v))
-        .collect()
-}
-
-/// Recursively collect files under `dir` that match `predicate`.
-pub(crate) fn collect_files(dir: &Path, predicate: fn(&Path) -> bool) -> Vec<PathBuf> {
-    let mut files = Vec::new();
-    let mut stack = vec![dir.to_path_buf()];
-    while let Some(current) = stack.pop() {
-        let entries = match std::fs::read_dir(&current) {
-            Ok(entries) => entries,
-            Err(_) => continue,
-        };
-        for entry in entries.flatten() {
-            let path = entry.path();
-            if path.is_dir() {
-                stack.push(path);
-            } else if predicate(&path) {
-                files.push(path);
-            }
-        }
-    }
-    files
-}
-
-pub(crate) fn has_cpp_extension(path: &Path) -> bool {
-    matches!(
-        path.extension().and_then(|e| e.to_str()),
-        Some("c" | "cpp" | "h" | "hpp")
-    )
-}
-
-/// Extract a human-readable scope directory from a file path, e.g.
-/// `"tests/"` or `"inst/tests/"`. Used in help messages.
-fn scope_dir_from_path(rel_path: &Path) -> String {
-    let components: Vec<_> = rel_path
-        .components()
-        .map(|c| c.as_os_str().to_string_lossy().to_string())
-        .collect();
-    for (i, comp) in components.iter().enumerate() {
-        if comp == "tests" {
-            return "tests/".to_string();
-        }
-        if comp == "inst"
-            && let Some(next) = components.get(i + 1)
-            && (next == "tinytest" || next == "tests")
-        {
-            return format!("inst/{next}/");
-        }
-    }
-    "tests/".to_string()
-}
-
-/// Compute unused functions from pre-scanned shared file data.
 ///
-/// This is the inner logic extracted from `compute_package_unused_functions`,
-/// operating on already-scanned `SharedFileData` to avoid redundant file reads.
-/// Uses O(1) cross-file symbol lookup via pre-computed frequency maps.
+/// ## Implementation
+///
+/// Operates on the already-scanned `SharedFileData` of a package rather than
+/// reading its files again, and looks symbols up across files in O(1) through
+/// the pre-computed frequency maps.
 ///
 /// `namespace_contents` maps package root paths to their NAMESPACE file
 /// contents. Packages without a NAMESPACE entry are skipped.
@@ -366,4 +269,53 @@ pub(crate) fn compute_unused_from_shared(
     }
 
     result
+}
+
+/// Recursively collect files under `dir` that match `predicate`.
+pub(crate) fn collect_files(dir: &Path, predicate: fn(&Path) -> bool) -> Vec<PathBuf> {
+    let mut files = Vec::new();
+    let mut stack = vec![dir.to_path_buf()];
+    while let Some(current) = stack.pop() {
+        let entries = match std::fs::read_dir(&current) {
+            Ok(entries) => entries,
+            Err(_) => continue,
+        };
+        for entry in entries.flatten() {
+            let path = entry.path();
+            if path.is_dir() {
+                stack.push(path);
+            } else if predicate(&path) {
+                files.push(path);
+            }
+        }
+    }
+    files
+}
+
+pub(crate) fn has_cpp_extension(path: &Path) -> bool {
+    matches!(
+        path.extension().and_then(|e| e.to_str()),
+        Some("c" | "cpp" | "h" | "hpp")
+    )
+}
+
+/// Extract a human-readable scope directory from a file path, e.g.
+/// `"tests/"` or `"inst/tests/"`. Used in help messages.
+fn scope_dir_from_path(rel_path: &Path) -> String {
+    let components: Vec<_> = rel_path
+        .components()
+        .map(|c| c.as_os_str().to_string_lossy().to_string())
+        .collect();
+    for (i, comp) in components.iter().enumerate() {
+        if comp == "tests" {
+            return "tests/".to_string();
+        }
+        if comp == "inst"
+            && let Some(next) = components.get(i + 1)
+            && (next == "tinytest" || next == "tests")
+        {
+            return format!("inst/{next}/");
+        }
+    }
+    "tests/".to_string()
 }

--- a/crates/jarl-core/src/lints/base/unused_object/unused_object.rs
+++ b/crates/jarl-core/src/lints/base/unused_object/unused_object.rs
@@ -42,6 +42,7 @@ pub fn unused_object(
         semantic,
         &checker.source_index_cache,
         &checker.loaded_packages,
+        &checker.unevaluated_ranges,
     );
     let exports = &checker.namespace_exports;
 

--- a/crates/jarl-core/src/package.rs
+++ b/crates/jarl-core/src/package.rs
@@ -106,6 +106,12 @@ pub struct PackageAnalysis {
 pub struct PackageFileAnalysis {
     pub duplicate_assignments: Vec<(String, TextRange, String)>,
     pub unused_functions: Vec<(String, TextRange, String)>,
+    /// Top-level names read from outside the code being linted. For an R file
+    /// that is [`PackageAnalysis::cross_file_used`]; for an Rmd/Qmd document,
+    /// where only the R chunks are linted, it is instead the names read by the
+    /// rest of the document (see [`crate::check`]). Both are the same question
+    /// for `unused_object`: is this top-level binding read somewhere the file's
+    /// own analysis can't see?
     pub cross_file_used: HashSet<String>,
 }
 

--- a/crates/jarl-core/src/package.rs
+++ b/crates/jarl-core/src/package.rs
@@ -14,10 +14,11 @@ use crate::lints::base::duplicated_function_definition::duplicated_function_defi
     compute_duplicates_from_shared, scan_top_level_assignments,
 };
 use crate::lints::base::unused_function::unused_function::{
-    collect_files, compute_unused_from_shared, has_cpp_extension, scan_symbols,
+    collect_files, compute_unused_from_shared, has_cpp_extension,
 };
 use crate::namespace::{parse_namespace_exports, parse_namespace_imports};
 use crate::rule_set::Rule;
+use crate::utils::scan_symbols;
 
 /// Scope of a file within an R package, determining how its definitions
 /// are checked for unused functions.

--- a/crates/jarl-core/src/rmd/extraction.rs
+++ b/crates/jarl-core/src/rmd/extraction.rs
@@ -20,6 +20,15 @@ use crate::directive::{
 static OPEN_FENCE: LazyLock<Regex> =
     LazyLock::new(|| Regex::new(r"^[ \t]*(`{3,})\{[rR][^}]*\}").unwrap());
 
+/// Matches inline R code in prose: `` `r expr` ``.
+///
+/// Captures group 1: the R expression. The backtick-delimited span cannot
+/// itself contain a backtick, which also keeps the opening fence of a chunk
+/// (```` ```{r} ````) from matching — there the `r` is preceded by `{`, not by
+/// whitespace.
+static INLINE_CODE: LazyLock<Regex> =
+    LazyLock::new(|| Regex::new(r"`[rR][ \t\r\n]([^`]*)`").unwrap());
+
 /// An R code chunk extracted from an Rmd/Qmd document.
 #[derive(Debug)]
 pub struct RCodeChunk {
@@ -73,6 +82,34 @@ pub fn extract_r_chunks(content: &str) -> Vec<RCodeChunk> {
     }
 
     chunks
+}
+
+/// Extract the R expressions of inline code spans (`` `r expr` ``) written in
+/// the document's prose.
+///
+/// Two kinds of match are left out:
+/// - spans inside a code chunk, where a backtick pair is part of an R string
+///   (`glue("`r x`")`) rather than something the document evaluates;
+/// - spans whose opening backtick is itself preceded by one, which is the
+///   fence of a display-only ` ```r ` block, not an inline span.
+///
+/// `chunks` must be the output of [`extract_r_chunks`] for the same content,
+/// whose spans are ordered and non-overlapping.
+pub fn extract_inline_r_code<'a>(content: &'a str, chunks: &[RCodeChunk]) -> Vec<&'a str> {
+    INLINE_CODE
+        .captures_iter(content)
+        .filter(|caps| {
+            let start = caps.get(0).unwrap().start();
+            !in_a_chunk(start, chunks) && !content[..start].ends_with('`')
+        })
+        .map(|caps| caps.get(1).unwrap().as_str())
+        .collect()
+}
+
+/// Whether `offset` falls within the code of one of `chunks`.
+fn in_a_chunk(offset: usize, chunks: &[RCodeChunk]) -> bool {
+    let idx = chunks.partition_point(|c| c.start_byte + c.code.len() <= offset);
+    chunks.get(idx).is_some_and(|c| offset >= c.start_byte)
 }
 
 /// A segment mapping virtual-string byte positions to original-file byte positions.
@@ -214,19 +251,30 @@ fn find_chunk_ignore_blocks(code: &str) -> Vec<ChunkIgnoreBlock> {
     blocks
 }
 
+/// The concatenated R code of a document, plus what it took to build it.
+pub struct VirtualSource {
+    /// The virtual R source: every valid chunk's code, in document order.
+    pub source: String,
+    /// Maps offsets in `source` back to the original Rmd/Qmd file.
+    pub offset_map: OffsetMap,
+    /// Indices into the input chunks of the chunks left out because they have
+    /// parse errors. Their code is absent from `source`, so anything they read
+    /// is invisible to the analysis unless the caller accounts for it.
+    pub skipped: Vec<usize>,
+}
+
 /// Build a virtual R source string by concatenating all valid R chunks,
 /// translating `#| jarl-ignore-chunk:` YAML blocks into
 /// `# jarl-ignore-start` / `# jarl-ignore-end` pairs.
 ///
-/// Chunks with parse errors are silently dropped.
-///
-/// Returns the virtual source and an `OffsetMap` for remapping diagnostic
-/// byte offsets back to the original Rmd file.
-pub fn build_virtual_r_source(chunks: &[RCodeChunk]) -> (String, OffsetMap) {
+/// Chunks with parse errors are dropped, and reported in
+/// [`VirtualSource::skipped`].
+pub fn build_virtual_r_source(chunks: &[RCodeChunk]) -> VirtualSource {
     let mut virtual_src = String::new();
     let mut segments: Vec<Segment> = Vec::new();
+    let mut skipped: Vec<usize> = Vec::new();
 
-    for chunk in chunks {
+    for (i, chunk) in chunks.iter().enumerate() {
         // Skip empty chunks.
         if chunk.code.trim().is_empty() {
             continue;
@@ -235,6 +283,7 @@ pub fn build_virtual_r_source(chunks: &[RCodeChunk]) -> (String, OffsetMap) {
         // Pre-validate: skip chunks with parse errors.
         let parsed = air_r_parser::parse(&chunk.code, RParserOptions::default());
         if parsed.has_error() {
+            skipped.push(i);
             continue;
         }
 
@@ -267,7 +316,11 @@ pub fn build_virtual_r_source(chunks: &[RCodeChunk]) -> (String, OffsetMap) {
         }
     }
 
-    (virtual_src, OffsetMap { segments })
+    VirtualSource {
+        source: virtual_src,
+        offset_map: OffsetMap { segments },
+        skipped,
+    }
 }
 
 /// Emit a single chunk with YAML ignore blocks translated to start/end comments.
@@ -519,6 +572,77 @@ mod tests {
         let chunks = extract_r_chunks(content);
         assert_eq!(chunks.len(), 1);
         assert_eq!(chunks[0].code, "  any(is.na(1))\n");
+    }
+
+    // --- Inline R code ---
+
+    /// Extract the inline spans of `content`, in document order.
+    fn inline(content: &str) -> Vec<&str> {
+        let chunks = extract_r_chunks(content);
+        extract_inline_r_code(content, &chunks)
+    }
+
+    #[test]
+    fn test_inline_code_in_prose() {
+        assert_eq!(inline("The mean is `r mean(x)`.\n"), vec!["mean(x)"]);
+    }
+
+    #[test]
+    fn test_several_inline_spans_on_one_line() {
+        assert_eq!(inline("`r a` and `r b`\n"), vec!["a", "b"]);
+    }
+
+    #[test]
+    fn test_inline_code_spanning_lines() {
+        assert_eq!(inline("Value: `r mean(\n  x\n)`\n"), vec!["mean(\n  x\n)"]);
+    }
+
+    #[test]
+    fn test_capital_r_inline_code() {
+        assert_eq!(inline("`R x`\n"), vec!["x"]);
+    }
+
+    #[test]
+    fn test_inline_code_inside_a_chunk_ignored() {
+        // A backtick pair in chunk code is an R string, not an inline span.
+        let content = "```{r}\nglue(\"`r x`\")\n```\n";
+        assert!(inline(content).is_empty());
+    }
+
+    #[test]
+    fn test_inline_code_around_a_chunk() {
+        // Spans before and after a chunk are kept; the fences themselves and
+        // the chunk body are not spans.
+        let content = "`r before`\n\n```{r}\ny <- 1\n```\n\n`r after`\n";
+        assert_eq!(inline(content), vec!["before", "after"]);
+    }
+
+    #[test]
+    fn test_chunk_fence_is_not_inline_code() {
+        assert!(inline("```{r}\nx <- 1\n```\n").is_empty());
+    }
+
+    #[test]
+    fn test_display_only_r_block_is_not_inline_code() {
+        // ```r opens a display block, so its fences are not an inline span.
+        assert!(inline("```r\nx\n```\n").is_empty());
+    }
+
+    // --- Skipped chunks ---
+
+    #[test]
+    fn test_chunk_with_parse_error_is_reported_as_skipped() {
+        let content = "```{r}\nx <- 1\n```\n\n```{r}\nif (y\n```\n";
+        let chunks = extract_r_chunks(content);
+        let virtual_source = build_virtual_r_source(&chunks);
+        assert_eq!(virtual_source.skipped, vec![1]);
+        assert_eq!(virtual_source.source, "x <- 1\n");
+    }
+
+    #[test]
+    fn test_valid_chunks_are_not_reported_as_skipped() {
+        let chunks = extract_r_chunks("```{r}\nx <- 1\n```\n\n```{r}\n```\n");
+        assert!(build_virtual_r_source(&chunks).skipped.is_empty());
     }
 
     #[test]

--- a/crates/jarl-core/src/rmd/extraction.rs
+++ b/crates/jarl-core/src/rmd/extraction.rs
@@ -38,6 +38,12 @@ static HEADER_EVAL_FALSE: LazyLock<Regex> =
 static YAML_EVAL_FALSE: LazyLock<Regex> =
     LazyLock::new(|| Regex::new(r"(?i)^[ \t]*#\|[ \t]*eval[ \t]*:[ \t]*false[ \t]*$").unwrap());
 
+/// Matches a Quarto chunk option whose value is R code: `#| key: !expr code`.
+///
+/// Captures group 1: the R code after `!expr`.
+static YAML_EXPR_OPTION: LazyLock<Regex> =
+    LazyLock::new(|| Regex::new(r"^[ \t]*#\|[^:]*:[ \t]*!expr[ \t]+(.+?)[ \t]*$").unwrap());
+
 /// Matches inline R code in prose: `` `r expr` ``.
 ///
 /// Captures group 1: the R expression. The backtick-delimited span cannot
@@ -55,6 +61,9 @@ pub struct RCodeChunk {
     /// Byte offset in the original file where the chunk code starts.
     /// This is the byte immediately after the opening fence line's newline.
     pub start_byte: usize,
+    /// The chunk options as written in the opening fence, i.e. everything
+    /// between `{r` and `}` (`" my-chunk, echo = FALSE"`).
+    pub options: String,
     /// Whether the chunk runs when the document is rendered, i.e. whether it
     /// is *not* marked `eval = FALSE` (header form) or `#| eval: false`
     /// (Quarto form).
@@ -67,6 +76,14 @@ pub struct RCodeChunk {
     pub evaluated: bool,
 }
 
+/// A chunk being accumulated between its opening and closing fence.
+struct PendingChunk {
+    code: String,
+    start_byte: usize,
+    header_eval_false: bool,
+    options: String,
+}
+
 /// Extract all executable R code chunks from Rmd/Qmd content.
 ///
 /// Only fenced chunks whose opening line matches ` ```{r...} ` (any number of
@@ -77,33 +94,40 @@ pub fn extract_r_chunks(content: &str) -> Vec<RCodeChunk> {
     let mut chunks = Vec::new();
     let mut byte_offset: usize = 0;
 
-    // State: None = outside a chunk, Some((fence, code, start_byte,
-    // header_says_eval_false)) = inside.
-    let mut current: Option<(String, String, usize, bool)> = None;
+    // State: None = outside a chunk, Some(chunk being accumulated) = inside.
+    let mut current: Option<(String, PendingChunk)> = None;
 
     for line in content.split_inclusive('\n') {
         let mut finished = false;
 
-        if let Some((fence, code, start_byte, header_eval_false)) = current.as_mut() {
+        if let Some((fence, pending)) = current.as_mut() {
             if line.trim() == fence.as_str() {
                 // Closing fence found — emit the chunk.
-                let code = std::mem::take(code);
+                let code = std::mem::take(&mut pending.code);
                 chunks.push(RCodeChunk {
-                    evaluated: !*header_eval_false && !yaml_says_eval_false(&code),
+                    evaluated: !pending.header_eval_false && !yaml_says_eval_false(&code),
                     code,
-                    start_byte: *start_byte,
+                    start_byte: pending.start_byte,
+                    options: std::mem::take(&mut pending.options),
                 });
                 finished = true;
             } else {
-                code.push_str(line);
+                pending.code.push_str(line);
             }
         } else if let Some(caps) = OPEN_FENCE.captures(line) {
             // Opening fence found — start a new chunk.
             let fence = caps.get(1).unwrap().as_str().to_string();
-            let header_eval_false = HEADER_EVAL_FALSE.is_match(caps.get(2).unwrap().as_str());
-            // The chunk code starts immediately after this line.
-            let chunk_start_byte = byte_offset + line.len();
-            current = Some((fence, String::new(), chunk_start_byte, header_eval_false));
+            let options = caps.get(2).unwrap().as_str().to_string();
+            current = Some((
+                fence,
+                PendingChunk {
+                    code: String::new(),
+                    // The chunk code starts immediately after this line.
+                    start_byte: byte_offset + line.len(),
+                    header_eval_false: HEADER_EVAL_FALSE.is_match(&options),
+                    options,
+                },
+            ));
         }
 
         if finished {
@@ -125,6 +149,53 @@ fn yaml_says_eval_false(code: &str) -> bool {
     code.lines()
         .take_while(|line| line.trim_start().starts_with("#|"))
         .any(|line| YAML_EVAL_FALSE.is_match(line))
+}
+
+/// The R code found in a chunk's options, as snippets the caller can parse.
+///
+/// Both option forms can name an object: `{r, fig.cap = my_caption}` in the
+/// fence header, and `#| fig-cap: !expr my_caption` in Quarto's block. Knitr
+/// evaluates a chunk's options when it renders the chunk — that is how
+/// `eval = run_it` gets to decide anything — so this holds for every chunk,
+/// including one whose own code never runs.
+///
+/// The header snippet is wrapped as a call so that it parses as R, which lets
+/// the caller tell an option's *value* (`my_caption`, a read) from its *name*
+/// (`fig.cap`, not a read). Header options are R's named-argument syntax
+/// already, so the wrapping is all it takes. A leading chunk label is dropped:
+/// it is a bare word, often not even valid R (`{r my-chunk}`).
+pub fn chunk_option_code(chunk: &RCodeChunk) -> Vec<String> {
+    let mut snippets = Vec::new();
+
+    if let Some(options) = header_options_without_label(&chunk.options) {
+        snippets.push(format!("list({options})"));
+    }
+
+    snippets.extend(
+        chunk
+            .code
+            .lines()
+            .take_while(|line| line.trim_start().starts_with("#|"))
+            .filter_map(|line| YAML_EXPR_OPTION.captures(line))
+            .map(|caps| caps.get(1).unwrap().as_str().to_string()),
+    );
+
+    snippets
+}
+
+/// The chunk options with the leading label removed, or `None` when nothing
+/// but a label is left.
+fn header_options_without_label(options: &str) -> Option<&str> {
+    let rest = match options.split_once(',') {
+        // A first segment without `=` is the label, not an option.
+        Some((first, rest)) if !first.contains('=') => rest,
+        // A single segment without `=` is a label on its own.
+        None => return None,
+        _ => options,
+    };
+
+    let rest = rest.trim();
+    (!rest.is_empty()).then_some(rest)
 }
 
 /// Extract the R expressions of inline code spans (`` `r expr` ``) written in
@@ -804,6 +875,73 @@ mod tests {
         assert_eq!(
             &content[chunks[1].start_byte..chunks[1].start_byte + 6],
             "b <- 2"
+        );
+    }
+
+    // --- Chunk options ---
+
+    /// The option snippets of the single chunk in `content`.
+    fn option_code(content: &str) -> Vec<String> {
+        let chunks = extract_r_chunks(content);
+        assert_eq!(chunks.len(), 1, "expected exactly one chunk");
+        chunk_option_code(&chunks[0])
+    }
+
+    #[test]
+    fn test_header_options_are_wrapped_as_a_call() {
+        assert_eq!(
+            option_code("```{r, fig.cap = my_caption}\nx <- 1\n```\n"),
+            vec!["list(fig.cap = my_caption)"]
+        );
+    }
+
+    #[test]
+    fn test_header_label_is_dropped() {
+        // A label is a bare word, and `my-chunk` isn't even valid R.
+        assert_eq!(
+            option_code("```{r my-chunk, eval = run_it}\nx <- 1\n```\n"),
+            vec!["list(eval = run_it)"]
+        );
+    }
+
+    #[test]
+    fn test_header_with_only_a_label_has_no_option_code() {
+        assert!(option_code("```{r my-chunk}\nx <- 1\n```\n").is_empty());
+        assert!(option_code("```{r}\nx <- 1\n```\n").is_empty());
+    }
+
+    #[test]
+    fn test_header_option_value_may_contain_a_comma() {
+        assert_eq!(
+            option_code("```{r, fig.cap = paste(a, b)}\nx <- 1\n```\n"),
+            vec!["list(fig.cap = paste(a, b))"]
+        );
+    }
+
+    #[test]
+    fn test_quarto_expr_option_is_r_code() {
+        assert_eq!(
+            option_code("```{r}\n#| eval: !expr run_it\nx <- 1\n```\n"),
+            vec!["run_it"]
+        );
+    }
+
+    #[test]
+    fn test_quarto_plain_option_is_not_r_code() {
+        // Without `!expr` the value is data, not code.
+        assert!(option_code("```{r}\n#| fig-cap: my_caption\nx <- 1\n```\n").is_empty());
+    }
+
+    #[test]
+    fn test_quarto_expr_option_below_the_code_is_ignored() {
+        assert!(option_code("```{r}\nx <- 1\n#| eval: !expr run_it\n```\n").is_empty());
+    }
+
+    #[test]
+    fn test_both_option_forms_are_collected() {
+        assert_eq!(
+            option_code("```{r, fig.cap = cap}\n#| eval: !expr run_it\nx <- 1\n```\n"),
+            vec!["list(fig.cap = cap)", "run_it"]
         );
     }
 }

--- a/crates/jarl-core/src/rmd/extraction.rs
+++ b/crates/jarl-core/src/rmd/extraction.rs
@@ -14,11 +14,29 @@ use crate::directive::{
 /// Matches the opening fence of an executable R code chunk.
 ///
 /// Captures group 1: the backtick sequence (e.g. "```").
+/// Captures group 2: the chunk options, i.e. everything between `{r` and `}`.
 /// Accepts `{r}`, `{r label}`, `{r, options}`, etc.
 /// Leading spaces or tabs are allowed to support indented chunks (e.g. inside
 /// list items).
 static OPEN_FENCE: LazyLock<Regex> =
-    LazyLock::new(|| Regex::new(r"^[ \t]*(`{3,})\{[rR][^}]*\}").unwrap());
+    LazyLock::new(|| Regex::new(r"^[ \t]*(`{3,})\{[rR]([^}]*)\}").unwrap());
+
+/// Matches `eval = FALSE` among the options of a chunk header.
+///
+/// Case-sensitive on the value: `FALSE` and `F` are R's false literals, while
+/// `false` is an ordinary symbol. A value this doesn't match (`eval = run_it`,
+/// `eval = nrow(x) > 0`) is decided at render time, and treating those as
+/// evaluated is the conservative reading — see [`RCodeChunk::evaluated`].
+static HEADER_EVAL_FALSE: LazyLock<Regex> =
+    LazyLock::new(|| Regex::new(r"\beval\s*=\s*(FALSE|F)\b").unwrap());
+
+/// Matches Quarto's `#| eval: false` chunk option.
+///
+/// The value is a YAML boolean, so unlike the header form it is not
+/// case-sensitive. `#| eval: !expr <code>` is resolved at render time and
+/// deliberately doesn't match.
+static YAML_EVAL_FALSE: LazyLock<Regex> =
+    LazyLock::new(|| Regex::new(r"(?i)^[ \t]*#\|[ \t]*eval[ \t]*:[ \t]*false[ \t]*$").unwrap());
 
 /// Matches inline R code in prose: `` `r expr` ``.
 ///
@@ -37,6 +55,16 @@ pub struct RCodeChunk {
     /// Byte offset in the original file where the chunk code starts.
     /// This is the byte immediately after the opening fence line's newline.
     pub start_byte: usize,
+    /// Whether the chunk runs when the document is rendered, i.e. whether it
+    /// is *not* marked `eval = FALSE` (header form) or `#| eval: false`
+    /// (Quarto form).
+    ///
+    /// Only literal false values count. An `eval` whose value is an expression
+    /// is unknowable here, and guessing "not evaluated" is the harmful
+    /// direction: it would drop the chunk's reads, which can turn an object
+    /// used only there into a false `unused_object` report. Guessing
+    /// "evaluated" can only leave a diagnostic unreported.
+    pub evaluated: bool,
 }
 
 /// Extract all executable R code chunks from Rmd/Qmd content.
@@ -49,17 +77,20 @@ pub fn extract_r_chunks(content: &str) -> Vec<RCodeChunk> {
     let mut chunks = Vec::new();
     let mut byte_offset: usize = 0;
 
-    // State: None = outside a chunk, Some((fence, code, start_byte)) = inside.
-    let mut current: Option<(String, String, usize)> = None;
+    // State: None = outside a chunk, Some((fence, code, start_byte,
+    // header_says_eval_false)) = inside.
+    let mut current: Option<(String, String, usize, bool)> = None;
 
     for line in content.split_inclusive('\n') {
         let mut finished = false;
 
-        if let Some((fence, code, start_byte)) = current.as_mut() {
+        if let Some((fence, code, start_byte, header_eval_false)) = current.as_mut() {
             if line.trim() == fence.as_str() {
                 // Closing fence found — emit the chunk.
+                let code = std::mem::take(code);
                 chunks.push(RCodeChunk {
-                    code: std::mem::take(code),
+                    evaluated: !*header_eval_false && !yaml_says_eval_false(&code),
+                    code,
                     start_byte: *start_byte,
                 });
                 finished = true;
@@ -69,9 +100,10 @@ pub fn extract_r_chunks(content: &str) -> Vec<RCodeChunk> {
         } else if let Some(caps) = OPEN_FENCE.captures(line) {
             // Opening fence found — start a new chunk.
             let fence = caps.get(1).unwrap().as_str().to_string();
+            let header_eval_false = HEADER_EVAL_FALSE.is_match(caps.get(2).unwrap().as_str());
             // The chunk code starts immediately after this line.
             let chunk_start_byte = byte_offset + line.len();
-            current = Some((fence, String::new(), chunk_start_byte));
+            current = Some((fence, String::new(), chunk_start_byte, header_eval_false));
         }
 
         if finished {
@@ -82,6 +114,17 @@ pub fn extract_r_chunks(content: &str) -> Vec<RCodeChunk> {
     }
 
     chunks
+}
+
+/// Whether the chunk's Quarto option block sets `eval: false`.
+///
+/// Quarto only reads `#|` options from the run of lines at the very top of the
+/// chunk, so the scan stops at the first line that isn't one. A `#| eval:
+/// false` further down is a plain comment.
+fn yaml_says_eval_false(code: &str) -> bool {
+    code.lines()
+        .take_while(|line| line.trim_start().starts_with("#|"))
+        .any(|line| YAML_EVAL_FALSE.is_match(line))
 }
 
 /// Extract the R expressions of inline code spans (`` `r expr` ``) written in
@@ -261,6 +304,11 @@ pub struct VirtualSource {
     /// parse errors. Their code is absent from `source`, so anything they read
     /// is invisible to the analysis unless the caller accounts for it.
     pub skipped: Vec<usize>,
+    /// Spans in `source` covering the chunks that don't run when the document
+    /// is rendered (see [`RCodeChunk::evaluated`]). Their code is still linted
+    /// — it is code the author wrote and readers see — but it neither defines
+    /// nor reads anything, so use-def analysis has to leave it out.
+    pub unevaluated: Vec<TextRange>,
 }
 
 /// Build a virtual R source string by concatenating all valid R chunks,
@@ -273,6 +321,7 @@ pub fn build_virtual_r_source(chunks: &[RCodeChunk]) -> VirtualSource {
     let mut virtual_src = String::new();
     let mut segments: Vec<Segment> = Vec::new();
     let mut skipped: Vec<usize> = Vec::new();
+    let mut unevaluated: Vec<TextRange> = Vec::new();
 
     for (i, chunk) in chunks.iter().enumerate() {
         // Skip empty chunks.
@@ -287,6 +336,7 @@ pub fn build_virtual_r_source(chunks: &[RCodeChunk]) -> VirtualSource {
             continue;
         }
 
+        let chunk_start = virtual_src.len();
         let blocks = find_chunk_ignore_blocks(&chunk.code);
 
         if blocks.is_empty() {
@@ -314,12 +364,20 @@ pub fn build_virtual_r_source(chunks: &[RCodeChunk]) -> VirtualSource {
         if !virtual_src.ends_with('\n') {
             virtual_src.push('\n');
         }
+
+        if !chunk.evaluated {
+            unevaluated.push(TextRange::new(
+                TextSize::from(chunk_start as u32),
+                TextSize::from(virtual_src.len() as u32),
+            ));
+        }
     }
 
     VirtualSource {
         source: virtual_src,
         offset_map: OffsetMap { segments },
         skipped,
+        unevaluated,
     }
 }
 
@@ -626,6 +684,92 @@ mod tests {
     fn test_display_only_r_block_is_not_inline_code() {
         // ```r opens a display block, so its fences are not an inline span.
         assert!(inline("```r\nx\n```\n").is_empty());
+    }
+
+    // --- eval = FALSE ---
+
+    /// Whether the single chunk of `content` is marked as evaluated.
+    fn evaluated(content: &str) -> bool {
+        let chunks = extract_r_chunks(content);
+        assert_eq!(chunks.len(), 1, "expected exactly one chunk");
+        chunks[0].evaluated
+    }
+
+    #[test]
+    fn test_chunk_without_eval_option_is_evaluated() {
+        assert!(evaluated("```{r}\nx <- 1\n```\n"));
+        assert!(evaluated("```{r label, echo=FALSE}\nx <- 1\n```\n"));
+    }
+
+    #[test]
+    fn test_header_eval_false_is_not_evaluated() {
+        assert!(!evaluated("```{r, eval = FALSE}\nx <- 1\n```\n"));
+        assert!(!evaluated("```{r eval=FALSE}\nx <- 1\n```\n"));
+        assert!(!evaluated("```{r label, eval=F, echo=TRUE}\nx <- 1\n```\n"));
+    }
+
+    #[test]
+    fn test_header_eval_true_is_evaluated() {
+        assert!(evaluated("```{r, eval = TRUE}\nx <- 1\n```\n"));
+        assert!(evaluated("```{r, eval=T}\nx <- 1\n```\n"));
+    }
+
+    #[test]
+    fn test_header_eval_expression_is_evaluated() {
+        // Decided at render time. Assuming it runs can only cost a diagnostic;
+        // assuming it doesn't could invent one.
+        assert!(evaluated("```{r, eval = run_it}\nx <- 1\n```\n"));
+        assert!(evaluated("```{r, eval = nrow(d) > 0}\nx <- 1\n```\n"));
+    }
+
+    #[test]
+    fn test_eval_is_not_confused_with_another_option() {
+        // A different option whose name ends in `eval`, and a value that
+        // merely mentions FALSE.
+        assert!(evaluated("```{r, reeval = FALSE}\nx <- 1\n```\n"));
+        assert!(evaluated("```{r, echo = FALSE}\nx <- 1\n```\n"));
+    }
+
+    #[test]
+    fn test_quarto_eval_false_is_not_evaluated() {
+        assert!(!evaluated("```{r}\n#| eval: false\nx <- 1\n```\n"));
+        assert!(!evaluated(
+            "```{r}\n#| label: a\n#| eval: FALSE\nx <- 1\n```\n"
+        ));
+    }
+
+    #[test]
+    fn test_quarto_eval_true_is_evaluated() {
+        assert!(evaluated("```{r}\n#| eval: true\nx <- 1\n```\n"));
+    }
+
+    #[test]
+    fn test_quarto_eval_expression_is_evaluated() {
+        assert!(evaluated("```{r}\n#| eval: !expr run_it\nx <- 1\n```\n"));
+    }
+
+    #[test]
+    fn test_quarto_option_below_the_code_is_a_comment() {
+        // Quarto only reads the `#|` block at the top of the chunk.
+        assert!(evaluated("```{r}\nx <- 1\n#| eval: false\n```\n"));
+    }
+
+    #[test]
+    fn test_unevaluated_chunk_span_covers_its_code() {
+        let content = "```{r}\nkeep <- 1\n```\n\n```{r, eval = FALSE}\ndead <- 2\n```\n";
+        let chunks = extract_r_chunks(content);
+        let virtual_source = build_virtual_r_source(&chunks);
+
+        assert_eq!(virtual_source.source, "keep <- 1\ndead <- 2\n");
+        assert_eq!(virtual_source.unevaluated.len(), 1);
+        let range = virtual_source.unevaluated[0];
+        assert_eq!(&virtual_source.source[range], "dead <- 2\n");
+    }
+
+    #[test]
+    fn test_evaluated_chunks_have_no_unevaluated_span() {
+        let chunks = extract_r_chunks("```{r}\nx <- 1\n```\n");
+        assert!(build_virtual_r_source(&chunks).unevaluated.is_empty());
     }
 
     // --- Skipped chunks ---

--- a/crates/jarl-core/src/rmd/mod.rs
+++ b/crates/jarl-core/src/rmd/mod.rs
@@ -1,2 +1,5 @@
 pub mod extraction;
-pub use extraction::{OffsetMap, RCodeChunk, build_virtual_r_source, extract_r_chunks};
+pub use extraction::{
+    OffsetMap, RCodeChunk, VirtualSource, build_virtual_r_source, extract_inline_r_code,
+    extract_r_chunks,
+};

--- a/crates/jarl-core/src/rmd/mod.rs
+++ b/crates/jarl-core/src/rmd/mod.rs
@@ -1,5 +1,5 @@
 pub mod extraction;
 pub use extraction::{
-    OffsetMap, RCodeChunk, VirtualSource, build_virtual_r_source, extract_inline_r_code,
-    extract_r_chunks,
+    OffsetMap, RCodeChunk, VirtualSource, build_virtual_r_source, chunk_option_code,
+    extract_inline_r_code, extract_r_chunks,
 };

--- a/crates/jarl-core/src/utils.rs
+++ b/crates/jarl-core/src/utils.rs
@@ -9,6 +9,7 @@ use biome_rowan::{AstNode, AstSeparatedList, Direction};
 use oak_core::syntax_ext::{RIdentifierExt, RStringValueExt};
 use oak_semantic::effects::CallContext;
 pub use oak_semantic::effects::Formals;
+use std::collections::HashMap;
 
 /// Macro to unwrap an Option or return Ok(None) early.
 ///
@@ -385,4 +386,116 @@ pub fn node_contains_comments(node: &RSyntaxNode) -> bool {
             token.has_trailing_comments() && last_token.as_ref() != Some(&token);
         has_internal_leading || has_internal_trailing
     })
+}
+
+/// Count every identifier-shaped word in R source text.
+///
+/// Returns a map from identifier name to occurrence count. A deliberately
+/// crude scan: it reads the text rather than the syntax tree, so it also
+/// matches inside strings, and it makes no distinction between a definition,
+/// a call, and a mention. Callers use it where over-counting is the safe
+/// direction — `unused_function` would rather miss a dead function than
+/// report a live one, and the Rmd/Qmd reader would rather keep an object
+/// alive than invent an `unused_object` report.
+///
+/// Reading the text is also what lets it catch the indirect references a
+/// syntax-directed pass would miss: `do.call("name", ...)`, `lapply(xs,
+/// name)`, `match.fun(name)`.
+///
+/// Regular comments are skipped, but roxygen comments (`#'`) are kept: they
+/// can reference internal functions, e.g. through `\Sexpr`.
+pub fn scan_symbols(content: &str) -> HashMap<String, usize> {
+    let mut symbols: HashMap<&str, usize> = HashMap::new();
+
+    for line in content.lines() {
+        let trimmed = line.trim_start();
+        if trimmed.starts_with('#') && !trimmed.starts_with("#'") {
+            continue;
+        }
+
+        let bytes = line.as_bytes();
+        let len = bytes.len();
+        let mut i = 0;
+
+        while i < len {
+            let b = bytes[i];
+
+            // R identifiers start with a letter, `.`, or `_`
+            if b.is_ascii_alphabetic() || b == b'.' || b == b'_' {
+                let start = i;
+                i += 1;
+                while i < len
+                    && (bytes[i].is_ascii_alphanumeric() || bytes[i] == b'.' || bytes[i] == b'_')
+                {
+                    i += 1;
+                }
+                let name = &line[start..i];
+                *symbols.entry(name).or_insert(0) += 1;
+            } else {
+                i += 1;
+            }
+        }
+    }
+
+    symbols
+        .into_iter()
+        .map(|(k, v)| (k.to_string(), v))
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::scan_symbols;
+
+    #[test]
+    fn test_scan_symbols_from_calls() {
+        let syms = scan_symbols("foo(1)\nbar(x, y)\n");
+        assert!(syms.contains_key("foo"));
+        assert!(syms.contains_key("bar"));
+        assert!(syms.contains_key("x"));
+        assert!(syms.contains_key("y"));
+    }
+
+    #[test]
+    fn test_scan_symbols_from_assignments() {
+        let syms = scan_symbols("x <- 1\ny + z\n");
+        assert!(syms.contains_key("x"));
+        assert!(syms.contains_key("y"));
+        assert!(syms.contains_key("z"));
+    }
+
+    #[test]
+    fn test_scan_symbols_nested() {
+        let syms = scan_symbols("outer(inner(x))\n");
+        assert!(syms.contains_key("outer"));
+        assert!(syms.contains_key("inner"));
+        assert!(syms.contains_key("x"));
+    }
+
+    #[test]
+    fn test_scan_symbols_ignores_comments() {
+        let syms = scan_symbols("# foo(bar)\nreal()\n");
+        assert!(!syms.contains_key("foo"));
+        assert!(!syms.contains_key("bar"));
+        assert!(syms.contains_key("real"));
+    }
+
+    #[test]
+    fn test_scan_symbols_ignores_indented_comments() {
+        let syms = scan_symbols("  # foo(bar)\n");
+        assert!(!syms.contains_key("foo"));
+    }
+
+    #[test]
+    fn test_scan_symbols_includes_roxygen_comments() {
+        let syms = scan_symbols("#' \\Sexpr[stage=render]{dplyr:::methods_rd(\"rows_insert\")}\n");
+        assert!(syms.contains_key("methods_rd"));
+    }
+
+    #[test]
+    fn test_scan_symbols_ignores_numbers() {
+        let syms = scan_symbols("123 + foo\n");
+        assert!(syms.contains_key("foo"));
+        assert!(!syms.contains_key("123"));
+    }
 }

--- a/crates/jarl-semantic/src/lib.rs
+++ b/crates/jarl-semantic/src/lib.rs
@@ -155,11 +155,15 @@ pub struct SemanticInfo<'a> {
     /// resolves to the definition it actually sees, so a *later* same-scope
     /// reassignment of the name is not kept alive by it.
     positional_uses: Vec<(String, TextRange)>,
-    /// Identifier `Use` ranges that should be ignored because they sit inside
-    /// a quoting call oak's effects registry doesn't cover (`Quote(…)`,
-    /// `expression(…)`, `alist(…)`). `quote()`, `bquote()` and `substitute()`
-    /// are modeled by oak itself (their quoted arguments produce no uses or
-    /// definitions in the index), so they don't need ranges here.
+    /// Ranges holding code that is parsed but never evaluated, so that an
+    /// identifier inside one is neither a definition nor a use.
+    ///
+    /// Two things land here. Quoting calls oak's effects registry doesn't
+    /// cover (`Quote(…)`, `expression(…)`, `alist(…)`) — `quote()`, `bquote()`
+    /// and `substitute()` are modeled by oak itself, so their arguments never
+    /// enter the index and need no range. And ranges the caller declares
+    /// unevaluated up front (see [`SemanticInfo::build`]), which is how an
+    /// Rmd/Qmd chunk marked `eval = FALSE` is kept out of the analysis.
     nse_ranges: Vec<TextRange>,
     /// Packages this file can reach: attached with `library()`/`require()`,
     /// listed in DESCRIPTION when linting package code, or named in a
@@ -183,12 +187,17 @@ impl<'a> SemanticInfo<'a> {
     /// Build the info table. Runs the AST pass (collecting synthetic uses,
     /// interpolation reads, NSE ranges, formula ranges) and then the
     /// reaching-use precomputation over oak's use-def maps.
+    ///
+    /// `unevaluated` names ranges the caller already knows never run, on top
+    /// of the ones the AST pass finds itself. Callers linting plain R code
+    /// pass nothing; the Rmd/Qmd path passes the chunks marked `eval = FALSE`.
     pub fn build(
         root: &RSyntaxNode,
         expressions: &[RSyntaxNode],
         index: &'a SemanticIndex,
         source_cache: &SourceIndexCache,
         loaded_packages: &[String],
+        unevaluated: &[TextRange],
     ) -> Self {
         // `pkg::fn()` reaches a package without attaching it, so namespaced
         // accesses count alongside what the caller resolved from
@@ -214,7 +223,7 @@ impl<'a> SemanticInfo<'a> {
             short_circuit_ranges: Vec::new(),
             loop_ranges: Vec::new(),
             positional_uses: Vec::new(),
-            nse_ranges: Vec::new(),
+            nse_ranges: unevaluated.to_vec(),
             available_packages,
             formula_ranges: Vec::new(),
             has_any_interpolation_package,

--- a/crates/jarl/tests/integration/rmd.rs
+++ b/crates/jarl/tests/integration/rmd.rs
@@ -1422,3 +1422,178 @@ x <- 1
 
     Ok(())
 }
+
+/// A chunk marked `eval = FALSE` never runs, so nothing it assigns is a
+/// definition and nothing it mentions is a read.
+#[test]
+fn test_rmd_unevaluated_chunk_defines_and_reads_nothing() -> anyhow::Result<()> {
+    let case = CliTest::with_file(
+        "test.Rmd",
+        "
+```{r}
+read_only_in_dead_chunk <- 1
+```
+
+```{r, eval = FALSE}
+defined_in_dead_chunk <- 2
+print(read_only_in_dead_chunk)
+```
+",
+    )?;
+
+    insta::assert_snapshot!(
+        &mut case
+            .command()
+            .arg("check")
+            .arg("test.Rmd")
+            .arg("--select")
+            .arg("unused_object")
+            .run()
+            .normalize_os_executable_name(),
+        @"
+
+    success: false
+    exit_code: 1
+    ----- stdout -----
+    warning: unused_object
+     --> test.Rmd:3:1
+      |
+    3 | read_only_in_dead_chunk <- 1
+      | ----------------------- Object `read_only_in_dead_chunk` is defined but never used.
+      |
+
+
+    ── Summary ──────────────────────────────────────
+    Found 1 error.
+
+    ----- stderr -----
+    "
+    );
+
+    Ok(())
+}
+
+/// Quarto's option form is honoured too.
+#[test]
+fn test_rmd_quarto_eval_false_chunk_defines_nothing() -> anyhow::Result<()> {
+    let case = CliTest::with_file(
+        "test.Rmd",
+        "
+```{r}
+#| eval: false
+x <- 1
+```
+",
+    )?;
+
+    insta::assert_snapshot!(
+        &mut case
+            .command()
+            .arg("check")
+            .arg("test.Rmd")
+            .arg("--select")
+            .arg("unused_object")
+            .run()
+            .normalize_os_executable_name(),
+        @"
+
+    success: true
+    exit_code: 0
+    ----- stdout -----
+    ── Summary ──────────────────────────────────────
+    All checks passed!
+
+    ----- stderr -----
+    "
+    );
+
+    Ok(())
+}
+
+/// An `eval` option whose value is decided at render time is assumed to run:
+/// dropping its reads could invent a diagnostic, keeping them can only miss
+/// one.
+#[test]
+fn test_rmd_dynamic_eval_chunk_is_treated_as_evaluated() -> anyhow::Result<()> {
+    let case = CliTest::with_file(
+        "test.Rmd",
+        "
+```{r}
+x <- 1
+```
+
+```{r, eval = run_it}
+print(x)
+```
+",
+    )?;
+
+    insta::assert_snapshot!(
+        &mut case
+            .command()
+            .arg("check")
+            .arg("test.Rmd")
+            .arg("--select")
+            .arg("unused_object")
+            .run()
+            .normalize_os_executable_name(),
+        @"
+
+    success: true
+    exit_code: 0
+    ----- stdout -----
+    ── Summary ──────────────────────────────────────
+    All checks passed!
+
+    ----- stderr -----
+    "
+    );
+
+    Ok(())
+}
+
+/// An unevaluated chunk is left out of the use-def analysis, but it is still
+/// code in the document and other rules still apply to it.
+#[test]
+fn test_rmd_unevaluated_chunk_is_still_linted() -> anyhow::Result<()> {
+    let case = CliTest::with_file(
+        "test.Rmd",
+        "
+```{r, eval = FALSE}
+any(is.na(x))
+```
+",
+    )?;
+
+    insta::assert_snapshot!(
+        &mut case
+            .command()
+            .arg("check")
+            .arg("test.Rmd")
+            .arg("--select")
+            .arg("any_is_na")
+            .run()
+            .normalize_os_executable_name(),
+        @"
+
+    success: false
+    exit_code: 1
+    ----- stdout -----
+    warning: any_is_na
+     --> test.Rmd:3:1
+      |
+    3 | any(is.na(x))
+      | ------------- `any(is.na(...))` is inefficient.
+      |
+      = help: Use `anyNA(...)` instead.
+
+
+    ── Summary ──────────────────────────────────────
+    Found 1 error.
+
+    ----- stderr -----
+    "
+    );
+
+    Ok(())
+}

--- a/crates/jarl/tests/integration/rmd.rs
+++ b/crates/jarl/tests/integration/rmd.rs
@@ -1059,3 +1059,366 @@ any(is.na(x))
 
     Ok(())
 }
+
+// ---------------------------------------------------------------------------
+// unused_object
+// ---------------------------------------------------------------------------
+
+/// Knitr runs every chunk in one session, so an object no chunk ever reads is
+/// unused. The diagnostic points at the line in the original document.
+#[test]
+fn test_rmd_unused_object_reported() -> anyhow::Result<()> {
+    let case = CliTest::with_file(
+        "test.Rmd",
+        "
+---
+title: \"Test\"
+---
+
+```{r}
+x <- 1
+```
+",
+    )?;
+
+    insta::assert_snapshot!(
+        &mut case
+            .command()
+            .arg("check")
+            .arg("test.Rmd")
+            .arg("--select")
+            .arg("unused_object")
+            .run()
+            .normalize_os_executable_name(),
+        @"
+
+    success: false
+    exit_code: 1
+    ----- stdout -----
+    warning: unused_object
+     --> test.Rmd:7:1
+      |
+    7 | x <- 1
+      | - Object `x` is defined but never used.
+      |
+
+
+    ── Summary ──────────────────────────────────────
+    Found 1 error.
+
+    ----- stderr -----
+    "
+    );
+
+    Ok(())
+}
+
+/// Chunks share one environment, so a read in a later chunk uses the object.
+#[test]
+fn test_rmd_object_read_in_a_later_chunk_not_flagged() -> anyhow::Result<()> {
+    let case = CliTest::with_file(
+        "test.Rmd",
+        "
+```{r}
+x <- 1
+```
+
+Some prose in between.
+
+```{r}
+print(x)
+```
+",
+    )?;
+
+    insta::assert_snapshot!(
+        &mut case
+            .command()
+            .arg("check")
+            .arg("test.Rmd")
+            .arg("--select")
+            .arg("unused_object")
+            .run()
+            .normalize_os_executable_name(),
+        @"
+
+    success: true
+    exit_code: 0
+    ----- stdout -----
+    ── Summary ──────────────────────────────────────
+    All checks passed!
+
+    ----- stderr -----
+    "
+    );
+
+    Ok(())
+}
+
+/// Inline R code in the prose isn't linted, but it does run: an object it
+/// reads is used.
+#[test]
+fn test_rmd_object_read_by_inline_code_not_flagged() -> anyhow::Result<()> {
+    let case = CliTest::with_file(
+        "test.Rmd",
+        "
+```{r}
+x <- 1
+```
+
+The value is `r mean(x)`.
+",
+    )?;
+
+    insta::assert_snapshot!(
+        &mut case
+            .command()
+            .arg("check")
+            .arg("test.Rmd")
+            .arg("--select")
+            .arg("unused_object")
+            .run()
+            .normalize_os_executable_name(),
+        @"
+
+    success: true
+    exit_code: 0
+    ----- stdout -----
+    ── Summary ──────────────────────────────────────
+    All checks passed!
+
+    ----- stderr -----
+    "
+    );
+
+    Ok(())
+}
+
+/// A chunk that doesn't parse is dropped from the analysis, but it still runs
+/// when the document is knitted, so the objects it reads are not unused.
+#[test]
+fn test_rmd_object_read_in_a_chunk_with_syntax_error_not_flagged() -> anyhow::Result<()> {
+    let case = CliTest::with_file(
+        "test.Rmd",
+        "
+```{r}
+x <- 1
+y <- 2
+```
+
+```{r}
+if (x
+```
+",
+    )?;
+
+    insta::assert_snapshot!(
+        &mut case
+            .command()
+            .arg("check")
+            .arg("test.Rmd")
+            .arg("--select")
+            .arg("unused_object")
+            .run()
+            .normalize_os_executable_name(),
+        @"
+
+    success: false
+    exit_code: 1
+    ----- stdout -----
+    warning: unused_object
+     --> test.Rmd:4:1
+      |
+    4 | y <- 2
+      | - Object `y` is defined but never used.
+      |
+
+
+    ── Summary ──────────────────────────────────────
+    Found 1 error.
+
+    ----- stderr -----
+    "
+    );
+
+    Ok(())
+}
+
+/// `source()` in a chunk resolves next to the document: the helper's own
+/// definitions land in the document's environment, so reading one is not a
+/// read of an undefined object, and the helper's free reads consume the
+/// document's bindings.
+#[test]
+fn test_rmd_object_read_by_sourced_file_not_flagged() -> anyhow::Result<()> {
+    let case = CliTest::with_files([
+        ("helper.R", "print(x)\n"),
+        (
+            "test.Rmd",
+            "
+```{r}
+x <- 1
+y <- 2
+source(\"helper.R\")
+```
+",
+        ),
+    ])?;
+
+    insta::assert_snapshot!(
+        &mut case
+            .command()
+            .arg("check")
+            .arg("test.Rmd")
+            .arg("--select")
+            .arg("unused_object")
+            .run()
+            .normalize_os_executable_name(),
+        @"
+
+    success: false
+    exit_code: 1
+    ----- stdout -----
+    warning: unused_object
+     --> test.Rmd:4:1
+      |
+    4 | y <- 2
+      | - Object `y` is defined but never used.
+      |
+
+
+    ── Summary ──────────────────────────────────────
+    Found 1 error.
+
+    ----- stderr -----
+    "
+    );
+
+    Ok(())
+}
+
+/// An object a sourced file defines is imported, not defined by the document,
+/// so it is never reported here.
+#[test]
+fn test_rmd_object_defined_by_sourced_file_not_flagged() -> anyhow::Result<()> {
+    let case = CliTest::with_files([
+        ("helper.R", "from_helper <- 1\n"),
+        (
+            "test.Rmd",
+            "
+```{r}
+source(\"helper.R\")
+```
+",
+        ),
+    ])?;
+
+    insta::assert_snapshot!(
+        &mut case
+            .command()
+            .arg("check")
+            .arg("test.Rmd")
+            .arg("--select")
+            .arg("unused_object")
+            .run()
+            .normalize_os_executable_name(),
+        @"
+
+    success: true
+    exit_code: 0
+    ----- stdout -----
+    ── Summary ──────────────────────────────────────
+    All checks passed!
+
+    ----- stderr -----
+    "
+    );
+
+    Ok(())
+}
+
+/// Both suppression forms apply to the rule.
+#[test]
+fn test_rmd_unused_object_can_be_suppressed() -> anyhow::Result<()> {
+    let case = CliTest::with_file(
+        "test.Rmd",
+        "
+```{r}
+#| jarl-ignore-chunk:
+#| - unused_object: kept for illustration
+x <- 1
+```
+
+```{r}
+# jarl-ignore unused_object: kept for illustration
+y <- 2
+```
+",
+    )?;
+
+    insta::assert_snapshot!(
+        &mut case
+            .command()
+            .arg("check")
+            .arg("test.Rmd")
+            .arg("--select")
+            .arg("unused_object")
+            .run()
+            .normalize_os_executable_name(),
+        @"
+
+    success: true
+    exit_code: 0
+    ----- stdout -----
+    ── Summary ──────────────────────────────────────
+    All checks passed!
+
+    ----- stderr -----
+    "
+    );
+
+    Ok(())
+}
+
+/// Same as `test_rmd_unused_object_reported` but with a `.qmd` extension.
+#[test]
+fn test_qmd_unused_object_reported() -> anyhow::Result<()> {
+    let case = CliTest::with_file(
+        "test.qmd",
+        "
+```{r}
+x <- 1
+```
+",
+    )?;
+
+    insta::assert_snapshot!(
+        &mut case
+            .command()
+            .arg("check")
+            .arg("test.qmd")
+            .arg("--select")
+            .arg("unused_object")
+            .run()
+            .normalize_os_executable_name(),
+        @"
+
+    success: false
+    exit_code: 1
+    ----- stdout -----
+    warning: unused_object
+     --> test.qmd:3:1
+      |
+    3 | x <- 1
+      | - Object `x` is defined but never used.
+      |
+
+
+    ── Summary ──────────────────────────────────────
+    Found 1 error.
+
+    ----- stderr -----
+    "
+    );
+
+    Ok(())
+}

--- a/crates/jarl/tests/integration/rmd.rs
+++ b/crates/jarl/tests/integration/rmd.rs
@@ -1597,3 +1597,141 @@ any(is.na(x))
 
     Ok(())
 }
+
+/// Chunk options can name objects. Knitr evaluates a chunk's options when it
+/// renders the chunk, so those are reads — including for a chunk whose own
+/// code never runs.
+#[test]
+fn test_rmd_objects_used_in_chunk_options_not_flagged() -> anyhow::Result<()> {
+    let case = CliTest::with_file(
+        "test.Rmd",
+        "
+```{r setup}
+run_it <- TRUE
+my_caption <- \"a caption\"
+quarto_flag <- TRUE
+```
+
+```{r plot-one, eval = run_it, fig.cap = my_caption}
+plot(1)
+```
+
+```{r}
+#| eval: !expr quarto_flag
+plot(2)
+```
+",
+    )?;
+
+    insta::assert_snapshot!(
+        &mut case
+            .command()
+            .arg("check")
+            .arg("test.Rmd")
+            .arg("--select")
+            .arg("unused_object")
+            .run()
+            .normalize_os_executable_name(),
+        @"
+
+    success: true
+    exit_code: 0
+    ----- stdout -----
+    ── Summary ──────────────────────────────────────
+    All checks passed!
+
+    ----- stderr -----
+    "
+    );
+
+    Ok(())
+}
+
+/// Only the *values* of chunk options are reads. An object whose name happens
+/// to match an option name is still reported.
+#[test]
+fn test_rmd_chunk_option_names_are_not_reads() -> anyhow::Result<()> {
+    let case = CliTest::with_file(
+        "test.Rmd",
+        "
+```{r}
+results <- 1
+```
+
+```{r, results = 'asis', echo = FALSE}
+plot(1)
+```
+",
+    )?;
+
+    insta::assert_snapshot!(
+        &mut case
+            .command()
+            .arg("check")
+            .arg("test.Rmd")
+            .arg("--select")
+            .arg("unused_object")
+            .run()
+            .normalize_os_executable_name(),
+        @"
+
+    success: false
+    exit_code: 1
+    ----- stdout -----
+    warning: unused_object
+     --> test.Rmd:3:1
+      |
+    3 | results <- 1
+      | ------- Object `results` is defined but never used.
+      |
+
+
+    ── Summary ──────────────────────────────────────
+    Found 1 error.
+
+    ----- stderr -----
+    "
+    );
+
+    Ok(())
+}
+
+/// Options are evaluated even when the chunk they belong to is not.
+#[test]
+fn test_rmd_options_of_unevaluated_chunk_are_reads() -> anyhow::Result<()> {
+    let case = CliTest::with_file(
+        "test.Rmd",
+        "
+```{r}
+my_caption <- \"a caption\"
+```
+
+```{r, eval = FALSE, fig.cap = my_caption}
+plot(1)
+```
+",
+    )?;
+
+    insta::assert_snapshot!(
+        &mut case
+            .command()
+            .arg("check")
+            .arg("test.Rmd")
+            .arg("--select")
+            .arg("unused_object")
+            .run()
+            .normalize_os_executable_name(),
+        @"
+
+    success: true
+    exit_code: 0
+    ----- stdout -----
+    ── Summary ──────────────────────────────────────
+    All checks passed!
+
+    ----- stderr -----
+    "
+    );
+
+    Ok(())
+}

--- a/docs/howto/rmarkdown-quarto.md
+++ b/docs/howto/rmarkdown-quarto.md
@@ -13,6 +13,11 @@ All R code chunks of a document are analyzed together, in document order, since 
 Rules that need to know how objects flow through the document, such as `unused_object`, therefore work across chunks: an object created in one chunk and used in a later one is not reported.
 Inline R code isn't linted, but the objects it reads are taken into account, so `` `r x` `` in the prose keeps `x` from being reported as unused.
 
+Chunks that don't run when the document is rendered, i.e. those marked `eval = FALSE` or `#| eval: false`, are left out of this: they neither create objects nor use them.
+An object only used in such a chunk is therefore still reported as unused.
+Their code is checked by all the other rules, as usual.
+An `eval` option whose value is an expression, such as `eval = run_it`, is only known at render time, so the chunk is assumed to run.
+
 Suppression comments such as `# jarl-ignore` are supported in R code chunks.
 In Quarto and R Markdown files, you can also use the comment `#| jarl-ignore-chunk` to ignore specific rules on entire chunks.
 Moreover, the comment `# jarl-ignore-file` must be located in the first R code chunk, before any R code.

--- a/docs/howto/rmarkdown-quarto.md
+++ b/docs/howto/rmarkdown-quarto.md
@@ -9,6 +9,10 @@ This comes with a few limitations:
 * inline R code isn't analyzed, only code chunks;
 * features from the editor integration, such as highlighting diagnostics, are only available when the file is open in source mode, not in visual mode.
 
+All R code chunks of a document are analyzed together, in document order, since this is how they are evaluated when the document is rendered.
+Rules that need to know how objects flow through the document, such as `unused_object`, therefore work across chunks: an object created in one chunk and used in a later one is not reported.
+Inline R code isn't linted, but the objects it reads are taken into account, so `` `r x` `` in the prose keeps `x` from being reported as unused.
+
 Suppression comments such as `# jarl-ignore` are supported in R code chunks.
 In Quarto and R Markdown files, you can also use the comment `#| jarl-ignore-chunk` to ignore specific rules on entire chunks.
 Moreover, the comment `# jarl-ignore-file` must be located in the first R code chunk, before any R code.

--- a/docs/howto/rmarkdown-quarto.md
+++ b/docs/howto/rmarkdown-quarto.md
@@ -18,6 +18,10 @@ An object only used in such a chunk is therefore still reported as unused.
 Their code is checked by all the other rules, as usual.
 An `eval` option whose value is an expression, such as `eval = run_it`, is only known at render time, so the chunk is assumed to run.
 
+Chunk options can name objects, either in the chunk header (`` ```{r, fig.cap = my_caption} ``) or with Quarto's `!expr` (`#| eval: !expr run_it`).
+Those objects count as used, in every chunk: knitr evaluates a chunk's options even when the chunk itself doesn't run.
+Only the values are read, so an object that happens to be named like a chunk option is still reported.
+
 Suppression comments such as `# jarl-ignore` are supported in R code chunks.
 In Quarto and R Markdown files, you can also use the comment `#| jarl-ignore-chunk` to ignore specific rules on entire chunks.
 Moreover, the comment `# jarl-ignore-file` must be located in the first R code chunk, before any R code.


### PR DESCRIPTION
Part of #608 
