### PR TITLE
feat: Skip some functions in `unused_object` and add TOML options

### DIFF
--- a/artifacts/jarl.schema.json
+++ b/artifacts/jarl.schema.json
@@ -396,6 +396,18 @@
               "type": "null"
             }
           ]
+        },
+        "unused_object": {
+          "title": "Options for the `unused_object` rule",
+          "description": "Use `skipped-functions` to fully replace the default list of calls whose\ndirectly-assigned arguments are allowed to be unused. Use\n`extend-skipped-functions` to add to the default list.\nSpecifying both is an error.",
+          "anyOf": [
+            {
+              "$ref": "#/$defs/UnusedObjectOptions"
+            },
+            {
+              "type": "null"
+            }
+          ]
         }
       }
     },
@@ -561,6 +573,31 @@
           ],
           "format": "uint",
           "minimum": 0
+        }
+      },
+      "additionalProperties": false
+    },
+    "UnusedObjectOptions": {
+      "description": "TOML options for `[lint.unused_object]`.\n\nUse `skipped-functions` to fully replace the default list of calls whose\ndirectly-assigned arguments are allowed to be unused. Use\n`extend-skipped-functions` to add to the default list. Specifying both is an\nerror.",
+      "type": "object",
+      "properties": {
+        "extend-skipped-functions": {
+          "type": [
+            "array",
+            "null"
+          ],
+          "items": {
+            "type": "string"
+          }
+        },
+        "skipped-functions": {
+          "type": [
+            "array",
+            "null"
+          ],
+          "items": {
+            "type": "string"
+          }
         }
       },
       "additionalProperties": false

--- a/crates/jarl-core/src/lints/base/unused_object/mod.rs
+++ b/crates/jarl-core/src/lints/base/unused_object/mod.rs
@@ -1,11 +1,29 @@
+pub(crate) mod options;
 pub(crate) mod unused_object;
 #[cfg(test)]
 mod tests {
+    use crate::lints::base::unused_object::options::ResolvedUnusedObjectOptions;
+    use crate::lints::base::unused_object::options::UnusedObjectOptions;
+    use crate::rule_options::ResolvedRuleOptions;
+    use crate::settings::{LinterSettings, Settings};
     use crate::utils_test::*;
     use insta::assert_snapshot;
 
     fn snapshot_lint(code: &str) -> String {
         format_diagnostics(code, "unused_object", None)
+    }
+
+    /// Build a `Settings` with custom `UnusedObjectOptions`.
+    fn settings_with_options(options: UnusedObjectOptions) -> Settings {
+        Settings {
+            linter: LinterSettings {
+                rule_options: ResolvedRuleOptions {
+                    unused_object: ResolvedUnusedObjectOptions::resolve(Some(&options)).unwrap(),
+                    ..Default::default()
+                },
+                ..Default::default()
+            },
+        }
     }
 
     /// Renders the `unused_object` diagnostics produced by linting `main_path`
@@ -2406,5 +2424,62 @@ expect_equal(x <- 1, 1)
         Found 1 error.
         "
         );
+    }
+
+    #[test]
+    fn test_skipped_functions_replaces_defaults() {
+        // `skipped-functions` is a full replacement: `my_expect()` is allowed
+        // and the built-in `expect_error()` no longer is.
+        let options = UnusedObjectOptions {
+            skipped_functions: Some(vec!["my_expect".to_string()]),
+            extend_skipped_functions: None,
+        };
+        expect_no_lint_with_settings(
+            "my_expect(x <- 1)",
+            "unused_object",
+            None,
+            settings_with_options(options.clone()),
+        );
+        assert_snapshot!(
+            format_diagnostics_with_settings(
+                "expect_error(x <- 1)",
+                "unused_object",
+                None,
+                Some(settings_with_options(options)),
+            ),
+            @"
+        warning: unused_object
+         --> <test>:1:14
+          |
+        1 | expect_error(x <- 1)
+          |              - Object `x` is defined but never used.
+          |
+        Found 1 error.
+        "
+        );
+    }
+
+    #[test]
+    fn test_extend_skipped_functions_keeps_defaults() {
+        let options = UnusedObjectOptions {
+            skipped_functions: None,
+            extend_skipped_functions: Some(vec!["my_expect".to_string()]),
+        };
+        expect_no_lint_with_settings(
+            "my_expect(x <- 1)\nexpect_error(y <- 1)",
+            "unused_object",
+            None,
+            settings_with_options(options),
+        );
+    }
+
+    #[test]
+    fn test_skipped_functions_and_extend_together_is_an_error() {
+        let options = UnusedObjectOptions {
+            skipped_functions: Some(vec!["my_expect".to_string()]),
+            extend_skipped_functions: Some(vec!["other_expect".to_string()]),
+        };
+        let error = ResolvedUnusedObjectOptions::resolve(Some(&options)).unwrap_err();
+        assert_snapshot!(error.to_string(), @"Cannot specify both `skipped-functions` and `extend-skipped-functions` in `[lint.unused_object]`.");
     }
 }

