### PR TITLE
fix: Do not report assignments in `within()` as unused

### DIFF
--- a/crates/jarl-core/src/lints/base/unused_object/mod.rs
+++ b/crates/jarl-core/src/lints/base/unused_object/mod.rs
@@ -1077,6 +1077,61 @@ for (i in 1:2) {
     }
 
     #[test]
+    fn test_no_lint_assignment_in_within() {
+        // `within()` returns the environment it evaluated the block in, so
+        // every binding the block creates comes back as a column of the result.
+        expect_no_lint(
+            "
+dat <- data.frame(x = 1)
+within(dat, {
+  x <- x + 1
+  y <- 2
+})
+",
+            "unused_object",
+            None,
+        );
+    }
+
+    #[test]
+    fn test_no_lint_assignment_in_namespaced_within() {
+        expect_no_lint(
+            "
+dat <- data.frame(x = 1)
+base::within(dat, expr = { y <- 2 })
+",
+            "unused_object",
+            None,
+        );
+    }
+
+    #[test]
+    fn test_lint_unused_object_in_function_defined_inside_within() {
+        // A function defined in the block has its own frame, so its locals are
+        // ordinary temporaries.
+        assert_snapshot!(
+            snapshot_lint("
+dat <- data.frame(x = 1)
+within(dat, {
+  y <- (function() {
+    tmp <- 1
+    2
+  })()
+})
+"),
+            @"
+        warning: unused_object
+         --> <test>:4:5
+          |
+        4 |     tmp <- 1
+          |     --- Object `tmp` is defined but never used.
+          |
+        Found 1 error.
+        "
+        );
+    }
+
+    #[test]
     fn test_nse_assignment_does_not_shadow_real_definition() {
         // The quoted `x <- 2` must not kill the real `x <- 1`; `print(x)`
         // reads the live binding (which is still `1`).

--- a/crates/jarl-core/src/lints/base/unused_object/mod.rs
+++ b/crates/jarl-core/src/lints/base/unused_object/mod.rs
@@ -1121,9 +1121,9 @@ within(dat, {
 "),
             @"
         warning: unused_object
-         --> <test>:4:5
+         --> <test>:5:5
           |
-        4 |     tmp <- 1
+        5 |     tmp <- 1
           |     --- Object `tmp` is defined but never used.
           |
         Found 1 error.

--- a/crates/jarl-core/src/lints/base/unused_object/unused_object.rs
+++ b/crates/jarl-core/src/lints/base/unused_object/unused_object.rs
@@ -211,6 +211,12 @@ fn should_lint_definition(info: &SemanticInfo<'_>, def: &Definition) -> bool {
         return false;
     }
 
+    // An assignment in `within(data, { … })` mutates the environment the call
+    // returns, so the binding is the result rather than a dead store.
+    if info.is_in_returned_env(def.range()) {
+        return false;
+    }
+
     true
 }
 

--- a/crates/jarl-semantic/src/lib.rs
+++ b/crates/jarl-semantic/src/lib.rs
@@ -173,6 +173,14 @@ pub struct SemanticInfo<'a> {
     available_packages: HashSet<String>,
     /// Ranges of formula RHSes (`~ rhs`).
     formula_ranges: Vec<TextRange>,
+    /// Ranges of expressions evaluated against an environment the call then
+    /// hands back (`within(data, expr)`): a binding created there is part of
+    /// the call's result, not a local temporary.
+    returned_env_ranges: Vec<TextRange>,
+    /// Function definitions nested inside a [`Self::returned_env_ranges`]
+    /// entry. Such a function has its own frame, so its locals are ordinary
+    /// temporaries again and stay lintable.
+    returned_env_functions: Vec<TextRange>,
     /// Whether any package providing `{...}` interpolation is in reach.
     /// Computed once so a file that uses none of them skips the ancestor walk
     /// [`interpolation_flavor`] does for every string literal.
@@ -226,6 +234,8 @@ impl<'a> SemanticInfo<'a> {
             nse_ranges: unevaluated.to_vec(),
             available_packages,
             formula_ranges: Vec::new(),
+            returned_env_ranges: Vec::new(),
+            returned_env_functions: Vec::new(),
             has_any_interpolation_package,
             reaching_used: HashSet::new(),
         };
@@ -285,6 +295,18 @@ impl<'a> SemanticInfo<'a> {
     /// the first place.
     pub fn is_in_nse(&self, range: TextRange) -> bool {
         in_any_range(range, &self.nse_ranges)
+    }
+
+    /// True when `range` sits in an expression whose assignments *are* the
+    /// enclosing call's return value. `within(data, expr)` evaluates `expr`
+    /// against an environment built from `data` and returns that environment's
+    /// contents, so every binding it creates comes back as a column — the
+    /// point of the call rather than a dead store. `if`/`for` bodies share
+    /// that environment, but a function defined there gets its own frame, so
+    /// its locals are excluded.
+    pub fn is_in_returned_env(&self, range: TextRange) -> bool {
+        in_any_range(range, &self.returned_env_ranges)
+            && !in_any_range(range, &self.returned_env_functions)
     }
 
     // ── Internal: AST pass ────────────────────────────────────────────
@@ -577,6 +599,22 @@ impl<'a> SemanticInfo<'a> {
                     if let Some(value) = arg.value() {
                         self.nse_ranges.push(value.syntax().text_trimmed_range());
                     }
+                }
+            }
+            // `within(data, expr)` evaluates `expr` against an environment
+            // made from `data` and returns what that environment holds, so an
+            // assignment there is the call's output. Only the quoted `expr`
+            // argument gets that treatment; `data` is evaluated normally.
+            "within" => {
+                let bound = CallContext::default().bind_arguments(call, &["data", "expr"]);
+                if let Some(expr) = bound.get("expr") {
+                    let node = expr.syntax();
+                    self.returned_env_ranges.push(node.text_trimmed_range());
+                    self.returned_env_functions.extend(
+                        node.descendants()
+                            .filter(|d| d.kind() == RSyntaxKind::R_FUNCTION_DEFINITION)
+                            .map(|d| d.text_trimmed_range()),
+                    );
                 }
             }
             // A name looked up at the call site, so it reads the binding live


### PR DESCRIPTION
Fixes #628 