### PR TITLE
refactor: Remove unnecessary `unwrap()`

### DIFF
--- a/crates/jarl-core/src/analyze/expression.rs
+++ b/crates/jarl-core/src/analyze/expression.rs
@@ -46,7 +46,7 @@ pub(crate) fn check_expression(
             }
 
             for arg in children.arguments()?.items() {
-                if let Some(expr) = arg.unwrap().as_fields().value {
+                if let Some(expr) = arg?.as_fields().value {
                     check_expression(&expr, checker)?;
                 }
             }


### PR DESCRIPTION
Not sure this was actually reachable but might as well remove it.