--- a/crates/jarl-core/src/lints/base/unused_object/mod.rs
+++ b/crates/jarl-core/src/lints/base/unused_object/mod.rs
@@ -2318,4 +2318,93 @@ while (cond) {
             @"All checks passed!"
         );
     }
+
+    #[test]
+    fn test_no_lint_assignment_in_condition_expectation() {
+        // The assignment is what the expectation runs, so never reading the
+        // binding is the point of the test.
+        expect_no_lint(
+            "
+  expect_error(x <- stop(\"boom\"))
+",
+            "unused_object",
+            None,
+        );
+    }
+
+    #[test]
+    fn test_no_lint_assignment_in_namespaced_condition_expectation() {
+        expect_no_lint(
+            "
+testthat::expect_no_error(x <- 1)
+",
+            "unused_object",
+            None,
+        );
+    }
+
+    #[test]
+    fn test_no_lint_assignment_in_named_condition_expectation_argument() {
+        expect_no_lint(
+            "
+expect_error(object = x <- foo, regexp = \"boom\")
+",
+            "unused_object",
+            None,
+        );
+    }
+
+    #[test]
+    fn test_lint_assignment_nested_in_condition_expectation() {
+        // Only the direct argument position is exempt: a block or a function
+        // defined inside the expectation holds ordinary locals.
+        assert_snapshot!(
+            snapshot_lint(
+                "
+expect_snapshot({
+  x <- 1
+  f()
+})
+expect_error(f <- function() y <- 1)
+"
+            ),
+            @"
+        warning: unused_object
+         --> <test>:3:3
+          |
+        3 |   x <- 1
+          |   - Object `x` is defined but never used.
+          |
+        warning: unused_object
+         --> <test>:6:30
+          |
+        6 | expect_error(f <- function() y <- 1)
+          |                              - Object `y` is defined but never used.
+          |
+        Found 2 errors.
+        "
+        );
+    }
+
+    #[test]
+    fn test_lint_assignment_in_non_listed_expectation() {
+        // `expect_equal()` compares a value, so its argument is an ordinary
+        // expression and the binding is a dead store.
+        assert_snapshot!(
+            snapshot_lint(
+                "
+expect_equal(x <- 1, 1)
+"
+            ),
+            @"
+        warning: unused_object
+         --> <test>:2:14
+          |
+        2 | expect_equal(x <- 1, 1)
+          |              - Object `x` is defined but never used.
+          |
+        Found 1 error.
+        "
+        );
+    }
 }

--- a/crates/jarl-core/src/lints/base/unused_object/mod.rs
+++ b/crates/jarl-core/src/lints/base/unused_object/mod.rs
@@ -2472,14 +2472,4 @@ expect_equal(x <- 1, 1)
             settings_with_options(options),
         );
     }
