### PR TITLE
refactor: Use `Rule` enum instead of a `String`

### DIFF
--- a/crates/jarl-core/src/analyze/document.rs
+++ b/crates/jarl-core/src/analyze/document.rs
@@ -118,7 +118,7 @@ pub(crate) fn check_document(
         for (name, range, help) in &package.duplicate_assignments {
             checker.report_diagnostic(Some(Diagnostic::new(
                 ViolationData::new(
-                    "duplicated_function_definition".to_string(),
+                    Rule::DuplicatedFunctionDefinition,
                     format!("`{name}` is defined more than once in this package."),
                     Some(help.clone()),
                 ),
@@ -132,7 +132,7 @@ pub(crate) fn check_document(
         for (name, range, help) in &package.unused_functions {
             checker.report_diagnostic(Some(Diagnostic::new(
                 ViolationData::new(
-                    "unused_function".to_string(),
+                    Rule::UnusedFunction,
                     format!("`{name}` is defined but never called in this package."),
                     Some(help.clone()),
                 ),

--- a/crates/jarl-core/src/check.rs
+++ b/crates/jarl-core/src/check.rs
@@ -386,8 +386,11 @@ pub fn get_checks(
             x.filename = file.to_path_buf();
             let rule = x.message.rule;
             // The rule has no fix at all, the user excluded it via
-            // `unfixable` / `fixable`, the node carries a comment (#95), or the
-            // file didn't parse cleanly: in all of those the fix must not apply.
+            // `unfixable` / `fixable`, the node carries a comment, or the file
+            // didn't parse cleanly: in all of those the fix must not apply.
+            //
+            // TODO: the `to_skip` term should be removed once comments in nodes
+            // are better handled, #95.
             if rule.has_no_fix()
                 || config.unfixable.contains(&rule)
                 || config

--- a/crates/jarl-core/src/check.rs
+++ b/crates/jarl-core/src/check.rs
@@ -379,38 +379,24 @@ pub fn get_checks(
     // When we get all the diagnostics with check_expression() above, we don't
     // pay attention to whether the user wants to fix them or not. Adding this
     // step here is a way to filter those fixes out before calling apply_fixes().
-    let rules_without_fix = checker
-        .rule_set
-        .iter()
-        .filter(|x| x.has_no_fix())
-        .map(|x| x.name().to_string())
-        .collect::<Vec<String>>();
-
     let diagnostics: Vec<Diagnostic> = checker
         .diagnostics
         .into_iter()
         .map(|mut x| {
             x.filename = file.to_path_buf();
-            // Check if fix should be skipped based on fixable/unfixable settings
-            if rules_without_fix.contains(&x.message.name) {
-                x.fix = Fix::empty();
-            }
-            // Also check against unfixable set from config
-            if config.unfixable.contains(&x.message.name) {
-                x.fix = Fix::empty();
-            }
-            // If fixable is specified, only allow those rules to have fixes
-            if let Some(ref fixable_set) = config.fixable
-                && !fixable_set.contains(&x.message.name)
+            let rule = x.message.rule;
+            // The rule has no fix at all, the user excluded it via
+            // `unfixable` / `fixable`, the node carries a comment (#95), or the
+            // file didn't parse cleanly: in all of those the fix must not apply.
+            if rule.has_no_fix()
+                || config.unfixable.contains(&rule)
+                || config
+                    .fixable
+                    .as_ref()
+                    .is_some_and(|set| !set.contains(&rule))
+                || x.fix.to_skip
+                || has_parse_errors
             {
-                x.fix = Fix::empty();
-            }
-            // TODO: this should be removed once comments in nodes are better
-            // handled, #95
-            if x.fix.to_skip {
-                x.fix = Fix::empty();
-            }
-            if has_parse_errors {
                 x.fix = Fix::empty();
             }
             x

--- a/crates/jarl-core/src/config.rs
+++ b/crates/jarl-core/src/config.rs
@@ -83,10 +83,10 @@ pub struct Config {
     /// Apply fixes even if there is no version control system?
     pub allow_no_vcs: bool,
     /// Rules that should not have their fixes applied (from unfixable setting)
-    pub unfixable: HashSet<String>,
+    pub unfixable: HashSet<Rule>,
     /// Rules that are allowed to have fixes applied (from fixable setting)
     /// None means all rules with fixes can be applied
-    pub fixable: Option<HashSet<String>>,
+    pub fixable: Option<HashSet<Rule>>,
     /// Whether to lint R code inside roxygen `@examples` sections
     pub check_roxygen: bool,
     /// Whether to apply autofixes to roxygen examples
@@ -267,16 +267,13 @@ pub(crate) fn resolve_rule_names<'a>(
         .collect())
 }
 
-/// [`resolve_rule_names`] for the settings still carried as rule-name strings
-/// (`fixable` / `unfixable`, which are matched against `Diagnostic`'s name).
+/// [`resolve_rule_names`] collected into a set, for the settings matched
+/// against a `Diagnostic`'s rule (`fixable` / `unfixable`).
 fn resolve_rule_name_set<'a>(
     names: impl IntoIterator<Item = &'a str>,
     field: &str,
-) -> Result<HashSet<String>> {
-    Ok(resolve_rule_names(names, field)?
-        .into_iter()
-        .map(|rule| rule.name().to_string())
-        .collect())
+) -> Result<HashSet<Rule>> {
+    Ok(resolve_rule_names(names, field)?.into_iter().collect())
 }
 
 /// Parse CLI rule arguments into a [`RuleSelection`].
@@ -333,7 +330,7 @@ fn resolve_optional(names: Option<&[String]>, field: &str) -> Result<Option<Hash
 /// `fixable` is `None` when unset, meaning every rule with a fix may apply it.
 pub fn parse_fixable_toml(
     toml_settings: Option<&Settings>,
-) -> Result<(Option<HashSet<String>>, HashSet<String>)> {
+) -> Result<(Option<HashSet<Rule>>, HashSet<Rule>)> {
     let Some(settings) = toml_settings else {
         return Ok((None, HashSet::new()));
     };

--- a/crates/jarl-core/src/diagnostic.rs
+++ b/crates/jarl-core/src/diagnostic.rs
@@ -31,8 +31,8 @@ impl Fix {
 
 /// Details on the violated rule.
 pub trait Violation {
-    /// Name of the rule.
-    fn name(&self) -> String;
+    /// The violated rule.
+    fn rule(&self) -> Rule;
     /// Explanation of the rule.
     fn body(&self) -> String;
     /// Optional suggestion for how to fix the violation.
@@ -43,7 +43,9 @@ pub trait Violation {
 
 #[derive(Serialize, Deserialize, Debug, PartialEq, Eq)]
 pub struct ViolationData {
-    pub name: String,
+    // Serialized as "name" so the JSON output keeps the key it always had.
+    #[serde(rename = "name")]
+    pub rule: Rule,
     pub body: String,
     pub suggestion: Option<String>,
 }
@@ -64,7 +66,7 @@ pub struct Diagnostic {
 impl<T: Violation> From<T> for ViolationData {
     fn from(value: T) -> Self {
         Self {
-            name: Violation::name(&value),
+            rule: Violation::rule(&value),
             body: Violation::body(&value),
             suggestion: Violation::suggestion(&value),
         }
@@ -72,16 +74,8 @@ impl<T: Violation> From<T> for ViolationData {
 }
 
 impl ViolationData {
-    pub fn new(name: String, body: String, suggestion: Option<String>) -> Self {
-        Self { name, body, suggestion }
-    }
-
-    pub fn empty() -> Self {
-        Self {
-            name: "".to_string(),
-            body: "".to_string(),
-            suggestion: None,
-        }
+    pub fn new(rule: Rule, body: String, suggestion: Option<String>) -> Self {
+        Self { rule, body, suggestion }
     }
 }
 
@@ -96,41 +90,16 @@ impl Diagnostic {
         }
     }
 
-    pub fn empty() -> Self {
-        Self {
-            message: ViolationData::empty(),
-            range: TextRange::empty(0.into()),
-            location: None,
-            fix: Fix::empty(),
-            filename: "".into(),
-        }
-    }
-
     // TODO: in these three functions, the first condition should be removed
     // once comments in nodes are better handled, #95.
     pub fn has_safe_fix(&self) -> bool {
-        if self.fix.to_skip {
-            return false;
-        }
-        Rule::from_name(&self.message.name)
-            .map(|r| r.fix_status() == FixStatus::Safe)
-            .unwrap_or(false)
+        !self.fix.to_skip && self.message.rule.fix_status() == FixStatus::Safe
     }
     pub fn has_unsafe_fix(&self) -> bool {
-        if self.fix.to_skip {
-            return false;
-        }
-        Rule::from_name(&self.message.name)
-            .map(|r| r.fix_status() == FixStatus::Unsafe)
-            .unwrap_or(false)
+        !self.fix.to_skip && self.message.rule.fix_status() == FixStatus::Unsafe
     }
     pub fn has_no_fix(&self) -> bool {
-        if self.fix.to_skip {
-            return true;
-        }
-        Rule::from_name(&self.message.name)
-            .map(|r| r.fix_status() == FixStatus::None)
-            .unwrap_or(true)
+        self.fix.to_skip || self.message.rule.fix_status() == FixStatus::None
     }
 }
 

--- a/crates/jarl-core/src/lints/base/all_equal/all_equal.rs
+++ b/crates/jarl-core/src/lints/base/all_equal/all_equal.rs
@@ -1,4 +1,5 @@
 use crate::diagnostic::*;
+use crate::rule_set::Rule;
 use crate::utils::{get_nested_functions_content, node_contains_comments};
 use crate::utils_ast::AstNodeExt;
 use air_r_syntax::*;
@@ -60,7 +61,7 @@ pub fn all_equal(ast: &RCall, fn_name: &str) -> anyhow::Result<Option<Diagnostic
         let range = outer_syntax.text_trimmed_range();
         return Ok(Some(Diagnostic::new(
             ViolationData::new(
-                "all_equal".to_string(),
+                Rule::AllEqual,
                 "`isFALSE(all.equal())` always returns `FALSE`".to_string(),
                 Some("Use `!isTRUE()` to check for differences instead.".to_string()),
             ),
@@ -100,7 +101,7 @@ pub fn all_equal(ast: &RCall, fn_name: &str) -> anyhow::Result<Option<Diagnostic
 
     let diagnostic = Diagnostic::new(
         ViolationData::new(
-            "all_equal".to_string(),
+            Rule::AllEqual,
             msg,
             Some("Wrap `all.equal()` in `isTRUE()`, or replace it by `identical()` if no tolerance is required.".to_string()),
         ),

--- a/crates/jarl-core/src/lints/base/any_duplicated/any_duplicated.rs
+++ b/crates/jarl-core/src/lints/base/any_duplicated/any_duplicated.rs
@@ -1,4 +1,5 @@
 use crate::diagnostic::*;
+use crate::rule_set::Rule;
 use crate::utils::{get_nested_functions_content, node_contains_comments};
 use air_r_syntax::*;
 
@@ -38,8 +39,8 @@ pub struct AnyDuplicated;
 ///
 /// See `?anyDuplicated`
 impl Violation for AnyDuplicated {
-    fn name(&self) -> String {
-        "any_duplicated".to_string()
+    fn rule(&self) -> Rule {
+        Rule::AnyDuplicated
     }
     fn body(&self) -> String {
         "`any(duplicated(...))` is inefficient.".to_string()

--- a/crates/jarl-core/src/lints/base/any_is_na/any_is_na.rs
+++ b/crates/jarl-core/src/lints/base/any_is_na/any_is_na.rs
@@ -1,4 +1,5 @@
 use crate::diagnostic::*;
+use crate::rule_set::Rule;
 use crate::utils::{get_nested_functions_content, node_contains_comments};
 use air_r_syntax::*;
 use biome_rowan::AstNode;
@@ -40,7 +41,7 @@ pub fn any_is_na(ast: &RCall, fn_name: &str) -> anyhow::Result<Option<Diagnostic
     let range = outer_syntax.text_trimmed_range();
     Ok(Some(Diagnostic::new(
         ViolationData::new(
-            "any_is_na".to_string(),
+            Rule::AnyIsNa,
             "`any(is.na(...))` is inefficient.".to_string(),
             Some("Use `anyNA(...)` instead.".to_string()),
         ),
@@ -102,7 +103,7 @@ pub fn any_is_na_2(ast: &RBinaryExpression) -> anyhow::Result<Option<Diagnostic>
 
     let diagnostic = Diagnostic::new(
         ViolationData::new(
-            "any_is_na".to_string(),
+            Rule::AnyIsNa,
             body.to_string(),
             Some(suggestion.to_string()),
         ),

--- a/crates/jarl-core/src/lints/base/assignment/assignment.rs
+++ b/crates/jarl-core/src/lints/base/assignment/assignment.rs
@@ -1,4 +1,5 @@
 use crate::diagnostic::*;
+use crate::rule_set::Rule;
 use air_r_syntax::*;
 use biome_rowan::AstNode;
 
@@ -121,7 +122,7 @@ pub fn assignment(
 
     let range = ast.syntax().text_trimmed_range();
     let diagnostic = Diagnostic::new(
-        ViolationData::new("assignment".to_string(), msg.to_string(), None),
+        ViolationData::new(Rule::Assignment, msg.to_string(), None),
         range_to_report,
         Fix {
             content: replacement,

--- a/crates/jarl-core/src/lints/base/browser/browser.rs
+++ b/crates/jarl-core/src/lints/base/browser/browser.rs
@@ -1,4 +1,5 @@
 use crate::diagnostic::*;
+use crate::rule_set::Rule;
 use air_r_syntax::*;
 use biome_rowan::AstNode;
 
@@ -37,8 +38,8 @@ pub struct Browser;
 ///
 /// See `?browser`
 impl Violation for Browser {
-    fn name(&self) -> String {
-        "browser".to_string()
+    fn rule(&self) -> Rule {
+        Rule::Browser
     }
     fn body(&self) -> String {
         "Calls to `browser()` should be removed.".to_string()

--- a/crates/jarl-core/src/lints/base/class_equals/class_equals.rs
+++ b/crates/jarl-core/src/lints/base/class_equals/class_equals.rs
@@ -1,4 +1,5 @@
 use crate::diagnostic::*;
+use crate::rule_set::Rule;
 use crate::utils::{get_arg_by_position, get_function_name, node_contains_comments};
 use air_r_syntax::*;
 use biome_rowan::AstNode;
@@ -113,7 +114,7 @@ pub fn class_equals(ast: &RBinaryExpression) -> anyhow::Result<Option<Diagnostic
     let range = ast.syntax().text_trimmed_range();
     let diagnostic = Diagnostic::new(
         ViolationData::new(
-            "class_equals".to_string(),
+            Rule::ClassEquals,
             "Comparing `class(x)` with `==` or `%in%` can be problematic.".to_string(),
             Some("Use `inherits(x, 'a')` instead.".to_string()),
         ),
@@ -153,7 +154,7 @@ pub fn class_identical(ast: &RCall, fn_name: &str) -> anyhow::Result<Option<Diag
     let range = ast.syntax().text_trimmed_range();
     let diagnostic = Diagnostic::new(
         ViolationData::new(
-            "class_equals".to_string(),
+            Rule::ClassEquals,
             "Using `identical(class(x), 'a')` can be problematic.".to_string(),
             Some("Use `inherits(x, 'a')` instead.".to_string()),
         ),

--- a/crates/jarl-core/src/lints/base/coalesce/coalesce.rs
+++ b/crates/jarl-core/src/lints/base/coalesce/coalesce.rs
@@ -1,4 +1,5 @@
 use crate::diagnostic::*;
+use crate::rule_set::Rule;
 use crate::utils::{get_function_name, node_contains_comments};
 use air_r_syntax::*;
 use biome_rowan::{AstNode, AstNodeList};
@@ -177,7 +178,7 @@ pub fn coalesce(ast: &RIfStatement) -> anyhow::Result<Option<Diagnostic>> {
     let range = ast.syntax().text_trimmed_range();
     let diagnostic = Diagnostic::new(
         ViolationData::new(
-            "coalesce".to_string(),
+            Rule::Coalesce,
             msg,
             Some("Use `x %||% y` instead.".to_string()),
         ),

--- a/crates/jarl-core/src/lints/base/comparison_negation/comparison_negation.rs
+++ b/crates/jarl-core/src/lints/base/comparison_negation/comparison_negation.rs
@@ -1,4 +1,5 @@
 use crate::diagnostic::*;
+use crate::rule_set::Rule;
 use crate::utils::node_contains_comments;
 use air_r_syntax::*;
 use biome_rowan::AstNode;
@@ -81,7 +82,7 @@ pub fn comparison_negation(ast: &RUnaryExpression) -> anyhow::Result<Option<Diag
     let range = ast.syntax().text_trimmed_range();
     let diagnostic = Diagnostic::new(
         ViolationData::new(
-            "comparison_negation".to_string(),
+            Rule::ComparisonNegation,
             format!("`!(x {} y)` can be simplified.", operator.text_trimmed()),
             Some(format!("Use `x {} y` instead.", replacement_operator)),
         ),

--- a/crates/jarl-core/src/lints/base/condition_call/condition_call.rs
+++ b/crates/jarl-core/src/lints/base/condition_call/condition_call.rs
@@ -1,4 +1,5 @@
 use crate::diagnostic::*;
+use crate::rule_set::Rule;
 use crate::utils::{get_arg_by_name, node_contains_comments};
 use air_r_syntax::*;
 use biome_rowan::AstNode;
@@ -136,7 +137,7 @@ pub fn condition_call(ast: &RCall, fn_name: &str) -> anyhow::Result<Option<Diagn
 
     let range = ast.syntax().text_trimmed_range();
     let diagnostic = Diagnostic::new(
-        ViolationData::new("condition_call".to_string(), body, Some(suggestion)),
+        ViolationData::new(Rule::ConditionCall, body, Some(suggestion)),
         range,
         fix,
     );

--- a/crates/jarl-core/src/lints/base/condition_message/condition_message.rs
+++ b/crates/jarl-core/src/lints/base/condition_message/condition_message.rs
@@ -1,4 +1,5 @@
 use crate::diagnostic::*;
+use crate::rule_set::Rule;
 use crate::utils::{
     get_arg_by_name, get_function_name, get_nested_functions_content, node_contains_comments,
 };
@@ -71,7 +72,7 @@ pub fn condition_message(ast: &RCall, fn_name: &str) -> anyhow::Result<Option<Di
     let range = outer_syntax.text_trimmed_range();
     Ok(Some(Diagnostic::new(
         ViolationData::new(
-            "condition_message".to_string(),
+            Rule::ConditionMessage,
             format!("`{}(paste0(...))` can be simplified.", fn_name),
             Some(format!("Use `{}(...)` instead.", fn_name)),
         ),

--- a/crates/jarl-core/src/lints/base/download_file/download_file.rs
+++ b/crates/jarl-core/src/lints/base/download_file/download_file.rs
@@ -1,4 +1,5 @@
 use crate::diagnostic::*;
+use crate::rule_set::Rule;
 use crate::utils::{Formals, get_arg};
 use air_r_syntax::*;
 use biome_rowan::AstNode;
@@ -95,7 +96,7 @@ pub fn download_file(ast: &RCall, fn_name: &str) -> anyhow::Result<Option<Diagno
     let range = ast.syntax().text_trimmed_range();
     let diagnostic = Diagnostic::new(
         ViolationData::new(
-            "download_file".to_string(),
+            Rule::DownloadFile,
             msg.to_string(),
             Some(suggestion.to_string()),
         ),

--- a/crates/jarl-core/src/lints/base/duplicated_arguments/duplicated_arguments.rs
+++ b/crates/jarl-core/src/lints/base/duplicated_arguments/duplicated_arguments.rs
@@ -2,6 +2,7 @@ use std::collections::{HashMap, HashSet};
 
 use crate::checker::Checker;
 use crate::diagnostic::*;
+use crate::rule_set::Rule;
 use air_r_syntax::*;
 use anyhow::anyhow;
 use biome_rowan::AstNode;
@@ -100,7 +101,7 @@ pub fn duplicated_arguments(ast: &RCall, checker: &Checker) -> anyhow::Result<Op
         let range = ast.syntax().text_trimmed_range();
         let diagnostic = Diagnostic::new(
             ViolationData::new(
-                "duplicated_arguments".to_string(),
+                Rule::DuplicatedArguments,
                 [
                     "Avoid duplicated arguments in function calls. Duplicated argument(s): ",
                     &duplicated_arg_names

--- a/crates/jarl-core/src/lints/base/empty_assignment/empty_assignment.rs
+++ b/crates/jarl-core/src/lints/base/empty_assignment/empty_assignment.rs
@@ -1,4 +1,5 @@
 use crate::diagnostic::*;
+use crate::rule_set::Rule;
 use air_r_syntax::*;
 use biome_rowan::AstNode;
 
@@ -30,8 +31,8 @@ pub struct EmptyAssignment;
 /// b <- NULL
 /// ```
 impl Violation for EmptyAssignment {
-    fn name(&self) -> String {
-        "empty_assignment".to_string()
+    fn rule(&self) -> Rule {
+        Rule::EmptyAssignment
     }
     fn body(&self) -> String {
         "Assign NULL explicitly or, whenever possible, allocate the empty object with the right type and size.".to_string()

--- a/crates/jarl-core/src/lints/base/empty_file/empty_file.rs
+++ b/crates/jarl-core/src/lints/base/empty_file/empty_file.rs
@@ -1,4 +1,5 @@
 use crate::diagnostic::{Diagnostic, Fix, Violation};
+use crate::rule_set::Rule;
 use air_r_syntax::RSyntaxNode;
 use biome_rowan::TextRange;
 
@@ -29,8 +30,8 @@ pub struct EmptyFile;
 ///
 /// Instead, delete the file or add the intended code.
 impl Violation for EmptyFile {
-    fn name(&self) -> String {
-        "empty_file".to_string()
+    fn rule(&self) -> Rule {
+        Rule::EmptyFile
     }
     fn body(&self) -> String {
         "This file is empty or only contains comments.".to_string()

--- a/crates/jarl-core/src/lints/base/equals_na/equals_na.rs
+++ b/crates/jarl-core/src/lints/base/equals_na/equals_na.rs
@@ -1,4 +1,5 @@
 use crate::diagnostic::*;
+use crate::rule_set::Rule;
 use crate::utils::node_contains_comments;
 use air_r_syntax::*;
 use biome_rowan::AstNode;
@@ -101,7 +102,7 @@ pub fn equals_na(ast: &RBinaryExpression) -> anyhow::Result<Option<Diagnostic>> 
 
     let diagnostic = Diagnostic::new(
         ViolationData::new(
-            "equals_na".to_string(),
+            Rule::EqualsNa,
             format!("Comparing to NA with `{operator_text}` is problematic."),
             Some(suggestion.to_string()),
         ),

--- a/crates/jarl-core/src/lints/base/equals_nan/equals_nan.rs
+++ b/crates/jarl-core/src/lints/base/equals_nan/equals_nan.rs
@@ -1,4 +1,5 @@
 use crate::diagnostic::*;
+use crate::rule_set::Rule;
 use crate::utils::node_contains_comments;
 use air_r_syntax::*;
 use biome_rowan::AstNode;
@@ -35,8 +36,8 @@ pub struct EqualsNaN;
 /// is.nan(x)
 /// ```
 impl Violation for EqualsNaN {
-    fn name(&self) -> String {
-        "equals_nan".to_string()
+    fn rule(&self) -> Rule {
+        Rule::EqualsNaN
     }
     fn body(&self) -> String {
         "Comparing to NaN with `==`, `!=` or `%in%` is problematic.".to_string()

--- a/crates/jarl-core/src/lints/base/equals_null/equals_null.rs
+++ b/crates/jarl-core/src/lints/base/equals_null/equals_null.rs
@@ -1,4 +1,5 @@
 use crate::diagnostic::*;
+use crate::rule_set::Rule;
 use crate::utils::node_contains_comments;
 use air_r_syntax::*;
 use biome_rowan::AstNode;
@@ -41,8 +42,8 @@ pub struct EqualsNull;
 /// is.null(y)
 /// ```
 impl Violation for EqualsNull {
-    fn name(&self) -> String {
-        "equals_null".to_string()
+    fn rule(&self) -> Rule {
+        Rule::EqualsNull
     }
     fn body(&self) -> String {
         "Comparing to NULL with `==`, `!=` or `%in%` is problematic.".to_string()

--- a/crates/jarl-core/src/lints/base/fixed_regex/fixed_regex.rs
+++ b/crates/jarl-core/src/lints/base/fixed_regex/fixed_regex.rs
@@ -1,4 +1,5 @@
 use crate::diagnostic::*;
+use crate::rule_set::Rule;
 use crate::utils::{Formals, get_arg, node_contains_comments};
 use air_r_syntax::*;
 use biome_rowan::AstNode;
@@ -67,8 +68,8 @@ pub struct FixedRegex;
 ///
 /// See `?grep` and `?fixed`
 impl Violation for FixedRegex {
-    fn name(&self) -> String {
-        "fixed_regex".to_string()
+    fn rule(&self) -> Rule {
+        Rule::FixedRegex
     }
     fn body(&self) -> String {
         "Pattern contains no regex special characters but `fixed = TRUE` is not set.".to_string()

--- a/crates/jarl-core/src/lints/base/for_loop_dup_index/for_loop_dup_index.rs
+++ b/crates/jarl-core/src/lints/base/for_loop_dup_index/for_loop_dup_index.rs
@@ -1,4 +1,5 @@
 use crate::diagnostic::*;
+use crate::rule_set::Rule;
 use air_r_syntax::*;
 use biome_rowan::AstNode;
 
@@ -36,8 +37,8 @@ pub struct ForLoopDupIndex;
 /// }
 /// ```
 impl Violation for ForLoopDupIndex {
-    fn name(&self) -> String {
-        "for_loop_dup_index".to_string()
+    fn rule(&self) -> Rule {
+        Rule::ForLoopDupIndex
     }
     fn body(&self) -> String {
         "This index variable is already used in a parent `for` loop.".to_string()

--- a/crates/jarl-core/src/lints/base/for_loop_index/for_loop_index.rs
+++ b/crates/jarl-core/src/lints/base/for_loop_index/for_loop_index.rs
@@ -1,4 +1,5 @@
 use crate::diagnostic::*;
+use crate::rule_set::Rule;
 use air_r_syntax::*;
 use biome_rowan::{AstNode, Text};
 
@@ -33,8 +34,8 @@ pub struct ForLoopIndex;
 /// }
 /// ```
 impl Violation for ForLoopIndex {
-    fn name(&self) -> String {
-        "for_loop_index".to_string()
+    fn rule(&self) -> Rule {
+        Rule::ForLoopIndex
     }
     fn body(&self) -> String {
         "Don't re-use any sequence symbols as the index symbol in a for loop.".to_string()

--- a/crates/jarl-core/src/lints/base/glue/glue.rs
+++ b/crates/jarl-core/src/lints/base/glue/glue.rs
@@ -1,4 +1,5 @@
 use crate::diagnostic::*;
+use crate::rule_set::Rule;
 use crate::utils::{get_arg_by_name, get_unnamed_args};
 use crate::utils_ast::AstNodeExt;
 use air_r_syntax::*;
@@ -100,7 +101,7 @@ pub fn glue(
     let diagnostic = if has_incomplete_delimiters(&dot_text, open, close) {
         Some(Diagnostic::new(
             ViolationData::new(
-                "glue".to_string(),
+                Rule::Glue,
                 "This `glue()` call contains incomplete delimiters and would error when evaluated."
                     .to_string(),
                 None,
@@ -111,7 +112,7 @@ pub fn glue(
     } else if !dot_text.contains(open) && !dot_text.contains(close) {
         Some(Diagnostic::new(
             ViolationData::new(
-                "glue".to_string(),
+                Rule::Glue,
                 "This `glue()` call isn't necessary because it performs no interpolation."
                     .to_string(),
                 None,

--- a/crates/jarl-core/src/lints/base/grepv/grepv.rs
+++ b/crates/jarl-core/src/lints/base/grepv/grepv.rs
@@ -1,4 +1,5 @@
 use crate::diagnostic::*;
+use crate::rule_set::Rule;
 use crate::utils::{Formals, drop_arg, get_arg, node_contains_comments};
 use air_r_syntax::*;
 use biome_rowan::AstNode;
@@ -46,8 +47,8 @@ pub struct Grepv;
 ///
 /// See `?grepv`
 impl Violation for Grepv {
-    fn name(&self) -> String {
-        "grepv".to_string()
+    fn rule(&self) -> Rule {
+        Rule::Grepv
     }
     fn body(&self) -> String {
         "`grep(..., value = TRUE)` can be simplified.".to_string()

--- a/crates/jarl-core/src/lints/base/if_always_true/if_always_true.rs
+++ b/crates/jarl-core/src/lints/base/if_always_true/if_always_true.rs
@@ -1,4 +1,5 @@
 use crate::diagnostic::*;
+use crate::rule_set::Rule;
 use air_r_syntax::*;
 use biome_rowan::AstNode;
 
@@ -42,8 +43,8 @@ pub struct IfAlwaysTrue;
 /// print("always true")
 /// ```
 impl Violation for IfAlwaysTrue {
-    fn name(&self) -> String {
-        "if_always_true".to_string()
+    fn rule(&self) -> Rule {
+        Rule::IfAlwaysTrue
     }
     fn body(&self) -> String {
         "`if` condition always evaluates to `TRUE`.".to_string()

--- a/crates/jarl-core/src/lints/base/if_not_else/if_not_else.rs
+++ b/crates/jarl-core/src/lints/base/if_not_else/if_not_else.rs
@@ -2,6 +2,7 @@ use std::collections::HashSet;
 
 use crate::checker::Checker;
 use crate::diagnostic::*;
+use crate::rule_set::Rule;
 use crate::utils::{get_arg_by_position, get_function_name};
 use air_r_syntax::*;
 use biome_rowan::AstNode;
@@ -60,7 +61,7 @@ pub fn if_not_else(ast: &RIfStatement, checker: &Checker) -> anyhow::Result<Opti
     let range = ast.syntax().text_trimmed_range();
     let diagnostic = Diagnostic::new(
         ViolationData::new(
-            "if_not_else".to_string(),
+            Rule::IfNotElse,
             "Negating the condition like `if (!A) y else x` can be hard to read.".to_string(),
             Some("Remove the negation and swap branches, such as `if (A) x else y`.".to_string()),
         ),
@@ -97,7 +98,7 @@ pub fn if_not_else_call(
     let range = ast.syntax().text_trimmed_range();
     let diagnostic = Diagnostic::new(
         ViolationData::new(
-            "if_not_else".to_string(),
+            Rule::IfNotElse,
             format!("Negating the condition like `{fn_name}(!A, y, x)` can be hard to read."),
             Some(format!(
                 "Remove the negation and swap branches, such as `{fn_name}(A, x, y)`."

--- a/crates/jarl-core/src/lints/base/implicit_assignment/implicit_assignment.rs
+++ b/crates/jarl-core/src/lints/base/implicit_assignment/implicit_assignment.rs
@@ -1,5 +1,6 @@
 use crate::check::Checker;
 use crate::diagnostic::*;
+use crate::rule_set::Rule;
 use crate::utils::get_function_name;
 use crate::utils_ast::AstNodeExt;
 use air_r_syntax::*;
@@ -204,7 +205,7 @@ pub fn implicit_assignment(
 
     let range = ast.syntax().text_trimmed_range();
     let diagnostic = Diagnostic::new(
-        ViolationData::new("implicit_assignment".to_string(), msg.to_string(), None),
+        ViolationData::new(Rule::ImplicitAssignment, msg.to_string(), None),
         range,
         Fix::empty(),
     );

--- a/crates/jarl-core/src/lints/base/internal_function/internal_function.rs
+++ b/crates/jarl-core/src/lints/base/internal_function/internal_function.rs
@@ -1,4 +1,5 @@
 use crate::diagnostic::*;
+use crate::rule_set::Rule;
 use air_r_syntax::*;
 use biome_rowan::AstNode;
 
@@ -25,7 +26,7 @@ pub fn internal_function(ast: &RNamespaceExpression) -> anyhow::Result<Option<Di
     let range = ast.syntax().text_trimmed_range();
     let diagnostic = Diagnostic::new(
         ViolationData::new(
-            "internal_function".to_string(),
+            Rule::InternalFunction,
             "Accessing a package's internal function with `:::` is likely to break in the future."
                 .to_string(),
             Some("Use public functions via `::` instead.".to_string()),

--- a/crates/jarl-core/src/lints/base/is_numeric/is_numeric.rs
+++ b/crates/jarl-core/src/lints/base/is_numeric/is_numeric.rs
@@ -1,4 +1,5 @@
 use crate::diagnostic::*;
+use crate::rule_set::Rule;
 use crate::utils::node_contains_comments;
 use air_r_syntax::*;
 use biome_rowan::AstNode;
@@ -33,8 +34,8 @@ pub struct IsNumeric;
 ///
 /// See `?is.numeric`
 impl Violation for IsNumeric {
-    fn name(&self) -> String {
-        "is_numeric".to_string()
+    fn rule(&self) -> Rule {
+        Rule::IsNumeric
     }
     fn body(&self) -> String {
         "`is.numeric(x) || is.integer(x)` is redundant.".to_string()

--- a/crates/jarl-core/src/lints/base/length_levels/length_levels.rs
+++ b/crates/jarl-core/src/lints/base/length_levels/length_levels.rs
@@ -1,4 +1,5 @@
 use crate::diagnostic::*;
+use crate::rule_set::Rule;
 use crate::utils::{get_nested_functions_content, node_contains_comments};
 use air_r_syntax::*;
 pub struct LengthLevels;
@@ -29,8 +30,8 @@ pub struct LengthLevels;
 /// nlevels(x)
 /// ```
 impl Violation for LengthLevels {
-    fn name(&self) -> String {
-        "length_levels".to_string()
+    fn rule(&self) -> Rule {
+        Rule::LengthLevels
     }
     fn body(&self) -> String {
         "`length(levels(...))` is less readable than `nlevels(...)`.".to_string()

--- a/crates/jarl-core/src/lints/base/length_test/length_test.rs
+++ b/crates/jarl-core/src/lints/base/length_test/length_test.rs
@@ -1,4 +1,5 @@
 use crate::diagnostic::*;
+use crate::rule_set::Rule;
 use crate::utils::node_contains_comments;
 use air_r_syntax::RSyntaxKind::*;
 use air_r_syntax::*;
@@ -32,8 +33,8 @@ pub struct LengthTest;
 /// length(x) == 1
 /// ```
 impl Violation for LengthTest {
-    fn name(&self) -> String {
-        "length_test".to_string()
+    fn rule(&self) -> Rule {
+        Rule::LengthTest
     }
     fn body(&self) -> String {
         "Checking the length of a logical vector is likely a mistake".to_string()

--- a/crates/jarl-core/src/lints/base/lengths/lengths.rs
+++ b/crates/jarl-core/src/lints/base/lengths/lengths.rs
@@ -1,4 +1,5 @@
 use crate::diagnostic::*;
+use crate::rule_set::Rule;
 use crate::utils::{Formals, get_arg, node_contains_comments};
 use air_r_syntax::*;
 use anyhow::Context;
@@ -43,8 +44,8 @@ pub struct Lengths;
 ///
 /// See `?lengths`
 impl Violation for Lengths {
-    fn name(&self) -> String {
-        "lengths".to_string()
+    fn rule(&self) -> Rule {
+        Rule::Lengths
     }
     fn body(&self) -> String {
         "Using `length()` on each element of a list is inefficient.".to_string()

--- a/crates/jarl-core/src/lints/base/list2df/list2df.rs
+++ b/crates/jarl-core/src/lints/base/list2df/list2df.rs
@@ -1,4 +1,5 @@
 use crate::diagnostic::*;
+use crate::rule_set::Rule;
 use crate::utils::{Formals, get_arg, get_arg_by_position, node_contains_comments};
 use air_r_syntax::*;
 use biome_rowan::AstNode;
@@ -41,8 +42,8 @@ pub struct List2Df;
 ///
 /// See `?list2DF`
 impl Violation for List2Df {
-    fn name(&self) -> String {
-        "list2df".to_string()
+    fn rule(&self) -> Rule {
+        Rule::List2df
     }
     fn body(&self) -> String {
         "`do.call(cbind.data.frame, x)` is inefficient and can be hard to read.".to_string()

--- a/crates/jarl-core/src/lints/base/literal_coercion/literal_coercion.rs
+++ b/crates/jarl-core/src/lints/base/literal_coercion/literal_coercion.rs
@@ -1,4 +1,5 @@
 use crate::diagnostic::*;
+use crate::rule_set::Rule;
 use crate::utils::{get_arg_by_position, get_unnamed_args, node_contains_comments};
 use air_r_syntax::*;
 use biome_rowan::{AstNode, Direction};
@@ -105,7 +106,7 @@ pub fn literal_coercion(
     let range = ast.syntax().text_trimmed_range();
     let diagnostic = Diagnostic::new(
         ViolationData::new(
-            "literal_coercion".to_string(),
+            Rule::LiteralCoercion,
             "This coercion can be simplified.".to_string(),
             Some(format!("Use `{}` instead of `{}`.", result, call_text)),
         ),

--- a/crates/jarl-core/src/lints/base/matrix_apply/matrix_apply.rs
+++ b/crates/jarl-core/src/lints/base/matrix_apply/matrix_apply.rs
@@ -1,4 +1,5 @@
 use crate::diagnostic::*;
+use crate::rule_set::Rule;
 use crate::utils::{Formals, get_arg, get_arg_by_name, node_contains_comments};
 use air_r_syntax::*;
 use biome_rowan::AstNode;
@@ -137,7 +138,7 @@ pub fn matrix_apply(ast: &RCall, fn_name: &str) -> anyhow::Result<Option<Diagnos
 
     let diagnostic = Diagnostic::new(
         ViolationData::new(
-            "matrix_apply".to_string(),
+            Rule::MatrixApply,
             msg.to_string(),
             Some(suggestion.to_string()),
         ),

--- a/crates/jarl-core/src/lints/base/missing_argument/missing_argument.rs
+++ b/crates/jarl-core/src/lints/base/missing_argument/missing_argument.rs
@@ -1,5 +1,6 @@
 use crate::check::Checker;
 use crate::diagnostic::*;
+use crate::rule_set::Rule;
 use air_r_syntax::*;
 use biome_rowan::AstNode;
 use biome_rowan::AstSeparatedList;
@@ -84,7 +85,7 @@ pub fn missing_argument(
     let range = ast.syntax().text_trimmed_range();
     let diagnostic = Diagnostic::new(
         ViolationData::new(
-            "missing_argument".to_string(),
+            Rule::MissingArgument,
             msg.to_string(),
             Some("Consider removing or filling them.".to_string()),
         ),

--- a/crates/jarl-core/src/lints/base/nested_pipe/nested_pipe.rs
+++ b/crates/jarl-core/src/lints/base/nested_pipe/nested_pipe.rs
@@ -1,5 +1,6 @@
 use crate::checker::Checker;
 use crate::diagnostic::*;
+use crate::rule_set::Rule;
 use crate::utils::get_function_name;
 use air_r_syntax::*;
 use biome_rowan::{AstNode, SyntaxResult};
@@ -38,8 +39,8 @@ pub struct NestedPipe;
 /// print(out)
 /// ```
 impl Violation for NestedPipe {
-    fn name(&self) -> String {
-        "nested_pipe".to_string()
+    fn rule(&self) -> Rule {
+        Rule::NestedPipe
     }
     fn body(&self) -> String {
         "Don't nest pipes inside other calls.".to_string()

--- a/crates/jarl-core/src/lints/base/notin/notin.rs
+++ b/crates/jarl-core/src/lints/base/notin/notin.rs
@@ -1,4 +1,5 @@
 use crate::diagnostic::*;
+use crate::rule_set::Rule;
 use crate::utils::node_contains_comments;
 use air_r_syntax::*;
 use biome_rowan::AstNode;
@@ -79,7 +80,7 @@ pub fn notin(ast: &RUnaryExpression) -> anyhow::Result<Option<Diagnostic>> {
     let range = ast.syntax().text_trimmed_range();
     let diagnostic = Diagnostic::new(
         ViolationData::new(
-            "notin".to_string(),
+            Rule::NotIn,
             format!("`{linted_expression}` can be simplified."),
             Some("Use `x %notin% y` instead.".to_string()),
         ),

--- a/crates/jarl-core/src/lints/base/numeric_leading_zero/numeric_leading_zero.rs
+++ b/crates/jarl-core/src/lints/base/numeric_leading_zero/numeric_leading_zero.rs
@@ -1,4 +1,5 @@
 use crate::diagnostic::*;
+use crate::rule_set::Rule;
 use air_r_syntax::*;
 use biome_rowan::{AstNode, SyntaxToken};
 
@@ -27,8 +28,8 @@ pub struct NumericLeadingZero;
 /// x <- 0.1
 /// ```
 impl Violation for NumericLeadingZero {
-    fn name(&self) -> String {
-        "numeric_leading_zero".to_string()
+    fn rule(&self) -> Rule {
+        Rule::NumericLeadingZero
     }
     fn body(&self) -> String {
         "Include the leading zero for fractional numeric constants.".to_string()

--- a/crates/jarl-core/src/lints/base/nzchar/nzchar.rs
+++ b/crates/jarl-core/src/lints/base/nzchar/nzchar.rs
@@ -1,4 +1,5 @@
 use crate::diagnostic::*;
+use crate::rule_set::Rule;
 use crate::utils::node_contains_comments;
 use air_r_syntax::*;
 use biome_rowan::AstNode;
@@ -78,7 +79,7 @@ pub fn nzchar(ast: &RBinaryExpression) -> anyhow::Result<Option<Diagnostic>> {
     let diagnostic = match operator.kind() {
         RSyntaxKind::EQUAL2 => Diagnostic::new(
             ViolationData::new(
-                "nzchar".to_string(),
+                Rule::NzChar,
                 "`x == \"\"` is inefficient.".to_string(),
                 Some("Use `!nzchar(x)` instead.".to_string()),
             ),
@@ -92,7 +93,7 @@ pub fn nzchar(ast: &RBinaryExpression) -> anyhow::Result<Option<Diagnostic>> {
         ),
         RSyntaxKind::NOT_EQUAL => Diagnostic::new(
             ViolationData::new(
-                "nzchar".to_string(),
+                Rule::NzChar,
                 "`x != \"\"` is inefficient.".to_string(),
                 Some("Use `nzchar(x)` instead.".to_string()),
             ),

--- a/crates/jarl-core/src/lints/base/outer_negation/outer_negation.rs
+++ b/crates/jarl-core/src/lints/base/outer_negation/outer_negation.rs
@@ -1,4 +1,5 @@
 use crate::diagnostic::*;
+use crate::rule_set::Rule;
 use crate::utils::{get_arg_by_position, node_contains_comments};
 use crate::utils_ast::AstNodeExt;
 use air_r_syntax::*;
@@ -99,7 +100,7 @@ pub fn outer_negation(ast: &RCall) -> anyhow::Result<Option<Diagnostic>> {
     let range = ast.syntax().text_trimmed_range();
     let diagnostic = Diagnostic::new(
         ViolationData::new(
-            "outer_negation".to_string(),
+            Rule::OuterNegation,
             msg.to_string(),
             Some(suggestion.to_string()),
         ),

--- a/crates/jarl-core/src/lints/base/pipe_consistency/pipe_consistency.rs
+++ b/crates/jarl-core/src/lints/base/pipe_consistency/pipe_consistency.rs
@@ -1,5 +1,6 @@
 use crate::diagnostic::*;
 use crate::lints::base::pipe_consistency::options::PreferredPipe;
+use crate::rule_set::Rule;
 use crate::utils::node_contains_comments;
 use air_r_syntax::*;
 use biome_rowan::{AstNode, Direction, TextRange};
@@ -133,7 +134,7 @@ pub fn pipe_consistency(
 
     let diagnostic = Diagnostic::new(
         ViolationData::new(
-            "pipe_consistency".to_string(),
+            Rule::PipeConsistency,
             body.to_string(),
             Some(suggestion.to_string()),
         ),

--- a/crates/jarl-core/src/lints/base/pipe_return/pipe_return.rs
+++ b/crates/jarl-core/src/lints/base/pipe_return/pipe_return.rs
@@ -1,4 +1,5 @@
 use crate::diagnostic::*;
+use crate::rule_set::Rule;
 use crate::utils::get_function_name;
 use air_r_syntax::*;
 use biome_rowan::AstNode;
@@ -80,7 +81,7 @@ pub fn pipe_return(ast: &RBinaryExpression) -> anyhow::Result<Option<Diagnostic>
     let range = right.syntax().text_trimmed_range();
     let diagnostic = Diagnostic::new(
         ViolationData::new(
-            "pipe_return".to_string(),
+            Rule::PipeReturn,
             "Using `return()` after `%>%` doesn't actually return the output, which can create misleading results."
                 .to_string(),
             Some("Either wrap the pipe in `return()` instead, or store the output in an intermediate object and use `return()` on it, e.g. `out <- x %>% sum(); return(out)`.".to_string()),

--- a/crates/jarl-core/src/lints/base/quotes/quotes.rs
+++ b/crates/jarl-core/src/lints/base/quotes/quotes.rs
@@ -1,5 +1,6 @@
 use crate::diagnostic::*;
 use crate::lints::base::quotes::options::PreferredQuote;
+use crate::rule_set::Rule;
 use air_r_syntax::*;
 use biome_rowan::AstNode;
 
@@ -150,7 +151,7 @@ pub fn quotes(
     let range = ast.syntax().text_trimmed_range();
     let diagnostic = Diagnostic::new(
         ViolationData::new(
-            "quotes".to_string(),
+            Rule::Quotes,
             quote_message(preferred_quote).to_string(),
             None,
         ),

--- a/crates/jarl-core/src/lints/base/redundant_equals/redundant_equals.rs
+++ b/crates/jarl-core/src/lints/base/redundant_equals/redundant_equals.rs
@@ -1,4 +1,5 @@
 use crate::diagnostic::*;
+use crate::rule_set::Rule;
 use crate::utils::node_contains_comments;
 use crate::utils_ast::AstNodeExt;
 use air_r_syntax::*;
@@ -40,8 +41,8 @@ pub struct RedundantEquals;
 /// }
 /// ```
 impl Violation for RedundantEquals {
-    fn name(&self) -> String {
-        "redundant_equals".to_string()
+    fn rule(&self) -> Rule {
+        Rule::RedundantEquals
     }
     fn body(&self) -> String {
         "Using == on a logical vector is redundant.".to_string()

--- a/crates/jarl-core/src/lints/base/redundant_ifelse/redundant_ifelse.rs
+++ b/crates/jarl-core/src/lints/base/redundant_ifelse/redundant_ifelse.rs
@@ -1,4 +1,5 @@
 use crate::diagnostic::*;
+use crate::rule_set::Rule;
 use crate::utils::{Formals, get_arg, node_contains_comments};
 use air_r_syntax::*;
 use biome_rowan::{AstNode, AstSeparatedList};
@@ -123,7 +124,7 @@ pub fn redundant_ifelse(ast: &RCall, fn_name: &str) -> anyhow::Result<Option<Dia
     };
 
     let diagnostic = Diagnostic::new(
-        ViolationData::new("redundant_ifelse".to_string(), msg, Some(suggestion)),
+        ViolationData::new(Rule::RedundantIfelse, msg, Some(suggestion)),
         range,
         fix,
     );

--- a/crates/jarl-core/src/lints/base/rep_times_ignored/rep_times_ignored.rs
+++ b/crates/jarl-core/src/lints/base/rep_times_ignored/rep_times_ignored.rs
@@ -1,4 +1,5 @@
 use crate::diagnostic::*;
+use crate::rule_set::Rule;
 use crate::utils::{get_function_name, get_function_namespace_prefix, node_contains_comments};
 use air_r_syntax::*;
 use biome_rowan::{AstNode, AstSeparatedList};
@@ -112,7 +113,7 @@ pub fn rep_times_ignored(ast: &RCall) -> anyhow::Result<Option<Diagnostic>> {
 
     Ok(Some(Diagnostic::new(
         ViolationData::new(
-            "rep_times_ignored".to_string(),
+            Rule::RepTimesIgnored,
             "`times` is ignored when `length.out` is supplied.".to_string(),
             Some(format!("Use `{replacement}` instead.")),
         ),

--- a/crates/jarl-core/src/lints/base/repeat/repeat.rs
+++ b/crates/jarl-core/src/lints/base/repeat/repeat.rs
@@ -1,3 +1,4 @@
+use crate::rule_set::Rule;
 use crate::{diagnostic::*, utils::node_contains_comments};
 use air_r_syntax::*;
 use biome_rowan::AstNode;
@@ -32,8 +33,8 @@ pub struct Repeat;
 /// }
 /// ```
 impl Violation for Repeat {
-    fn name(&self) -> String {
-        "repeat".to_string()
+    fn rule(&self) -> Rule {
+        Rule::Repeat
     }
     fn body(&self) -> String {
         "`while (TRUE)` is less clear than `repeat` for infinite loops.".to_string()

--- a/crates/jarl-core/src/lints/base/sample_int/sample_int.rs
+++ b/crates/jarl-core/src/lints/base/sample_int/sample_int.rs
@@ -1,4 +1,5 @@
 use crate::diagnostic::*;
+use crate::rule_set::Rule;
 use crate::utils::{Formals, drop_arg, get_arg, node_contains_comments};
 use air_r_syntax::*;
 use biome_rowan::AstNode;
@@ -36,8 +37,8 @@ pub struct SampleInt;
 ///
 /// See `?sample`
 impl Violation for SampleInt {
-    fn name(&self) -> String {
-        "sample_int".to_string()
+    fn rule(&self) -> Rule {
+        Rule::SampleInt
     }
     fn body(&self) -> String {
         "`sample(1:n, m, ...)` is less readable than `sample.int(n, m, ...)`.".to_string()

--- a/crates/jarl-core/src/lints/base/seq/seq.rs
+++ b/crates/jarl-core/src/lints/base/seq/seq.rs
@@ -1,3 +1,4 @@
+use crate::rule_set::Rule;
 use crate::{
     diagnostic::*,
     utils::{get_function_name, node_contains_comments},
@@ -102,7 +103,7 @@ pub fn seq(ast: &RBinaryExpression) -> anyhow::Result<Option<Diagnostic>> {
     let range = ast.syntax().text_trimmed_range();
     let diagnostic = Diagnostic::new(
         ViolationData::new(
-            "seq".to_string(),
+            Rule::Seq,
             format!("`1:{right_fun_name}(...)` can be wrong if the RHS is 0.").to_string(),
             Some(format!("Use `{suggestion}` instead.").to_string()),
         ),

--- a/crates/jarl-core/src/lints/base/seq2/seq2.rs
+++ b/crates/jarl-core/src/lints/base/seq2/seq2.rs
@@ -1,3 +1,4 @@
+use crate::rule_set::Rule;
 use crate::{
     diagnostic::*,
     utils::{get_function_name, node_contains_comments},
@@ -101,7 +102,7 @@ pub fn seq2(ast: &RCall, fn_name: &str) -> anyhow::Result<Option<Diagnostic>> {
         let range = ast.syntax().text_trimmed_range();
         let diagnostic = Diagnostic::new(
             ViolationData::new(
-                "seq2".to_string(),
+                Rule::Seq2,
                 format!("`seq({inner_fn_name}(...))` can be wrong if the argument has length 0.")
                     .to_string(),
                 Some(format!("Use `{suggestion}` instead.").to_string()),

--- a/crates/jarl-core/src/lints/base/sort/sort.rs
+++ b/crates/jarl-core/src/lints/base/sort/sort.rs
@@ -1,4 +1,5 @@
 use crate::diagnostic::*;
+use crate::rule_set::Rule;
 use crate::utils::{get_arg_by_name, get_function_name, get_unnamed_args, node_contains_comments};
 use air_r_syntax::*;
 use biome_rowan::AstNode;
@@ -37,8 +38,8 @@ pub struct Sort;
 ///
 /// See `?sort`
 impl Violation for Sort {
-    fn name(&self) -> String {
-        "sort".to_string()
+    fn rule(&self) -> Rule {
+        Rule::Sort
     }
     fn body(&self) -> String {
         "`x[order(x)]` is inefficient.".to_string()

--- a/crates/jarl-core/src/lints/base/sprintf/sprintf.rs
+++ b/crates/jarl-core/src/lints/base/sprintf/sprintf.rs
@@ -1,6 +1,7 @@
 use crate::diagnostic::*;
 use crate::utils::{Formals, get_arg, get_unnamed_args, node_contains_comments};
 
+use crate::rule_set::Rule;
 use crate::utils_ast::AstNodeExt;
 use air_r_syntax::*;
 use biome_rowan::AstNode;
@@ -82,7 +83,7 @@ pub fn sprintf(ast: &RCall, fn_name: &str) -> anyhow::Result<Option<Diagnostic>>
         let range = ast.syntax().text_trimmed_range();
         let diagnostic = Diagnostic::new(
             ViolationData::new(
-                "sprintf".to_string(),
+                Rule::Sprintf,
                 "`sprintf()` contains some invalid `%`.".to_string(),
                 None,
             ),
@@ -97,7 +98,7 @@ pub fn sprintf(ast: &RCall, fn_name: &str) -> anyhow::Result<Option<Diagnostic>>
         let range = ast.syntax().text_trimmed_range();
         let diagnostic = Diagnostic::new(
             ViolationData::new(
-                "sprintf".to_string(),
+                Rule::Sprintf,
                 "`sprintf()` without special characters is useless.".to_string(),
                 Some("Use directly the input of `sprintf()` instead.".to_string()),
             ),
@@ -131,7 +132,7 @@ pub fn sprintf(ast: &RCall, fn_name: &str) -> anyhow::Result<Option<Diagnostic>>
         let range = ast.syntax().text_trimmed_range();
         let diagnostic = Diagnostic::new(
             ViolationData::new(
-                "sprintf".to_string(),
+                Rule::Sprintf,
                 "Mismatch between number of special characters and number of arguments."
                     .to_string(),
                 Some(format!(

--- a/crates/jarl-core/src/lints/base/stopifnot_all/stopifnot_all.rs
+++ b/crates/jarl-core/src/lints/base/stopifnot_all/stopifnot_all.rs
@@ -1,4 +1,5 @@
 use crate::diagnostic::*;
+use crate::rule_set::Rule;
 use crate::utils::{get_arg_by_name, get_function_name, node_contains_comments};
 use air_r_syntax::{RArgument, RCall};
 use biome_rowan::AstNode;
@@ -37,8 +38,8 @@ pub struct StopifnotAll;
 ///
 /// See `?stopifnot`.
 impl Violation for StopifnotAll {
-    fn name(&self) -> String {
-        "stopifnot_all".to_string()
+    fn rule(&self) -> Rule {
+        Rule::StopifnotAll
     }
 
     fn body(&self) -> String {

--- a/crates/jarl-core/src/lints/base/string_boundary/string_boundary.rs
+++ b/crates/jarl-core/src/lints/base/string_boundary/string_boundary.rs
@@ -1,4 +1,5 @@
 use crate::diagnostic::*;
+use crate::rule_set::Rule;
 use crate::utils::{get_function_name, node_contains_comments};
 use air_r_syntax::*;
 use biome_rowan::AstNode;
@@ -98,7 +99,7 @@ pub fn string_boundary(ast: &RBinaryExpression) -> anyhow::Result<Option<Diagnos
 
         let diagnostic = Diagnostic::new(
             ViolationData::new(
-                "string_boundary".to_string(),
+                Rule::StringBoundary,
                 format!(
                     "Using `{func_name}()` to detect an initial substring is hard to read and inefficient."
                 ),
@@ -128,7 +129,7 @@ pub fn string_boundary(ast: &RBinaryExpression) -> anyhow::Result<Option<Diagnos
 
         let diagnostic = Diagnostic::new(
             ViolationData::new(
-                "string_boundary".to_string(),
+                Rule::StringBoundary,
                 format!(
                     "Using `{func_name}()` to detect a terminal substring is hard to read and inefficient."
                 ),

--- a/crates/jarl-core/src/lints/base/strings_as_factors/strings_as_factors.rs
+++ b/crates/jarl-core/src/lints/base/strings_as_factors/strings_as_factors.rs
@@ -1,5 +1,6 @@
 use crate::checker::Checker;
 use crate::diagnostic::*;
+use crate::rule_set::Rule;
 use crate::utils::{get_arg_by_position, get_function_name};
 use air_r_syntax::*;
 use biome_rowan::{AstNode, AstSeparatedList};
@@ -42,8 +43,8 @@ pub struct StringsAsFactors;
 /// See `?data.frame`
 /// and the [R Core discussion](https://developer.r-project.org/Blog/public/2020/02/16/stringsasfactors/).
 impl Violation for StringsAsFactors {
-    fn name(&self) -> String {
-        "strings_as_factors".to_string()
+    fn rule(&self) -> Rule {
+        Rule::StringsAsFactors
     }
 
     fn body(&self) -> String {

--- a/crates/jarl-core/src/lints/base/system_file/system_file.rs
+++ b/crates/jarl-core/src/lints/base/system_file/system_file.rs
@@ -1,4 +1,5 @@
 use crate::diagnostic::*;
+use crate::rule_set::Rule;
 use crate::utils::{get_named_args, get_unnamed_args, node_contains_comments};
 use air_r_syntax::*;
 use biome_rowan::{AstNode, AstSeparatedList};
@@ -32,8 +33,8 @@ pub struct SystemFile;
 ///
 /// See `?system.file`
 impl Violation for SystemFile {
-    fn name(&self) -> String {
-        "system_file".to_string()
+    fn rule(&self) -> Rule {
+        Rule::SystemFile
     }
     fn body(&self) -> String {
         "`system.file(file.path(...))` is redundant.".to_string()

--- a/crates/jarl-core/src/lints/base/true_false_symbol/true_false_symbol.rs
+++ b/crates/jarl-core/src/lints/base/true_false_symbol/true_false_symbol.rs
@@ -1,5 +1,6 @@
 use crate::check::Checker;
 use crate::diagnostic::*;
+use crate::rule_set::Rule;
 use crate::utils::get_function_name;
 use air_r_syntax::*;
 use biome_rowan::AstNode;
@@ -37,8 +38,8 @@ pub struct TrueFalseSymbol;
 /// y <- FALSE
 /// ```
 impl Violation for TrueFalseSymbol {
-    fn name(&self) -> String {
-        "true_false_symbol".to_string()
+    fn rule(&self) -> Rule {
+        Rule::TrueFalseSymbol
     }
     fn body(&self) -> String {
         "`T` and `F` can be confused with variable names. Spell `TRUE` and `FALSE` entirely instead.".to_string()

--- a/crates/jarl-core/src/lints/base/undesirable_function/undesirable_function.rs
+++ b/crates/jarl-core/src/lints/base/undesirable_function/undesirable_function.rs
@@ -1,5 +1,6 @@
 use crate::checker::Checker;
 use crate::diagnostic::*;
+use crate::rule_set::Rule;
 use air_r_syntax::*;
 use biome_rowan::AstNode;
 
@@ -43,8 +44,8 @@ pub struct UndesirableFunction {
 /// }
 /// ```
 impl Violation for UndesirableFunction {
-    fn name(&self) -> String {
-        "undesirable_function".to_string()
+    fn rule(&self) -> Rule {
+        Rule::UndesirableFunction
     }
     fn body(&self) -> String {
         format!("`{}()` is listed as an undesirable function.", self.fn_name)

--- a/crates/jarl-core/src/lints/base/unnecessary_nesting/unnecessary_nesting.rs
+++ b/crates/jarl-core/src/lints/base/unnecessary_nesting/unnecessary_nesting.rs
@@ -1,4 +1,5 @@
 use crate::diagnostic::*;
+use crate::rule_set::Rule;
 use crate::utils::node_contains_comments;
 use air_r_syntax::*;
 use biome_rowan::{AstNode, AstNodeList};
@@ -84,7 +85,7 @@ pub fn unnecessary_nesting(ast: &RIfStatement) -> anyhow::Result<Option<Diagnost
     let range = ast.syntax().text_trimmed_range();
     let diagnostic = Diagnostic::new(
         ViolationData::new(
-            "unnecessary_nesting".to_string(),
+            Rule::UnnecessaryNesting,
             "There is no need for nested if conditions here.".to_string(),
             Some("Gather the two conditions with `&&` instead.".to_string()),
         ),

--- a/crates/jarl-core/src/lints/base/unnecessary_parentheses/unnecessary_parentheses.rs
+++ b/crates/jarl-core/src/lints/base/unnecessary_parentheses/unnecessary_parentheses.rs
@@ -1,4 +1,5 @@
 use crate::diagnostic::{Diagnostic, Fix, ViolationData};
+use crate::rule_set::Rule;
 use crate::utils::node_contains_comments;
 use air_r_syntax::RParenthesizedExpression;
 use biome_rowan::AstNode;
@@ -69,11 +70,7 @@ pub fn unnecessary_parentheses(
     let range = ast.syntax().text_trimmed_range();
 
     Ok(Some(Diagnostic::new(
-        ViolationData::new(
-            "unnecessary_parentheses".to_string(),
-            body,
-            Some(suggestion),
-        ),
+        ViolationData::new(Rule::UnnecessaryParentheses, body, Some(suggestion)),
         range,
         Fix {
             content: format!("({})", current.to_trimmed_string()),

--- a/crates/jarl-core/src/lints/base/unreachable_code/unreachable_code.rs
+++ b/crates/jarl-core/src/lints/base/unreachable_code/unreachable_code.rs
@@ -3,6 +3,7 @@ use crate::diagnostic::*;
 use air_r_syntax::*;
 
 use super::cfg::{UnreachableReason, build_cfg, build_cfg_top_level, find_unreachable_code};
+use crate::rule_set::Rule;
 
 /// Version added: 0.4.0
 ///
@@ -60,7 +61,7 @@ pub fn unreachable_code(
     for unreachable_info in find_unreachable_code(&cfg) {
         let diagnostic = Diagnostic::new(
             ViolationData::new(
-                "unreachable_code".to_string(),
+                Rule::UnreachableCode,
                 unreachable_info.reason.message().to_string(),
                 None,
             ),
@@ -101,7 +102,7 @@ pub fn unreachable_code_top_level(
 
         let diagnostic = Diagnostic::new(
             ViolationData::new(
-                "unreachable_code".to_string(),
+                Rule::UnreachableCode,
                 unreachable_info.reason.message().to_string(),
                 None,
             ),

--- a/crates/jarl-core/src/lints/base/unused_function/mod.rs
+++ b/crates/jarl-core/src/lints/base/unused_function/mod.rs
@@ -546,7 +546,8 @@ mod tests {
             if let Ok(diagnostics) = result {
                 for d in diagnostics {
                     let content = fs::read_to_string(&d.filename).unwrap();
-                    let rendered = render_diagnostic(&content, path, &d.message.name, d, &renderer);
+                    let rendered =
+                        render_diagnostic(&content, path, d.message.rule.name(), d, &renderer);
                     all_diagnostics.push((d, rendered));
                 }
             }

--- a/crates/jarl-core/src/lints/base/unused_object/mod.rs
+++ b/crates/jarl-core/src/lints/base/unused_object/mod.rs
@@ -64,7 +64,7 @@ mod tests {
             let rendered = render_diagnostic(
                 main,
                 "<test>",
-                &diagnostic.message.name,
+                diagnostic.message.rule.name(),
                 diagnostic,
                 &renderer,
             );

--- a/crates/jarl-core/src/lints/base/unused_object/unused_object.rs
+++ b/crates/jarl-core/src/lints/base/unused_object/unused_object.rs
@@ -11,6 +11,7 @@ use jarl_semantic::{
 
 use crate::checker::Checker;
 use crate::diagnostic::{Diagnostic, Fix, ViolationData};
+use crate::rule_set::Rule;
 use crate::utils::get_function_name;
 
 /// Version added: 0.6.0
@@ -309,7 +310,7 @@ fn make_diagnostic(
     let range = lhs_range_for_definition(def, root).unwrap_or_else(|| def.range());
     Diagnostic::new(
         ViolationData::new(
-            "unused_object".to_string(),
+            Rule::UnusedObject,
             format!("Object `{name}` is defined but never used."),
             None,
         ),

--- a/crates/jarl-core/src/lints/base/vector_logic/vector_logic.rs
+++ b/crates/jarl-core/src/lints/base/vector_logic/vector_logic.rs
@@ -1,4 +1,5 @@
 use crate::diagnostic::*;
+use crate::rule_set::Rule;
 use crate::utils::get_function_name;
 use crate::utils_ast::AstNodeExt;
 use air_r_syntax::*;
@@ -78,7 +79,7 @@ pub fn vector_logic(ast: &RBinaryExpression) -> anyhow::Result<Option<Diagnostic
 
     let range = ast.syntax().text_trimmed_range();
     let diagnostic = Diagnostic::new(
-        ViolationData::new("vector_logic".to_string(), msg.to_string(), None),
+        ViolationData::new(Rule::VectorLogic, msg.to_string(), None),
         range,
         Fix::empty(),
     );

--- a/crates/jarl-core/src/lints/base/which_grepl/which_grepl.rs
+++ b/crates/jarl-core/src/lints/base/which_grepl/which_grepl.rs
@@ -1,4 +1,5 @@
 use crate::diagnostic::*;
+use crate::rule_set::Rule;
 use crate::utils::{
     Formals, get_arg, get_arg_by_name, get_function_name, get_nested_functions_content,
     node_contains_comments,
@@ -44,8 +45,8 @@ pub struct WhichGrepl;
 ///
 /// See `?grep`
 impl Violation for WhichGrepl {
-    fn name(&self) -> String {
-        "which_grepl".to_string()
+    fn rule(&self) -> Rule {
+        Rule::WhichGrepl
     }
     fn body(&self) -> String {
         "`which(grepl(pattern, x))` is less efficient than `grep(pattern, x)`.".to_string()

--- a/crates/jarl-core/src/lints/comments/blanket_suppression/blanket_suppression.rs
+++ b/crates/jarl-core/src/lints/comments/blanket_suppression/blanket_suppression.rs
@@ -1,4 +1,5 @@
 use crate::diagnostic::*;
+use crate::rule_set::Rule;
 use biome_rowan::TextRange;
 
 /// Version added: 0.4.0
@@ -37,7 +38,7 @@ pub fn blanket_suppression(ranges: &[TextRange]) -> Vec<Diagnostic> {
 fn create_diagnostic(range: TextRange) -> Diagnostic {
     Diagnostic::new(
         ViolationData::new(
-            "blanket_suppression".to_string(),
+            Rule::BlanketSuppression,
             "This comment isn't used by Jarl because it is missing a rule to ignore.".to_string(),
             Some(
                 "Use targeted comments instead, e.g., `# jarl-ignore any_is_na: <reason>`."

--- a/crates/jarl-core/src/lints/comments/invalid_chunk_suppression/invalid_chunk_suppression.rs
+++ b/crates/jarl-core/src/lints/comments/invalid_chunk_suppression/invalid_chunk_suppression.rs
@@ -1,4 +1,5 @@
 use crate::diagnostic::*;
+use crate::rule_set::Rule;
 use biome_rowan::TextRange;
 
 /// Version added: 0.5.0
@@ -49,7 +50,7 @@ pub fn invalid_chunk_suppression(ranges: &[TextRange]) -> Vec<Diagnostic> {
 fn create_diagnostic(range: TextRange) -> Diagnostic {
     Diagnostic::new(
         ViolationData::new(
-            "invalid_chunk_suppression".to_string(),
+            Rule::InvalidChunkSuppression,
             "This `jarl-ignore-chunk` comment is wrongly formatted.".to_string(),
             Some(
                 "Use the YAML array form instead:\n\

--- a/crates/jarl-core/src/lints/comments/misnamed_suppression/misnamed_suppression.rs
+++ b/crates/jarl-core/src/lints/comments/misnamed_suppression/misnamed_suppression.rs
@@ -1,4 +1,5 @@
 use crate::diagnostic::*;
+use crate::rule_set::Rule;
 use biome_rowan::TextRange;
 
 /// Version added: 0.4.0
@@ -36,7 +37,7 @@ pub fn misnamed_suppression(ranges: &[TextRange]) -> Vec<Diagnostic> {
 fn create_diagnostic(range: TextRange) -> Diagnostic {
     Diagnostic::new(
         ViolationData::new(
-            "misnamed_suppression".to_string(),
+            Rule::MisnamedSuppression,
             "This comment isn't used by Jarl because it contains an unrecognized rule name."
                 .to_string(),
             Some("Check the rule name for typos.".to_string()),

--- a/crates/jarl-core/src/lints/comments/misplaced_file_suppression/misplaced_file_suppression.rs
+++ b/crates/jarl-core/src/lints/comments/misplaced_file_suppression/misplaced_file_suppression.rs
@@ -1,4 +1,5 @@
 use crate::diagnostic::*;
+use crate::rule_set::Rule;
 use biome_rowan::TextRange;
 
 /// Version added: 0.4.0
@@ -40,7 +41,7 @@ pub fn misplaced_file_suppression(ranges: &[TextRange]) -> Vec<Diagnostic> {
 fn create_diagnostic(range: TextRange) -> Diagnostic {
     Diagnostic::new(
         ViolationData::new(
-            "misplaced_file_suppression".to_string(),
+            Rule::MisplacedFileSuppression,
             "This comment isn't used by Jarl because `# jarl-ignore-file` must be at the top of the file.".to_string(),
             Some("Move this comment to the beginning of the file, before any code.".to_string()),
         ),

--- a/crates/jarl-core/src/lints/comments/misplaced_suppression/misplaced_suppression.rs
+++ b/crates/jarl-core/src/lints/comments/misplaced_suppression/misplaced_suppression.rs
@@ -1,4 +1,5 @@
 use crate::diagnostic::*;
+use crate::rule_set::Rule;
 use biome_rowan::TextRange;
 
 /// Version added: 0.4.0
@@ -36,7 +37,7 @@ pub fn misplaced_suppression(ranges: &[TextRange]) -> Vec<Diagnostic> {
 fn create_diagnostic(range: TextRange) -> Diagnostic {
     Diagnostic::new(
         ViolationData::new(
-            "misplaced_suppression".to_string(),
+            Rule::MisplacedSuppression,
             "This comment isn't used by Jarl because end-of-line suppressions are not supported."
                 .to_string(),
             Some(

--- a/crates/jarl-core/src/lints/comments/outdated_suppression/outdated_suppression.rs
+++ b/crates/jarl-core/src/lints/comments/outdated_suppression/outdated_suppression.rs
@@ -1,4 +1,5 @@
 use crate::diagnostic::*;
+use crate::rule_set::Rule;
 use crate::suppression::UnusedSuppression;
 
 /// Version added: 0.4.0
@@ -38,7 +39,7 @@ pub fn outdated_suppression(unused: &[UnusedSuppression], source: &str) -> Vec<D
 fn create_diagnostic(suppression: &UnusedSuppression, source: &str) -> Diagnostic {
     Diagnostic::new(
         ViolationData::new(
-            "outdated_suppression".to_string(),
+            Rule::OutdatedSuppression,
             "This suppression comment is unused, no violation would be reported without it."
                 .to_string(),
             Some("Remove this suppression comment or verify that it's still needed.".to_string()),

--- a/crates/jarl-core/src/lints/comments/unexplained_suppression/unexplained_suppression.rs
+++ b/crates/jarl-core/src/lints/comments/unexplained_suppression/unexplained_suppression.rs
@@ -1,4 +1,5 @@
 use crate::diagnostic::*;
+use crate::rule_set::Rule;
 use biome_rowan::TextRange;
 
 /// Version added: 0.4.0
@@ -39,7 +40,7 @@ pub fn unexplained_suppression(ranges: &[TextRange]) -> Vec<Diagnostic> {
 fn create_diagnostic(range: TextRange) -> Diagnostic {
     Diagnostic::new(
         ViolationData::new(
-            "unexplained_suppression".to_string(),
+            Rule::UnexplainedSuppression,
             "This comment isn't used by Jarl because it is missing an explanation.".to_string(),
             Some(
                 "Add an explanation after the colon, e.g., `# jarl-ignore rule: <reason>`."

--- a/crates/jarl-core/src/lints/comments/unmatched_range_suppression/unmatched_range_suppression.rs
+++ b/crates/jarl-core/src/lints/comments/unmatched_range_suppression/unmatched_range_suppression.rs
@@ -1,4 +1,5 @@
 use crate::diagnostic::*;
+use crate::rule_set::Rule;
 use biome_rowan::TextRange;
 
 /// Version added: 0.4.0
@@ -51,7 +52,7 @@ pub fn unmatched_range_suppression_end(ranges: &[TextRange]) -> Vec<Diagnostic> 
 fn create_start_diagnostic(range: TextRange) -> Diagnostic {
     Diagnostic::new(
         ViolationData::new(
-            "unmatched_range_suppression".to_string(),
+            Rule::UnmatchedRangeSuppression,
             "This `jarl-ignore-start` has no matching `jarl-ignore-end` at the same nesting level."
                 .to_string(),
             Some("Add a matching `jarl-ignore-end` comment at the same nesting level.".to_string()),
@@ -64,7 +65,7 @@ fn create_start_diagnostic(range: TextRange) -> Diagnostic {
 fn create_end_diagnostic(range: TextRange) -> Diagnostic {
     Diagnostic::new(
         ViolationData::new(
-            "unmatched_range_suppression".to_string(),
+            Rule::UnmatchedRangeSuppression,
             "This `jarl-ignore-end` has no matching `jarl-ignore-start` at the same nesting level."
                 .to_string(),
             Some(

--- a/crates/jarl-core/src/lints/dplyr/dplyr_filter_out/dplyr_filter_out.rs
+++ b/crates/jarl-core/src/lints/dplyr/dplyr_filter_out/dplyr_filter_out.rs
@@ -1,5 +1,6 @@
 use crate::checker::{Checker, PackageOrigin};
 use crate::diagnostic::*;
+use crate::rule_set::Rule;
 use crate::utils::{get_function_name, node_contains_comments};
 use air_r_syntax::*;
 use biome_rowan::AstNode;
@@ -159,7 +160,7 @@ pub fn dplyr_filter_out(
 
     Ok(Some(Diagnostic::new(
         ViolationData::new(
-            "dplyr_filter_out".to_string(),
+            Rule::DplyrFilterOut,
             "This `filter()` contains complex condition(s).".to_string(),
             Some(
                 "It can be simplified by using `filter_out()`, which keeps `NA` rows.".to_string(),

--- a/crates/jarl-core/src/lints/dplyr/dplyr_group_by_ungroup/dplyr_group_by_ungroup.rs
+++ b/crates/jarl-core/src/lints/dplyr/dplyr_group_by_ungroup/dplyr_group_by_ungroup.rs
@@ -1,6 +1,7 @@
 use crate::check::Checker;
 use crate::checker::PackageOrigin;
 use crate::diagnostic::*;
+use crate::rule_set::Rule;
 use crate::utils::{get_function_name, get_function_namespace_prefix, node_contains_comments};
 use air_r_syntax::*;
 use biome_rowan::{AstNode, TextRange};
@@ -230,7 +231,7 @@ pub fn dplyr_group_by_ungroup(
     };
 
     Ok(Some(Diagnostic::new(
-        ViolationData::new("dplyr_group_by_ungroup".to_string(), body, Some(suggestion)),
+        ViolationData::new(Rule::DplyrGroupByUngroup, body, Some(suggestion)),
         range,
         fix,
     )))

--- a/crates/jarl-core/src/lints/testthat/expect_length/expect_length.rs
+++ b/crates/jarl-core/src/lints/testthat/expect_length/expect_length.rs
@@ -1,4 +1,5 @@
 use crate::diagnostic::*;
+use crate::rule_set::Rule;
 use crate::utils::{
     Formals, get_arg, get_function_name, get_function_namespace_prefix, node_contains_comments,
 };
@@ -124,7 +125,7 @@ pub fn expect_length(ast: &RCall, fn_name: &str) -> anyhow::Result<Option<Diagno
     let range = ast.syntax().text_trimmed_range();
     let diagnostic = Diagnostic::new(
         ViolationData::new(
-            "expect_length".to_string(),
+            Rule::TestthatExpectLength,
             format!(
                 "`expect_length(x, n)` is better than `{}(length(x), n)`.",
                 fn_name

--- a/crates/jarl-core/src/lints/testthat/expect_match/expect_match.rs
+++ b/crates/jarl-core/src/lints/testthat/expect_match/expect_match.rs
@@ -1,4 +1,5 @@
 use crate::diagnostic::*;
+use crate::rule_set::Rule;
 use crate::utils::{
     Formals, get_arg, get_function_name, get_function_namespace_prefix,
     get_nested_functions_content, get_unnamed_args, node_contains_comments,
@@ -42,8 +43,8 @@ pub struct ExpectMatch;
 /// expect_match(x, "bar", perl = FALSE, fixed = FALSE)
 /// ```
 impl Violation for ExpectMatch {
-    fn name(&self) -> String {
-        "expect_match".to_string()
+    fn rule(&self) -> Rule {
+        Rule::TestthatExpectMatch
     }
 
     fn body(&self) -> String {

--- a/crates/jarl-core/src/lints/testthat/expect_named/expect_named.rs
+++ b/crates/jarl-core/src/lints/testthat/expect_named/expect_named.rs
@@ -1,4 +1,5 @@
 use crate::diagnostic::*;
+use crate::rule_set::Rule;
 use crate::utils::{
     Formals, get_arg, get_function_name, get_function_namespace_prefix, node_contains_comments,
 };
@@ -89,7 +90,7 @@ pub fn expect_named(ast: &RCall, fn_name: &str) -> anyhow::Result<Option<Diagnos
     let range = ast.syntax().text_trimmed_range();
     let diagnostic = Diagnostic::new(
         ViolationData::new(
-            "expect_named".to_string(),
+            Rule::TestthatExpectNamed,
             format!(
                 "`expect_named(x, n)` is better than `{}(names(x), n)`.",
                 fn_name

--- a/crates/jarl-core/src/lints/testthat/expect_no_match/expect_no_match.rs
+++ b/crates/jarl-core/src/lints/testthat/expect_no_match/expect_no_match.rs
@@ -1,4 +1,5 @@
 use crate::diagnostic::*;
+use crate::rule_set::Rule;
 use crate::utils::{
     Formals, get_arg, get_function_name, get_function_namespace_prefix,
     get_nested_functions_content, get_unnamed_args, node_contains_comments,
@@ -42,8 +43,8 @@ pub struct ExpectNoMatch;
 /// expect_no_match(x, "bar", perl = FALSE, fixed = FALSE)
 /// ```
 impl Violation for ExpectNoMatch {
-    fn name(&self) -> String {
-        "expect_no_match".to_string()
+    fn rule(&self) -> Rule {
+        Rule::TestthatExpectNoMatch
     }
 
     fn body(&self) -> String {

--- a/crates/jarl-core/src/lints/testthat/expect_not/expect_not.rs
+++ b/crates/jarl-core/src/lints/testthat/expect_not/expect_not.rs
@@ -1,4 +1,5 @@
 use crate::diagnostic::*;
+use crate::rule_set::Rule;
 use crate::utils::{Formals, get_arg, get_function_namespace_prefix, node_contains_comments};
 use air_r_syntax::*;
 use biome_rowan::{AstNode, AstSeparatedList};
@@ -103,7 +104,7 @@ pub fn expect_not(ast: &RCall, fn_name: &str) -> anyhow::Result<Option<Diagnosti
     let range = ast.syntax().text_trimmed_range();
     let diagnostic = Diagnostic::new(
         ViolationData::new(
-            "expect_not".to_string(),
+            Rule::TestthatExpectNot,
             format!(
                 "`{}(!x)` is not as clear as `{}(x)`.",
                 current_fn, replacement_fn

--- a/crates/jarl-core/src/lints/testthat/expect_null/expect_null.rs
+++ b/crates/jarl-core/src/lints/testthat/expect_null/expect_null.rs
@@ -1,4 +1,5 @@
 use crate::diagnostic::*;
+use crate::rule_set::Rule;
 use crate::utils::{
     Formals, get_arg, get_function_name, get_function_namespace_prefix, node_contains_comments,
 };
@@ -80,7 +81,7 @@ fn check_expect_equal_null(ast: &RCall, function_name: &str) -> anyhow::Result<O
     let range = ast.syntax().text_trimmed_range();
     let diagnostic = Diagnostic::new(
         ViolationData::new(
-            "expect_null".to_string(),
+            Rule::TestthatExpectNull,
             format!(
                 "`{}(x, NULL)` is not as clear as `expect_null(x)`.",
                 function_name
@@ -123,7 +124,7 @@ fn check_expect_true_is_null(ast: &RCall) -> anyhow::Result<Option<Diagnostic>> 
     let range = ast.syntax().text_trimmed_range();
     let diagnostic = Diagnostic::new(
         ViolationData::new(
-            "expect_null".to_string(),
+            Rule::TestthatExpectNull,
             "`expect_true(is.null(x))` is not as clear as `expect_null(x)`.".to_string(),
             Some("Use `expect_null(x)` instead.".to_string()),
         ),

--- a/crates/jarl-core/src/lints/testthat/expect_s3_class/expect_s3_class.rs
+++ b/crates/jarl-core/src/lints/testthat/expect_s3_class/expect_s3_class.rs
@@ -1,4 +1,5 @@
 use crate::diagnostic::*;
+use crate::rule_set::Rule;
 use crate::utils::{
     Formals, get_arg, get_arg_by_position, get_function_name, get_function_namespace_prefix,
     node_contains_comments,
@@ -132,7 +133,7 @@ fn check_expect_class_comparison(
 
     Ok(Some(Diagnostic::new(
         ViolationData::new(
-            "expect_s3_class".to_string(),
+            Rule::TestthatExpectS3Class,
             format!("`{linted_text}` may fail if `{object_text}` gets more classes in the future."),
             Some(format!("Use `{replacement}` instead.")),
         ),
@@ -187,7 +188,7 @@ fn check_expect_true_class(ast: &RCall) -> anyhow::Result<Option<Diagnostic>> {
 
     Ok(Some(Diagnostic::new(
         ViolationData::new(
-            "expect_s3_class".to_string(),
+            Rule::TestthatExpectS3Class,
             format!("`{replacement}` is better than `{linted_text}`."),
             Some(format!("Use `{replacement}` instead.")),
         ),

--- a/crates/jarl-core/src/lints/testthat/expect_s4_class/expect_s4_class.rs
+++ b/crates/jarl-core/src/lints/testthat/expect_s4_class/expect_s4_class.rs
@@ -1,4 +1,5 @@
 use crate::diagnostic::*;
+use crate::rule_set::Rule;
 use crate::utils::{
     Formals, get_arg, get_function_name, get_function_namespace_prefix, node_contains_comments,
 };
@@ -77,7 +78,7 @@ pub fn expect_s4_class(ast: &RCall, fn_name: &str) -> anyhow::Result<Option<Diag
 
     Ok(Some(Diagnostic::new(
         ViolationData::new(
-            "expect_s4_class".to_string(),
+            Rule::TestthatExpectS4Class,
             format!("`{replacement}` is better than `{linted_text}`."),
             Some(format!("Use `{replacement}` instead.")),
         ),

--- a/crates/jarl-core/src/lints/testthat/expect_true_false/expect_true_false.rs
+++ b/crates/jarl-core/src/lints/testthat/expect_true_false/expect_true_false.rs
@@ -1,4 +1,5 @@
 use crate::diagnostic::*;
+use crate::rule_set::Rule;
 use crate::utils::{Formals, get_arg, get_function_namespace_prefix, node_contains_comments};
 use air_r_syntax::*;
 use biome_rowan::AstNode;
@@ -94,7 +95,7 @@ pub fn expect_true_false(ast: &RCall, fn_name: &str) -> anyhow::Result<Option<Di
     let range = ast.syntax().text_trimmed_range();
     let diagnostic = Diagnostic::new(
         ViolationData::new(
-            "expect_true_false".to_string(),
+            Rule::TestthatExpectTrueFalse,
             msg,
             Some(suggestion.to_string()),
         ),

--- a/crates/jarl-core/src/lints/testthat/expect_type/expect_type.rs
+++ b/crates/jarl-core/src/lints/testthat/expect_type/expect_type.rs
@@ -1,4 +1,5 @@
 use crate::diagnostic::*;
+use crate::rule_set::Rule;
 use crate::utils::{
     Formals, get_arg, get_function_name, get_function_namespace_prefix, node_contains_comments,
 };
@@ -95,7 +96,7 @@ fn check_expect_equal_typeof(
     let range = ast.syntax().text_trimmed_range();
     let diagnostic = Diagnostic::new(
         ViolationData::new(
-            "expect_type".to_string(),
+            Rule::TestthatExpectType,
             format!("`{}(typeof(x), t)` can be hard to read.", function_name),
             Some("Use `expect_type(x, t)` instead.".to_string()),
         ),
@@ -161,7 +162,7 @@ fn check_expect_true_is_type(ast: &RCall) -> anyhow::Result<Option<Diagnostic>> 
     let range = ast.syntax().text_trimmed_range();
     let diagnostic = Diagnostic::new(
         ViolationData::new(
-            "expect_type".to_string(),
+            Rule::TestthatExpectType,
             "`expect_true(is.<t>(x))` can be hard to read.".to_string(),
             Some("Use `expect_type(x, t)` instead.".to_string()),
         ),

--- a/crates/jarl-core/src/per_file_ignores.rs
+++ b/crates/jarl-core/src/per_file_ignores.rs
@@ -1,9 +1,8 @@
 use std::collections::HashSet;
 use std::path::{Path, PathBuf};
 
-use ignore::gitignore::{Gitignore, GitignoreBuilder};
-
 use crate::rule_set::Rule;
+use ignore::gitignore::{Gitignore, GitignoreBuilder};
 
 /// A single `per-file-ignores` entry: a glob pattern paired with the rules to
 /// ignore in the files it matches.

--- a/crates/jarl-core/src/rule_set.rs
+++ b/crates/jarl-core/src/rule_set.rs
@@ -1,3 +1,4 @@
+use serde::{Deserialize, Deserializer, Serialize, Serializer};
 use std::fmt;
 use std::str::FromStr;
 
@@ -852,6 +853,22 @@ declare_rules! {
         min_r_version: None,
     },
 
+}
+
+/// Serialized as the rule's string name, so a `Diagnostic` round-trips through
+/// the same identifier users write in `jarl.toml`.
+impl Serialize for Rule {
+    fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        serializer.serialize_str(self.name())
+    }
+}
+
+impl<'de> Deserialize<'de> for Rule {
+    fn deserialize<D: Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+        let name = String::deserialize(deserializer)?;
+        Rule::from_name(&name)
+            .ok_or_else(|| serde::de::Error::custom(format!("unknown rule: {name}")))
+    }
 }
 
 /// A collection of rules

--- a/crates/jarl-core/src/suppression.rs
+++ b/crates/jarl-core/src/suppression.rs
@@ -650,9 +650,7 @@ impl SuppressionManager {
 
     /// Check if a diagnostic should be suppressed, and if so, mark the suppression as used.
     fn is_diagnostic_suppressed(&mut self, diag: &Diagnostic) -> bool {
-        let Some(rule) = Rule::from_name(&diag.message.name) else {
-            return false;
-        };
+        let rule = diag.message.rule;
 
         // Check file-level suppressions
         for sup in &self.file_suppressions {

--- a/crates/jarl-core/src/utils_test.rs
+++ b/crates/jarl-core/src/utils_test.rs
@@ -353,7 +353,7 @@ fn render_diagnostics(
         let rendered = render_diagnostic(
             text,
             "<test>",
-            &diagnostic.message.name,
+            diagnostic.message.rule.name(),
             diagnostic,
             &renderer,
         );

--- a/crates/jarl-lsp/src/lint.rs
+++ b/crates/jarl-lsp/src/lint.rs
@@ -22,6 +22,7 @@ use jarl_core::diagnostic::Diagnostic as JarlDiagnostic;
 use jarl_core::discovery::{DiscoveredSettings, discover_settings};
 use jarl_core::fs::has_r_extension;
 use jarl_core::package::{is_in_r_package, make_package_analysis, summarize_package_info};
+use jarl_core::rule_set::Rule;
 use jarl_core::settings::Settings;
 
 /// Fix information that can be attached to a diagnostic for code actions
@@ -223,7 +224,7 @@ fn run_jarl_linting(
                 .unwrap_or(50);
 
             if total_unused > threshold {
-                diagnostics.retain(|d| d.message.name != "unused_function");
+                diagnostics.retain(|d| d.message.rule != Rule::UnusedFunction);
                 total_unused
             } else {
                 0
@@ -282,7 +283,7 @@ fn convert_to_lsp_diagnostic(
         start: jarl_diag.fix.start,
         end: jarl_diag.fix.end,
         is_safe: jarl_diag.has_safe_fix(),
-        rule_name: jarl_diag.message.name.clone(),
+        rule_name: jarl_diag.message.rule.name().to_string(),
         diagnostic_start: start_offset,
         diagnostic_end: end_offset,
     };
@@ -299,7 +300,9 @@ fn convert_to_lsp_diagnostic(
     let diagnostic = Diagnostic {
         range,
         severity: Some(severity),
-        code: Some(NumberOrString::String(jarl_diag.message.name.clone())),
+        code: Some(NumberOrString::String(
+            jarl_diag.message.rule.name().to_string(),
+        )),
         code_description: None,
         source: Some(DIAGNOSTIC_SOURCE.to_string()),
         message,

--- a/crates/jarl/src/commands/check.rs
+++ b/crates/jarl/src/commands/check.rs
@@ -426,7 +426,7 @@ fn add_jarl_ignore_comments(
         for diagnostic in &diagnostics {
             let start: usize = diagnostic.range.start().into();
             let end: usize = diagnostic.range.end().into();
-            let rule_name = &diagnostic.message.name;
+            let rule_name = diagnostic.message.rule.name();
 
             let edit = if is_rmd {
                 create_suppression_edit_in_rmd(&content, start, end, rule_name, reason)
@@ -439,7 +439,7 @@ fn add_jarl_ignore_comments(
                     edit.insert_point.offset,
                     edit.insert_point.indent,
                     edit.insert_point.needs_leading_newline,
-                    rule_name.clone(),
+                    rule_name.to_string(),
                 ));
             }
         }
@@ -570,13 +570,13 @@ fn hide_unused_function_if_needed(
     let unused_fn_count = all_diagnostics
         .iter()
         .flat_map(|(_path, diagnostics)| diagnostics.iter())
-        .filter(|d| d.message.name == "unused_function")
+        .filter(|d| d.message.rule == Rule::UnusedFunction)
         .count();
 
     let hidden = !explicitly_selected && unused_fn_count > threshold_ignore;
     if hidden {
         for (_path, diagnostics) in all_diagnostics.iter_mut() {
-            diagnostics.retain(|d| d.message.name != "unused_function");
+            diagnostics.retain(|d| d.message.rule != Rule::UnusedFunction);
         }
         all_diagnostics.retain(|(_path, diagnostics)| !diagnostics.is_empty());
     }

--- a/crates/jarl/src/output_format.rs
+++ b/crates/jarl/src/output_format.rs
@@ -242,9 +242,9 @@ impl Emitter for ConciseEmitter {
             };
             let use_colors = std::env::var("NO_COLOR").is_err();
             let rule_name = if use_colors {
-                &make_hyperlink(&diagnostic.message.name)
+                &make_hyperlink(diagnostic.message.rule.name())
             } else {
-                &diagnostic.message.name
+                diagnostic.message.rule.name()
             };
             writeln!(
                 writer,
@@ -320,7 +320,7 @@ impl Emitter for GithubEmitter {
             write!(
                 writer,
                 "::warning title=Jarl ({}),file={file},line={row},col={col}::{file}:{row}:{col} ",
-                diagnostic.message.name,
+                diagnostic.message.rule,
                 file = diagnostic.filename.to_string_lossy()
             )?;
 
@@ -329,7 +329,7 @@ impl Emitter for GithubEmitter {
             } else {
                 diagnostic.message.body.clone()
             };
-            writeln!(writer, "[{}] {}", diagnostic.message.name, message)?;
+            writeln!(writer, "[{}] {}", diagnostic.message.rule, message)?;
         }
 
         writer.flush()?;
@@ -522,7 +522,7 @@ impl Emitter for SarifEmitter {
             std::collections::BTreeMap::new();
         for diagnostic in diagnostics {
             rule_bodies
-                .entry(&diagnostic.message.name)
+                .entry(diagnostic.message.rule.name())
                 .or_insert(&diagnostic.message.body);
         }
         let rules: Vec<SarifRule> = rule_bodies
@@ -592,8 +592,8 @@ impl Emitter for SarifEmitter {
             };
 
             results.push(SarifResult {
-                rule_id: &diagnostic.message.name,
-                rule_index: rule_indices[diagnostic.message.name.as_str()],
+                rule_id: diagnostic.message.rule.name(),
+                rule_index: rule_indices[diagnostic.message.rule.name()],
                 level: "warning",
                 message: SarifMessage { text: Cow::Owned(message) },
                 locations: [SarifLocation {
@@ -721,9 +721,9 @@ impl Emitter for FullEmitter {
 
             // Create the main message with clickable rule name
             let title = if use_colors {
-                make_hyperlink(&diagnostic.message.name)
+                make_hyperlink(diagnostic.message.rule.name())
             } else {
-                diagnostic.message.name.clone()
+                diagnostic.message.rule.name().to_string()
             };
 
             let rendered = render_diagnostic(source, file_path, &title, diagnostic, &renderer);

--- a/crates/jarl/src/statistics.rs
+++ b/crates/jarl/src/statistics.rs
@@ -1,5 +1,6 @@
 use colored::Colorize;
 use jarl_core::diagnostic::Diagnostic;
+use jarl_core::rule_set::Rule;
 use std::{collections::HashMap, path::PathBuf};
 
 use crate::status::ExitStatus;
@@ -21,11 +22,10 @@ pub fn print_statistics(
 
     // Hashmap with rule name as key, and (number of occurrences, has_fix, has_unsafe_fix) as
     // value.
-    let mut hm: HashMap<&String, (usize, bool, bool)> = HashMap::new();
+    let mut hm: HashMap<Rule, (usize, bool, bool)> = HashMap::new();
 
     for diagnostic in diagnostics {
-        let rule_name = &diagnostic.message.name;
-        let entry = hm.entry(rule_name).or_default();
+        let entry = hm.entry(diagnostic.message.rule).or_default();
         entry.0 += 1;
         if diagnostic.has_safe_fix() {
             entry.1 = true;
@@ -51,7 +51,7 @@ pub fn print_statistics(
             "{:>5} [{}] {}",
             value.0.to_string().bold(),
             star,
-            key.bold().red()
+            key.name().bold().red()
         );
     }
 

--- a/docs/contributing-rule-example.md
+++ b/docs/contributing-rule-example.md
@@ -151,6 +151,7 @@ Let's start with a skeleton of this file:
 
 ```rust
 use crate::diagnostic::*;
+use crate::rule_set::Rule;
 use crate::utils::{get_arg_by_name_then_position, get_arg_by_position, node_contains_comments};
 use air_r_syntax::*;
 use biome_rowan::AstNode;
@@ -165,8 +166,8 @@ pub struct List2Df;
 ///
 /// [...]
 impl Violation for List2Df {
-    fn name(&self) -> String {
-        "list2df".to_string()
+    fn rule(&self) -> Rule {
+        Rule::List2df
     }
     fn body(&self) -> String {
         "`do.call(cbind.data.frame, x)` is inefficient and can be hard to read.".to_string()
@@ -185,7 +186,7 @@ Let's analyze this by blocks:
 
 * the first lines import required crates and functions, and define a struct using the rule name (in TitleCase);
 * then there is some documentation (truncated here for conciseness). The version number corresponds to the next version, not the current one.
-* the `impl` block is where we define the name and the main message (`body`) that will be used in the output of Jarl. Note that there is also a `suggestion()` function which is not always necessary.
+* the `impl` block is where we link the violation to its `Rule` variant (the one declared in `rule_set.rs`) and define the main message (`body`) that will be used in the output of Jarl. Note that there is also a `suggestion()` function which is not always necessary.
 * finally, we define the function where we parse the AST.
 
 ::: {.callout-note collapse="true"}
@@ -195,7 +196,7 @@ If you explore other rules implementation, you might notice that the `impl Viola
 This is because in some cases, the message and/or the suggestion depend on the AST itself.
 For example, for the `assignment` rule, the message will recommend the use of `<-` or `=` depending on the user settings.
 
-In this scenario, the name, body, and suggestion are defined at the very end, when we build the `Diagnostic`.
+In this scenario, the rule, body, and suggestion are defined at the very end, when we build the `Diagnostic`.
 :::
 
 


### PR DESCRIPTION
This avoids an extra parsing `Rule::from_name(&self.message.name)` in several functions.