### PR TITLE
[DO NOT MERGE] Run benchmarks

### DIFF
--- a/crates/jarl-core/src/vcs.rs
+++ b/crates/jarl-core/src/vcs.rs
@@ -1,6 +1,7 @@
 use crate::config::Config;
 use anyhow::{Result, bail};
 use std::collections::HashMap;
+
 use std::path::Path;
 use std::process::Command;
 

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -65,6 +65,7 @@
   information (#567).
 
 
+
 ### TOML improvements
 
 * New argument `[lint.per-file-ignores]` in `jarl.toml` to deactivate rules on


### PR DESCRIPTION
Benchmarks couldn't run in #633 because the `benchmark` profile didn't exist on the main branch yet. Results here should be compared to other PRs.