-
-    #[test]
-    fn test_skipped_functions_and_extend_together_is_an_error() {
-        let options = UnusedObjectOptions {
-            skipped_functions: Some(vec!["my_expect".to_string()]),
-            extend_skipped_functions: Some(vec!["other_expect".to_string()]),
-        };
-        let error = ResolvedUnusedObjectOptions::resolve(Some(&options)).unwrap_err();
-        assert_snapshot!(error.to_string(), @"Cannot specify both `skipped-functions` and `extend-skipped-functions` in `[lint.unused_object]`.");
-    }
 }

--- a/crates/jarl-core/src/lints/base/unused_object/options.rs
+++ b/crates/jarl-core/src/lints/base/unused_object/options.rs
@@ -1,0 +1,65 @@
+use std::collections::HashSet;
+
+use crate::rule_options::resolve_with_extend;
+
+/// Default calls whose directly-assigned arguments are allowed to be unused.
+///
+/// These `testthat` expectations run their argument for the condition it
+/// signals — or for a snapshot of its output — rather than for its value, so an
+/// assignment handed straight to one of them exists to give the expectation
+/// something to evaluate rather than to bind a value someone later reads.
+const DEFAULT_SKIPPED_FUNCTIONS: &[&str] = &[
+    "expect_error",
+    "expect_warning",
+    "expect_message",
+    "expect_silent",
+    "expect_defunct",
+    "expect_deprecated",
+    "expect_snapshot",
+    "expect_no_condition",
+    "expect_no_warning",
+    "expect_no_error",
+    "expect_no_message",
+];
+
+/// TOML options for `[lint.unused_object]`.
+///
+/// Use `skipped-functions` to fully replace the default list of calls whose
+/// directly-assigned arguments are allowed to be unused. Use
+/// `extend-skipped-functions` to add to the default list. Specifying both is an
+/// error.
+#[derive(Clone, Debug, PartialEq, Eq, Default, serde::Deserialize)]
+#[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
+#[serde(deny_unknown_fields, rename_all = "kebab-case")]
+pub struct UnusedObjectOptions {
+    pub skipped_functions: Option<Vec<String>>,
+    pub extend_skipped_functions: Option<Vec<String>>,
+}
+
+/// Resolved options for the `unused_object` rule, ready for use during linting.
+#[derive(Clone, Debug)]
+pub struct ResolvedUnusedObjectOptions {
+    pub skipped_functions: HashSet<String>,
+}
+
+impl ResolvedUnusedObjectOptions {
+    pub fn resolve(options: Option<&UnusedObjectOptions>) -> anyhow::Result<Self> {
+        let (base, extend) = match options {
+            Some(opts) => (
+                opts.skipped_functions.as_ref(),
+                opts.extend_skipped_functions.as_ref(),
+            ),
+            None => (None, None),
+        };
+
+        let skipped_functions = resolve_with_extend(
+            base,
+            extend,
+            DEFAULT_SKIPPED_FUNCTIONS,
+            "unused_object",
+            "skipped-functions",
+        )?;
+
+        Ok(Self { skipped_functions })
+    }
+}

