### PR TITLE
feat: Do not report `implicit_assignment` in `try()`

### DIFF
--- a/crates/jarl-core/src/lints/base/implicit_assignment/options.rs
+++ b/crates/jarl-core/src/lints/base/implicit_assignment/options.rs
@@ -19,6 +19,8 @@ const DEFAULT_SKIPPED_FUNCTIONS: &[&str] = &[
     "quote",
     "suppressMessages",
     "suppressWarnings",
+    // https://github.com/etiennebacher/jarl/issues/653
+    "try",
 ];
 
 /// TOML options for `[lint.implicit_assignment]`.

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -37,9 +37,9 @@
   * `expect_s3_class` now also reports `expect_true(is.<class>(x))`,
     `expect_true(inherits(x, class))`, and dynamic class expressions. Dynamic
     class expressions are reported without an automatic fix (#555, @Yousa-Mirage).
-  * Three more functions skipped by default from `implicit_assignment`: `expect_silent` (from
-    `testthat`), `expect_defunct` (from lifecycle) and `expect_deprecated` (from `lifecycle`)
-    (#543, @maelle).
+  * Four more functions skipped by default from `implicit_assignment`: `expect_silent()`
+    (from `testthat`), `expect_defunct()` and `expect_deprecated()` (from `lifecycle`),
+    and `try()` (#543, @maelle, #654).
   * `outdated_suppression` now has a safe fix that removes the unused
     suppression comment (or comments if `# jarl-ignore-start` and `# jarl-ignore-end`
     are used) (#638).

--- a/docs/reference/config-file.md
+++ b/docs/reference/config-file.md
@@ -363,7 +363,7 @@ namespaced calls, e.g. `skipped-functions = ["list2"]` will ignore `list2()` and
 Default: `skipped-functions = ["alist", "expect_error", "expect_warning", "expect_message",
 "expect_silent", "expect_defunct", "expect_deprecated", "expect_snapshot",
 "expect_no_condition", "expect_no_warning", "expect_no_error", "expect_no_message",
-"quote", "suppressMessages", "suppressWarnings"]`
+"quote", "suppressMessages", "suppressWarnings", "try"]`
 (`expect_`functions come from the `testthat` package, except `expect_defunct` and
 `expect_deprecated` which come from the `lifecycle` package)
 


### PR DESCRIPTION
Fixes #653 