### PR TITLE
feat: Skip more functions in `implicit_assignment`

### DIFF
--- a/crates/jarl-core/src/lints/base/implicit_assignment/options.rs
+++ b/crates/jarl-core/src/lints/base/implicit_assignment/options.rs
@@ -16,7 +16,6 @@ const DEFAULT_SKIPPED_FUNCTIONS: &[&str] = &[
     "expect_no_warning",
     "expect_no_error",
     "expect_no_message",
-    "expect_no_match",
     "quote",
     "suppressMessages",
     "suppressWarnings",

--- a/crates/jarl-core/src/lints/base/implicit_assignment/options.rs
+++ b/crates/jarl-core/src/lints/base/implicit_assignment/options.rs
@@ -12,6 +12,11 @@ const DEFAULT_SKIPPED_FUNCTIONS: &[&str] = &[
     "expect_defunct",    // from {lifecycle}
     "expect_deprecated", // from {lifecycle}
     "expect_snapshot",
+    "expect_no_condition",
+    "expect_no_warning",
+    "expect_no_error",
+    "expect_no_message",
+    "expect_no_match",
     "quote",
     "suppressMessages",
     "suppressWarnings",

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -113,8 +113,9 @@
 * Fixed false positives in `assignment` rule. Jarl could recommend replacing `<-`
   by `=` in places where this would change the meaning of the code (#515).
 
-* `implicit_assignment` now includes `alist()` in the list of functions skipped
-  by default (#527).
+* `implicit_assignment` now includes `alist()`, `expect_no_condition()`,
+  `expect_no_warning()`, `expect_no_error()`, `expect_no_message()`,
+  and `expect_no_match()` in the list of functions skipped by default (#527, #639).
 
 * Jarl no longer fails to parse `...()` (#584, @Yousa-Mirage).
 

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -114,8 +114,8 @@
   by `=` in places where this would change the meaning of the code (#515).
 
 * `implicit_assignment` now includes `alist()`, `expect_no_condition()`,
-  `expect_no_warning()`, `expect_no_error()`, `expect_no_message()`,
-  and `expect_no_match()` in the list of functions skipped by default (#527, #639).
+  `expect_no_warning()`, `expect_no_error()`, `expect_no_message()`, and
+  `expect_no_match()` in the list of functions skipped by default (#527, #639).
 
 * Jarl no longer fails to parse `...()` (#584, @Yousa-Mirage).
 

--- a/docs/reference/config-file.md
+++ b/docs/reference/config-file.md
@@ -363,7 +363,7 @@ namespaced calls, e.g. `skipped-functions = ["list2"]` will ignore `list2()` and
 Default: `skipped-functions = ["alist", "expect_error", "expect_warning", "expect_message",
 "expect_silent", "expect_defunct", "expect_deprecated", "expect_snapshot",
 "expect_no_condition", "expect_no_warning", "expect_no_error", "expect_no_message",
-"expect_no_match", "quote", "suppressMessages", "suppressWarnings"]`
+"quote", "suppressMessages", "suppressWarnings"]`
 (`expect_`functions come from the `testthat` package, except `expect_defunct` and
 `expect_deprecated` which come from the `lifecycle` package)
 

--- a/docs/reference/config-file.md
+++ b/docs/reference/config-file.md
@@ -361,8 +361,9 @@ namespaced calls, e.g. `skipped-functions = ["list2"]` will ignore `list2()` and
 `rlang::list2()`.
 
 Default: `skipped-functions = ["alist", "expect_error", "expect_warning", "expect_message",
-"expect_silent", "expect_defunct", "expect_deprecated",
-"expect_snapshot", "quote", "suppressMessages", "suppressWarnings"]`
+"expect_silent", "expect_defunct", "expect_deprecated", "expect_snapshot",
+"expect_no_condition", "expect_no_warning", "expect_no_error", "expect_no_message",
+"expect_no_match", "quote", "suppressMessages", "suppressWarnings"]`
 (`expect_`functions come from the `testthat` package, except `expect_defunct` and
 `expect_deprecated` which come from the `lifecycle` package)
 


### PR DESCRIPTION
More `testthat` functions that could test whether `<-.my_method` is noisy.

Part of #636