--- a/crates/jarl-core/src/lints/base/unused_object/unused_object.rs
+++ b/crates/jarl-core/src/lints/base/unused_object/unused_object.rs
@@ -1,4 +1,5 @@
-use air_r_syntax::RSyntaxNode;
+use air_r_syntax::{RArgument, RCall, RSyntaxNode};
+use biome_rowan::AstNode;
 use oak_semantic::semantic_index::{Definition, DefinitionKind, ScopeId, SemanticIndex};
 
 use jarl_semantic::{
@@ -8,6 +9,25 @@ use jarl_semantic::{
 
 use crate::checker::Checker;
 use crate::diagnostic::{Diagnostic, Fix, ViolationData};
+use crate::utils::get_function_name;
+
+/// `testthat` expectations that run their argument for the condition it signals
+/// — or for a snapshot of its output — rather than for its value. An assignment
+/// handed straight to one of these exists so the expectation has something to
+/// evaluate, so never using it is the point rather than a dead store.
+const CONDITION_EXPECTATION_FUNCTIONS: &[&str] = &[
+    "expect_error",
+    "expect_warning",
+    "expect_message",
+    "expect_silent",
+    "expect_defunct",
+    "expect_deprecated",
+    "expect_snapshot",
+    "expect_no_condition",
+    "expect_no_warning",
+    "expect_no_error",
+    "expect_no_message",
+];
 
 /// Version added: 0.6.0
 ///
@@ -62,6 +82,17 @@ use crate::diagnostic::{Diagnostic, Fix, ViolationData};
 ///
 /// - Some functions that can call other quoted functions (e.g. `do.call()`) are
 ///   supported.
+///
+/// - Assignments passed directly to a `testthat` expectation that runs its
+///   argument for the condition it signals (`expect_error()`,
+///   `expect_warning()`, `expect_message()`, `expect_silent()`,
+///   `expect_defunct()`, `expect_deprecated()`, `expect_snapshot()`,
+///   `expect_no_condition()`, `expect_no_warning()`, `expect_no_error()`,
+///   `expect_no_message()`) are not reported:
+///
+///   ```r
+///   expect_error(x <- foo)
+///   ```
 ///
 /// ## Limitations
 ///
@@ -191,6 +222,11 @@ fn should_lint_definition(info: &SemanticInfo<'_>, def: &Definition) -> bool {
             if assignment_lhs_is_complex(&bin) {
                 return false;
             }
+            // `expect_error(x <- f())`: the binding exists so the expectation
+            // has something to evaluate, so never using it is the point.
+            if is_condition_expectation_argument(bin.syntax()) {
+                return false;
+            }
         }
         // A call-created binding (`assign("x", 1)`, `x %<>% f()`). A call that
         // redirects its binding to another environment never reaches here:
@@ -218,6 +254,23 @@ fn should_lint_definition(info: &SemanticInfo<'_>, def: &Definition) -> bool {
     }
 
     true
+}
+
+/// Whether `node` is passed directly as an argument to one of
+/// [`CONDITION_EXPECTATION_FUNCTIONS`]. Deliberately only the immediate
+/// argument position: an assignment nested in a block or in a function defined
+/// inside the expectation is an ordinary local and stays lintable.
+fn is_condition_expectation_argument(node: &RSyntaxNode) -> bool {
+    let Some(argument) = node.parent().and_then(RArgument::cast) else {
+        return false;
+    };
+    let Some(call) = argument.syntax().ancestors().find_map(RCall::cast) else {
+        return false;
+    };
+    let Ok(function) = call.function() else {
+        return false;
+    };
+    CONDITION_EXPECTATION_FUNCTIONS.contains(&get_function_name(function).as_str())
 }
 
 fn is_exported(

--- a/crates/jarl-core/src/lints/base/unused_object/unused_object.rs
+++ b/crates/jarl-core/src/lints/base/unused_object/unused_object.rs
@@ -1,3 +1,5 @@
+use std::collections::HashSet;
+
 use air_r_syntax::{RArgument, RCall, RSyntaxNode};
 use biome_rowan::AstNode;
 use oak_semantic::semantic_index::{Definition, DefinitionKind, ScopeId, SemanticIndex};
@@ -10,24 +12,6 @@ use jarl_semantic::{
 use crate::checker::Checker;
 use crate::diagnostic::{Diagnostic, Fix, ViolationData};
 use crate::utils::get_function_name;
-
-/// `testthat` expectations that run their argument for the condition it signals
-/// — or for a snapshot of its output — rather than for its value. An assignment
-/// handed straight to one of these exists so the expectation has something to
-/// evaluate, so never using it is the point rather than a dead store.
-const CONDITION_EXPECTATION_FUNCTIONS: &[&str] = &[
-    "expect_error",
-    "expect_warning",
-    "expect_message",
-    "expect_silent",
-    "expect_defunct",
-    "expect_deprecated",
-    "expect_snapshot",
-    "expect_no_condition",
-    "expect_no_warning",
-    "expect_no_error",
-    "expect_no_message",
-];
 
 /// Version added: 0.6.0
 ///
@@ -93,6 +77,9 @@ const CONDITION_EXPECTATION_FUNCTIONS: &[&str] = &[
 ///   ```r
 ///   expect_error(x <- foo)
 ///   ```
+///
+/// You can provide a list of functions whose arguments can be assignments that
+/// shouldn't be reported in `jarl.toml`.
 ///
 /// ## Limitations
 ///
@@ -174,12 +161,13 @@ pub fn unused_object(
         &checker.unevaluated_ranges,
     );
     let exports = &checker.namespace_exports;
+    let skipped = &checker.rule_options.unused_object.skipped_functions;
 
     let mut diagnostics = Vec::new();
     let top_level = ScopeId::from(0);
     for scope_id in info.scope_ids() {
         for (def_id, def) in semantic.definitions(scope_id).iter() {
-            if !should_lint_definition(&info, def) {
+            if !should_lint_definition(&info, def, skipped) {
                 continue;
             }
             if info.is_definition_used(scope_id, def_id) {
@@ -205,7 +193,11 @@ pub fn unused_object(
     Ok(())
 }
 
-fn should_lint_definition(info: &SemanticInfo<'_>, def: &Definition) -> bool {
+fn should_lint_definition(
+    info: &SemanticInfo<'_>,
+    def: &Definition,
+    skipped: &HashSet<String>,
+) -> bool {
     match def.kind() {
         DefinitionKind::Parameter(_)
         | DefinitionKind::ForVariable(_)
@@ -224,7 +216,7 @@ fn should_lint_definition(info: &SemanticInfo<'_>, def: &Definition) -> bool {
             }
             // `expect_error(x <- f())`: the binding exists so the expectation
             // has something to evaluate, so never using it is the point.
-            if is_condition_expectation_argument(bin.syntax()) {
+            if is_skipped_call_argument(bin.syntax(), skipped) {
                 return false;
             }
         }
@@ -256,11 +248,11 @@ fn should_lint_definition(info: &SemanticInfo<'_>, def: &Definition) -> bool {
     true
 }
 
-/// Whether `node` is passed directly as an argument to one of
-/// [`CONDITION_EXPECTATION_FUNCTIONS`]. Deliberately only the immediate
-/// argument position: an assignment nested in a block or in a function defined
-/// inside the expectation is an ordinary local and stays lintable.
-fn is_condition_expectation_argument(node: &RSyntaxNode) -> bool {
+/// Whether `node` is passed directly as an argument to one of `skipped`.
+/// Deliberately only the immediate argument position: an assignment nested in a
+/// block or in a function defined inside the call is an ordinary local and
+/// stays lintable.
+fn is_skipped_call_argument(node: &RSyntaxNode, skipped: &HashSet<String>) -> bool {
     let Some(argument) = node.parent().and_then(RArgument::cast) else {
         return false;
     };
@@ -270,7 +262,7 @@ fn is_condition_expectation_argument(node: &RSyntaxNode) -> bool {
     let Ok(function) = call.function() else {
         return false;
     };
-    CONDITION_EXPECTATION_FUNCTIONS.contains(&get_function_name(function).as_str())
+    skipped.contains(&get_function_name(function))
 }
 
 fn is_exported(

--- a/crates/jarl-core/src/rule_options.rs
+++ b/crates/jarl-core/src/rule_options.rs
@@ -24,6 +24,8 @@ use crate::lints::base::unreachable_code::options::ResolvedUnreachableCodeOption
 use crate::lints::base::unreachable_code::options::UnreachableCodeOptions;
 use crate::lints::base::unused_function::options::ResolvedUnusedFunctionOptions;
 use crate::lints::base::unused_function::options::UnusedFunctionOptions;
+use crate::lints::base::unused_object::options::ResolvedUnusedObjectOptions;
+use crate::lints::base::unused_object::options::UnusedObjectOptions;
 
 /// Resolve a pair of `field` / `extend-field` options against a set of defaults.
 ///
@@ -79,6 +81,7 @@ pub struct RuleOptions<'a> {
     pub undesirable_function: Option<&'a UndesirableFunctionOptions>,
     pub unreachable_code: Option<&'a UnreachableCodeOptions>,
     pub unused_function: Option<&'a UnusedFunctionOptions>,
+    pub unused_object: Option<&'a UnusedObjectOptions>,
 }
 
 /// Resolved per-rule options, ready for use during linting.
@@ -104,6 +107,7 @@ pub struct ResolvedRuleOptions {
     pub undesirable_function: ResolvedUndesirableFunctionOptions,
     pub unreachable_code: ResolvedUnreachableCodeOptions,
     pub unused_function: ResolvedUnusedFunctionOptions,
+    pub unused_object: ResolvedUnusedObjectOptions,
 }
 
 impl ResolvedRuleOptions {
@@ -127,6 +131,7 @@ impl ResolvedRuleOptions {
             )?,
             unreachable_code: ResolvedUnreachableCodeOptions::resolve(options.unreachable_code)?,
             unused_function: ResolvedUnusedFunctionOptions::resolve(options.unused_function)?,
+            unused_object: ResolvedUnusedObjectOptions::resolve(options.unused_object)?,
         })
     }
 }

--- a/crates/jarl-core/src/toml.rs
+++ b/crates/jarl-core/src/toml.rs
@@ -28,6 +28,7 @@ use crate::lints::base::true_false_symbol::options::TrueFalseSymbolOptions;
 use crate::lints::base::undesirable_function::options::UndesirableFunctionOptions;
 use crate::lints::base::unreachable_code::options::UnreachableCodeOptions;
 use crate::lints::base::unused_function::options::UnusedFunctionOptions;
+use crate::lints::base::unused_object::options::UnusedObjectOptions;
 use crate::per_file_ignores::PerFileIgnores;
 use crate::rule_options::{ResolvedRuleOptions, RuleOptions};
 use crate::rule_set::Rule;
@@ -346,6 +347,15 @@ pub struct LinterTomlOptions {
     #[serde(rename = "unused_function")]
     pub unused_function: Option<UnusedFunctionOptions>,
 
+    /// # Options for the `unused_object` rule
+    ///
+    /// Use `skipped-functions` to fully replace the default list of calls whose
+    /// directly-assigned arguments are allowed to be unused. Use
+    /// `extend-skipped-functions` to add to the default list.
+    /// Specifying both is an error.
+    #[serde(rename = "unused_object")]
+    pub unused_object: Option<UnusedObjectOptions>,
+
     /// Catch any unknown fields so we can produce a clean error message that
     /// only lists the primary `[lint]` options (not every rule sub-table).
     #[serde(flatten)]
@@ -434,6 +444,7 @@ impl TomlOptions {
                 undesirable_function: linter.undesirable_function.as_ref(),
                 unreachable_code: linter.unreachable_code.as_ref(),
                 unused_function: linter.unused_function.as_ref(),
+                unused_object: linter.unused_object.as_ref(),
             })?,
             per_file_ignores,
         };

--- a/crates/jarl/tests/integration/toml_rule_args.rs
+++ b/crates/jarl/tests/integration/toml_rule_args.rs
@@ -732,3 +732,88 @@ foo <- function() {
 
     Ok(())
 }
+
+// unused_object ----------------------------------------
+
+#[test]
+fn test_unused_object_both_skipped_and_extend_is_error() -> anyhow::Result<()> {
+    let case = CliTest::with_files([
+        (
+            "jarl.toml",
+            r#"
+[lint]
+
+[lint.unused_object]
+skipped-functions = ["try"]
+extend-skipped-functions = ["my_fun"]
+"#,
+        ),
+        ("test.R", "x <- 1"),
+    ])?;
+
+    insta::assert_snapshot!(
+        &mut case
+            .command()
+            .arg("check")
+            .arg(".")
+            .run()
+            .normalize_os_executable_name()
+            .normalize_temp_paths(),
+        @"
+
+    success: false
+    exit_code: 255
+    ----- stdout -----
+
+    ----- stderr -----
+    jarl failed
+      Cause: Invalid configuration in [TEMP_DIR]/jarl.toml:
+    Cannot specify both `skipped-functions` and `extend-skipped-functions` in `[lint.unused_object]`.
+    "
+    );
+
+    Ok(())
+}
+
+#[test]
+fn test_unused_object_unknown_field_is_error() -> anyhow::Result<()> {
+    let case = CliTest::with_files([
+        (
+            "jarl.toml",
+            r#"
+[lint]
+
+[lint.unused_object]
+unknown-option = ["try"]
+"#,
+        ),
+        ("test.R", "x <- 1"),
+    ])?;
+
+    insta::assert_snapshot!(
+        &mut case
+            .command()
+            .arg("check")
+            .arg(".")
+            .run()
+            .normalize_os_executable_name()
+            .normalize_temp_paths(),
+        @r#"
+
+    success: false
+    exit_code: 255
+    ----- stdout -----
+
+    ----- stderr -----
+    jarl failed
+      Cause: Failed to parse [TEMP_DIR]/jarl.toml:
+    TOML parse error at line 5, column 1
+      |
+    5 | unknown-option = ["try"]
+      | ^^^^^^^^^^^^^^
+    unknown field `unknown-option`, expected `skipped-functions` or `extend-skipped-functions`
+    "#
+    );
+
+    Ok(())
+}

--- a/docs/reference/config-file.md
+++ b/docs/reference/config-file.md
@@ -506,3 +506,31 @@ skipped-functions = ["^cs_", "^pl_", "my\\.function"]
 # (this is basically equivalent to never hiding unused functions).
 threshold-ignore = 10000
 ```
+
+### `unused_object`
+
+Use `skipped-functions` to fully replace the default list of calls whose
+directly-assigned arguments are allowed to be unused. Use
+`extend-skipped-functions` to add to the default list. Specifying both is an
+error.
+
+Function names in `skipped-functions` or `extend-skipped-functions` also match
+namespaced calls, e.g. `skipped-functions = ["expect_error"]` will allow
+`expect_error()` and `testthat::expect_error()`.
+
+Only the direct argument position counts: an assignment nested in a block or in
+a function defined inside the call is an ordinary local and is still reported.
+
+Default: `skipped-functions = ["expect_error", "expect_warning",
+"expect_message", "expect_silent", "expect_defunct", "expect_deprecated",
+"expect_snapshot", "expect_no_condition", "expect_no_warning",
+"expect_no_error", "expect_no_message"]`
+
+```toml
+[lint]
+...
+
+[lint.unused_object]
+# Also allow an unused assignment passed straight to `my_expect()`.
+extend-skipped-functions = ["my_expect"]
+```

--- a/docs/rules/unused_object.md
+++ b/docs/rules/unused_object.md
@@ -54,6 +54,17 @@ this rule handles the following cases:
 - Some functions that can call other quoted functions (e.g. `do.call()`) are
   supported.
 
+- Assignments passed directly to a `testthat` expectation that runs its
+  argument for the condition it signals (`expect_error()`,
+  `expect_warning()`, `expect_message()`, `expect_silent()`,
+  `expect_defunct()`, `expect_deprecated()`, `expect_snapshot()`,
+  `expect_no_condition()`, `expect_no_warning()`, `expect_no_error()`,
+  `expect_no_message()`) are not reported:
+
+  ```r
+  expect_error(x <- foo)
+  ```
+
 ## Limitations
 
 Some cases are deliberately left aside or might be tackled in the future:

--- a/docs/rules/unused_object.md
+++ b/docs/rules/unused_object.md
@@ -65,6 +65,9 @@ this rule handles the following cases:
   expect_error(x <- foo)
   ```
 
+You can provide a list of functions whose arguments can be assignments that
+shouldn't be reported in `jarl.toml`.
+
 ## Limitations
 
 Some cases are deliberately left aside or might be tackled in the future:


### PR DESCRIPTION
Fixes #636 