### PR TITLE
feat: Implement `undesirable_operator` rule

### DIFF
--- a/artifacts/jarl.schema.json
+++ b/artifacts/jarl.schema.json
@@ -364,7 +364,7 @@
         },
         "undesirable_operator": {
           "title": "Options for the `undesirable_operator` rule",
-          "description": "Use `operators` to fully replace the default list of undesirable operators.\nUse `extend-operators` to add to the default list.\nSpecifying both is an error.\nSet `call-is-undesirable = false` to skip backtick-quoted calls to operators.\nBanned operators are still reported when they are used in ordinary\nexpressions.",
+          "description": "Use `operators` to fully replace the default list of undesirable operators.\nUse `extend-operators` to add to the default list.\nSpecifying both is an error.",
           "anyOf": [
             {
               "$ref": "#/$defs/UndesirableOperatorOptions"
@@ -541,15 +541,9 @@
       "additionalProperties": false
     },
     "UndesirableOperatorOptions": {
-      "description": "TOML options for `[lint.undesirable_operator]`.\n\nUse `operators` to fully replace the default list of undesirable operators.\nUse `extend-operators` to add to the default list.\nSpecifying both is an error.\nSet `call-is-undesirable = false` to skip backtick-quoted calls to operators.\nBanned operators are still reported when they are used in ordinary\nexpressions.",
+      "description": "TOML options for `[lint.undesirable_operator]`.\n\nUse `operators` to fully replace the default list of undesirable operators.\nUse `extend-operators` to add to the default list.\nSpecifying both is an error.",
       "type": "object",
       "properties": {
-        "call-is-undesirable": {
-          "type": [
-            "boolean",
-            "null"
-          ]
-        },
         "extend-operators": {
           "type": [
             "array",

--- a/artifacts/jarl.schema.json
+++ b/artifacts/jarl.schema.json
@@ -362,6 +362,18 @@
             }
           ]
         },
+        "undesirable_operator": {
+          "title": "Options for the `undesirable_operator` rule",
+          "description": "Use `operators` to fully replace the default list of undesirable operators.\nUse `extend-operators` to add to the default list.\nSpecifying both is an error.\nSet `call-is-undesirable = false` to skip backtick-quoted calls to operators.\nBanned operators are still reported when they are used in ordinary\nexpressions.",
+          "anyOf": [
+            {
+              "$ref": "#/$defs/UndesirableOperatorOptions"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
         "unfixable": {
           "title": "Rule violations to never fix",
           "description": "A list of rules that are never fixed. This only matters if you pass\n`--fix` in the CLI.",
@@ -517,6 +529,37 @@
           }
         },
         "functions": {
+          "type": [
+            "array",
+            "null"
+          ],
+          "items": {
+            "type": "string"
+          }
+        }
+      },
+      "additionalProperties": false
+    },
+    "UndesirableOperatorOptions": {
+      "description": "TOML options for `[lint.undesirable_operator]`.\n\nUse `operators` to fully replace the default list of undesirable operators.\nUse `extend-operators` to add to the default list.\nSpecifying both is an error.\nSet `call-is-undesirable = false` to skip backtick-quoted calls to operators.\nBanned operators are still reported when they are used in ordinary\nexpressions.",
+      "type": "object",
+      "properties": {
+        "call-is-undesirable": {
+          "type": [
+            "boolean",
+            "null"
+          ]
+        },
+        "extend-operators": {
+          "type": [
+            "array",
+            "null"
+          ],
+          "items": {
+            "type": "string"
+          }
+        },
+        "operators": {
           "type": [
             "array",
             "null"

--- a/crates/jarl-core/src/analyze/binary_expression.rs
+++ b/crates/jarl-core/src/analyze/binary_expression.rs
@@ -18,6 +18,7 @@ use crate::lints::base::pipe_return::pipe_return::pipe_return;
 use crate::lints::base::redundant_equals::redundant_equals::redundant_equals;
 use crate::lints::base::seq::seq::seq;
 use crate::lints::base::string_boundary::string_boundary::string_boundary;
+use crate::lints::base::undesirable_operator::undesirable_operator::undesirable_operator_binary;
 use crate::lints::base::vector_logic::vector_logic::vector_logic;
 
 pub fn binary_expression(r_expr: &RBinaryExpression, checker: &mut Checker) -> anyhow::Result<()> {
@@ -77,6 +78,12 @@ pub fn binary_expression(r_expr: &RBinaryExpression, checker: &mut Checker) -> a
     }
     if checker.is_rule_enabled(Rule::StringBoundary) {
         checker.report_diagnostic(string_boundary(r_expr)?);
+    }
+    if checker.is_rule_enabled(Rule::UndesirableOperator) {
+        checker.report_diagnostic(undesirable_operator_binary(
+            r_expr,
+            &checker.rule_options.undesirable_operator,
+        )?);
     }
     Ok(())
 }

--- a/crates/jarl-core/src/analyze/call.rs
+++ b/crates/jarl-core/src/analyze/call.rs
@@ -33,6 +33,7 @@ use crate::lints::base::stopifnot_all::stopifnot_all::stopifnot_all;
 use crate::lints::base::strings_as_factors::strings_as_factors::strings_as_factors;
 use crate::lints::base::system_file::system_file::system_file;
 use crate::lints::base::undesirable_function::undesirable_function::undesirable_function;
+use crate::lints::base::undesirable_operator::undesirable_operator::undesirable_operator_call;
 use crate::lints::base::which_grepl::which_grepl::which_grepl;
 
 use crate::lints::dplyr::dplyr_filter_out::dplyr_filter_out::dplyr_filter_out;
@@ -147,6 +148,12 @@ pub fn call(r_expr: &RCall, checker: &mut Checker) -> anyhow::Result<()> {
     }
     if checker.is_rule_enabled(Rule::UndesirableFunction) {
         checker.report_diagnostic(undesirable_function(r_expr, fn_name, checker)?);
+    }
+    if checker.is_rule_enabled(Rule::UndesirableOperator) {
+        checker.report_diagnostic(undesirable_operator_call(
+            r_expr,
+            &checker.rule_options.undesirable_operator,
+        )?);
     }
     if checker.is_rule_enabled(Rule::WhichGrepl) {
         checker.report_diagnostic(which_grepl(r_expr, fn_name)?);

--- a/crates/jarl-core/src/analyze/expression.rs
+++ b/crates/jarl-core/src/analyze/expression.rs
@@ -52,6 +52,7 @@ pub(crate) fn check_expression(
             }
         }
         AnyRExpression::RExtractExpression(children) => {
+            analyze::extract_expression::extract_expression(children, checker)?;
             check_expression(&children.left()?, checker)?;
         }
         AnyRExpression::RForStatement(children) => {

--- a/crates/jarl-core/src/analyze/extract_expression.rs
+++ b/crates/jarl-core/src/analyze/extract_expression.rs
@@ -1,0 +1,17 @@
+use crate::checker::Checker;
+use crate::lints::base::undesirable_operator::undesirable_operator::undesirable_operator_extract;
+use crate::rule_set::Rule;
+use air_r_syntax::RExtractExpression;
+
+pub fn extract_expression(
+    r_expr: &RExtractExpression,
+    checker: &mut Checker,
+) -> anyhow::Result<()> {
+    if checker.is_rule_enabled(Rule::UndesirableOperator) {
+        checker.report_diagnostic(undesirable_operator_extract(
+            r_expr,
+            &checker.rule_options.undesirable_operator,
+        )?);
+    }
+    Ok(())
+}

--- a/crates/jarl-core/src/analyze/mod.rs
+++ b/crates/jarl-core/src/analyze/mod.rs
@@ -3,6 +3,7 @@ pub(crate) mod binary_expression;
 pub(crate) mod call;
 pub(crate) mod document;
 pub(crate) mod expression;
+pub(crate) mod extract_expression;
 pub(crate) mod for_loop;
 pub(crate) mod function_definition;
 pub(crate) mod identifier;

--- a/crates/jarl-core/src/analyze/namespace_expression.rs
+++ b/crates/jarl-core/src/analyze/namespace_expression.rs
@@ -3,6 +3,7 @@ use crate::rule_set::Rule;
 use air_r_syntax::RNamespaceExpression;
 
 use crate::lints::base::internal_function::internal_function::internal_function;
+use crate::lints::base::undesirable_operator::undesirable_operator::undesirable_operator_namespace;
 
 pub fn namespace_expression(
     r_expr: &RNamespaceExpression,
@@ -10,6 +11,12 @@ pub fn namespace_expression(
 ) -> anyhow::Result<()> {
     if checker.is_rule_enabled(Rule::InternalFunction) {
         checker.report_diagnostic(internal_function(r_expr)?);
+    }
+    if checker.is_rule_enabled(Rule::UndesirableOperator) {
+        checker.report_diagnostic(undesirable_operator_namespace(
+            r_expr,
+            &checker.rule_options.undesirable_operator,
+        )?);
     }
     Ok(())
 }

--- a/crates/jarl-core/src/lints/base/mod.rs
+++ b/crates/jarl-core/src/lints/base/mod.rs
@@ -56,6 +56,7 @@ pub(crate) mod strings_as_factors;
 pub(crate) mod system_file;
 pub(crate) mod true_false_symbol;
 pub(crate) mod undesirable_function;
+pub(crate) mod undesirable_operator;
 pub(crate) mod unnecessary_nesting;
 pub(crate) mod unnecessary_parentheses;
 pub(crate) mod unreachable_code;

--- a/crates/jarl-core/src/lints/base/undesirable_operator/mod.rs
+++ b/crates/jarl-core/src/lints/base/undesirable_operator/mod.rs
@@ -100,7 +100,6 @@ mod tests {
         let settings = settings_with_options(UndesirableOperatorOptions {
             operators: Some(vec!["$".to_string()]),
             extend_operators: None,
-            call_is_undesirable: None,
         });
 
         expect_no_lint_with_settings("x <<- 1", "undesirable_operator", None, settings.clone());
@@ -124,7 +123,6 @@ mod tests {
         let settings = settings_with_options(UndesirableOperatorOptions {
             operators: None,
             extend_operators: Some(vec!["$".to_string()]),
-            call_is_undesirable: None,
         });
 
         assert_snapshot!(
@@ -151,16 +149,5 @@ mod tests {
         Found 1 error.
         "
         );
-    }
-
-    #[test]
-    fn test_call_is_undesirable() {
-        let settings = settings_with_options(UndesirableOperatorOptions {
-            operators: None,
-            extend_operators: None,
-            call_is_undesirable: Some(false),
-        });
-
-        expect_no_lint_with_settings("`:::`(pkg, fun)", "undesirable_operator", None, settings);
     }
 }

--- a/crates/jarl-core/src/lints/base/undesirable_operator/mod.rs
+++ b/crates/jarl-core/src/lints/base/undesirable_operator/mod.rs
@@ -39,6 +39,7 @@ mod tests {
         expect_no_lint("x |> f()", "undesirable_operator", None);
         expect_no_lint("x %>% f()", "undesirable_operator", None);
         expect_no_lint("utils::f()", "undesirable_operator", None);
+        expect_no_lint("`+`(x, y)", "undesirable_operator", None);
         expect_no_lint("# x <<- 1", "undesirable_operator", None);
         expect_no_lint("x <- 'x <<- 1'", "undesirable_operator", None);
     }

--- a/crates/jarl-core/src/lints/base/undesirable_operator/mod.rs
+++ b/crates/jarl-core/src/lints/base/undesirable_operator/mod.rs
@@ -1,0 +1,166 @@
+pub(crate) mod options;
+pub(crate) mod undesirable_operator;
+
+#[cfg(test)]
+mod tests {
+    use crate::lints::base::undesirable_operator::options::ResolvedUndesirableOperatorOptions;
+    use crate::lints::base::undesirable_operator::options::UndesirableOperatorOptions;
+    use crate::rule_options::ResolvedRuleOptions;
+    use crate::settings::{LinterSettings, Settings};
+    use crate::utils_test::*;
+    use insta::assert_snapshot;
+
+    fn snapshot_lint(code: &str) -> String {
+        format_diagnostics(code, "undesirable_operator", None)
+    }
+
+    fn snapshot_lint_with_settings(code: &str, settings: Settings) -> String {
+        format_diagnostics_with_settings(code, "undesirable_operator", None, Some(settings))
+    }
+
+    fn settings_with_options(options: UndesirableOperatorOptions) -> Settings {
+        Settings {
+            linter: LinterSettings {
+                rule_options: ResolvedRuleOptions {
+                    undesirable_operator: ResolvedUndesirableOperatorOptions::resolve(Some(
+                        &options,
+                    ))
+                    .unwrap(),
+                    ..Default::default()
+                },
+                ..Default::default()
+            },
+        }
+    }
+
+    #[test]
+    fn test_no_lint_undesirable_operator() {
+        expect_no_lint("x + y", "undesirable_operator", None);
+        expect_no_lint("x |> f()", "undesirable_operator", None);
+        expect_no_lint("x %>% f()", "undesirable_operator", None);
+        expect_no_lint("utils::f()", "undesirable_operator", None);
+        expect_no_lint("# x <<- 1", "undesirable_operator", None);
+        expect_no_lint("x <- 'x <<- 1'", "undesirable_operator", None);
+    }
+
+    #[test]
+    fn test_lint_undesirable_operator() {
+        assert_snapshot!(
+            snapshot_lint("x <<- 1"),
+            @"
+        warning: undesirable_operator
+         --> <test>:1:3
+          |
+        1 | x <<- 1
+          |   --- `<<-` is listed as an undesirable operator.
+          |
+        Found 1 error.
+        "
+        );
+        assert_snapshot!(
+            snapshot_lint("1 ->> x"),
+            @"
+        warning: undesirable_operator
+         --> <test>:1:3
+          |
+        1 | 1 ->> x
+          |   --- `->>` is listed as an undesirable operator.
+          |
+        Found 1 error.
+        "
+        );
+        assert_snapshot!(
+            snapshot_lint("pkg:::fun()"),
+            @"
+        warning: undesirable_operator
+         --> <test>:1:4
+          |
+        1 | pkg:::fun()
+          |    --- `:::` is listed as an undesirable operator.
+          |
+        Found 1 error.
+        "
+        );
+        assert_snapshot!(
+            snapshot_lint("`:::`(pkg, fun)"),
+            @"
+        warning: undesirable_operator
+         --> <test>:1:1
+          |
+        1 | `:::`(pkg, fun)
+          | ----- `:::` is listed as an undesirable operator.
+          |
+        Found 1 error.
+        "
+        );
+    }
+
+    #[test]
+    fn test_custom_operators_replace_defaults() {
+        let settings = settings_with_options(UndesirableOperatorOptions {
+            operators: Some(vec!["$".to_string()]),
+            extend_operators: None,
+            call_is_undesirable: None,
+        });
+
+        expect_no_lint_with_settings("x <<- 1", "undesirable_operator", None, settings.clone());
+
+        assert_snapshot!(
+            snapshot_lint_with_settings("x$y", settings),
+            @"
+        warning: undesirable_operator
+         --> <test>:1:2
+          |
+        1 | x$y
+          |  - `$` is listed as an undesirable operator.
+          |
+        Found 1 error.
+        "
+        );
+    }
+
+    #[test]
+    fn test_extend_operators() {
+        let settings = settings_with_options(UndesirableOperatorOptions {
+            operators: None,
+            extend_operators: Some(vec!["$".to_string()]),
+            call_is_undesirable: None,
+        });
+
+        assert_snapshot!(
+            snapshot_lint_with_settings("x <<- 1", settings.clone()),
+            @"
+        warning: undesirable_operator
+         --> <test>:1:3
+          |
+        1 | x <<- 1
+          |   --- `<<-` is listed as an undesirable operator.
+          |
+        Found 1 error.
+        "
+        );
+        assert_snapshot!(
+            snapshot_lint_with_settings("x$y", settings),
+            @"
+        warning: undesirable_operator
+         --> <test>:1:2
+          |
+        1 | x$y
+          |  - `$` is listed as an undesirable operator.
+          |
+        Found 1 error.
+        "
+        );
+    }
+
+    #[test]
+    fn test_call_is_undesirable() {
+        let settings = settings_with_options(UndesirableOperatorOptions {
+            operators: None,
+            extend_operators: None,
+            call_is_undesirable: Some(false),
+        });
+
+        expect_no_lint_with_settings("`:::`(pkg, fun)", "undesirable_operator", None, settings);
+    }
+}

--- a/crates/jarl-core/src/lints/base/undesirable_operator/options.rs
+++ b/crates/jarl-core/src/lints/base/undesirable_operator/options.rs
@@ -10,16 +10,12 @@ const DEFAULT_OPERATORS: &[&str] = &["->>", ":::", "<<-"];
 /// Use `operators` to fully replace the default list of undesirable operators.
 /// Use `extend-operators` to add to the default list.
 /// Specifying both is an error.
-/// Set `call-is-undesirable = false` to skip backtick-quoted calls to operators.
-/// Banned operators are still reported when they are used in ordinary
-/// expressions.
 #[derive(Clone, Debug, PartialEq, Eq, Default, serde::Deserialize)]
 #[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 #[serde(deny_unknown_fields, rename_all = "kebab-case")]
 pub struct UndesirableOperatorOptions {
     pub operators: Option<Vec<String>>,
     pub extend_operators: Option<Vec<String>>,
-    pub call_is_undesirable: Option<bool>,
 }
 
 /// Resolved options for the `undesirable_operator` rule, ready for use during
@@ -27,7 +23,6 @@ pub struct UndesirableOperatorOptions {
 #[derive(Clone, Debug)]
 pub struct ResolvedUndesirableOperatorOptions {
     pub operators: HashSet<String>,
-    pub call_is_undesirable: bool,
 }
 
 impl ResolvedUndesirableOperatorOptions {
@@ -44,10 +39,6 @@ impl ResolvedUndesirableOperatorOptions {
             "undesirable_operator",
             "operators",
         )?;
-        let call_is_undesirable = options
-            .and_then(|opts| opts.call_is_undesirable)
-            .unwrap_or(true);
-
-        Ok(Self { operators, call_is_undesirable })
+        Ok(Self { operators })
     }
 }

--- a/crates/jarl-core/src/lints/base/undesirable_operator/options.rs
+++ b/crates/jarl-core/src/lints/base/undesirable_operator/options.rs
@@ -1,0 +1,53 @@
+use std::collections::HashSet;
+
+use crate::rule_options::resolve_with_extend;
+
+/// Default operators that are considered undesirable.
+const DEFAULT_OPERATORS: &[&str] = &["->>", ":::", "<<-"];
+
+/// TOML options for `[lint.undesirable_operator]`.
+///
+/// Use `operators` to fully replace the default list of undesirable operators.
+/// Use `extend-operators` to add to the default list.
+/// Specifying both is an error.
+/// Set `call-is-undesirable = false` to skip backtick-quoted calls to operators.
+/// Banned operators are still reported when they are used in ordinary
+/// expressions.
+#[derive(Clone, Debug, PartialEq, Eq, Default, serde::Deserialize)]
+#[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
+#[serde(deny_unknown_fields, rename_all = "kebab-case")]
+pub struct UndesirableOperatorOptions {
+    pub operators: Option<Vec<String>>,
+    pub extend_operators: Option<Vec<String>>,
+    pub call_is_undesirable: Option<bool>,
+}
+
+/// Resolved options for the `undesirable_operator` rule, ready for use during
+/// linting.
+#[derive(Clone, Debug)]
+pub struct ResolvedUndesirableOperatorOptions {
+    pub operators: HashSet<String>,
+    pub call_is_undesirable: bool,
+}
+
+impl ResolvedUndesirableOperatorOptions {
+    pub fn resolve(options: Option<&UndesirableOperatorOptions>) -> anyhow::Result<Self> {
+        let (base, extend) = match options {
+            Some(opts) => (opts.operators.as_ref(), opts.extend_operators.as_ref()),
+            None => (None, None),
+        };
+
+        let operators = resolve_with_extend(
+            base,
+            extend,
+            DEFAULT_OPERATORS,
+            "undesirable_operator",
+            "operators",
+        )?;
+        let call_is_undesirable = options
+            .and_then(|opts| opts.call_is_undesirable)
+            .unwrap_or(true);
+
+        Ok(Self { operators, call_is_undesirable })
+    }
+}

--- a/crates/jarl-core/src/lints/base/undesirable_operator/undesirable_operator.rs
+++ b/crates/jarl-core/src/lints/base/undesirable_operator/undesirable_operator.rs
@@ -32,17 +32,14 @@ pub struct UndesirableOperator {
 /// operators = ["$", "@"]
 /// ```
 ///
-/// To add to the defaults or skip backtick-quoted calls to operators:
+/// To add to the defaults:
 ///
 /// ```toml
 /// [lint.undesirable_operator]
 /// extend-operators = ["$", "%in%"]
-/// call-is-undesirable = false
 /// ```
 ///
-/// Specifying both `operators` and `extend-operators` is an error. Setting
-/// `call-is-undesirable = false` still reports the banned operators when
-/// they are used in ordinary expressions.
+/// Specifying both `operators` and `extend-operators` is an error.
 ///
 /// ## Example
 ///
@@ -105,10 +102,6 @@ pub fn undesirable_operator_call(
     ast: &RCall,
     options: &ResolvedUndesirableOperatorOptions,
 ) -> anyhow::Result<Option<Diagnostic>> {
-    if !options.call_is_undesirable {
-        return Ok(None);
-    }
-
     let function = ast.function()?;
     let function_text = function.syntax().text_trimmed().to_string();
     let Some(operator_text) = function_text

--- a/crates/jarl-core/src/lints/base/undesirable_operator/undesirable_operator.rs
+++ b/crates/jarl-core/src/lints/base/undesirable_operator/undesirable_operator.rs
@@ -1,0 +1,129 @@
+use crate::diagnostic::*;
+use crate::lints::base::undesirable_operator::options::ResolvedUndesirableOperatorOptions;
+use crate::rule_set::Rule;
+use air_r_syntax::*;
+use biome_rowan::{AstNode, TextRange};
+
+pub struct UndesirableOperator {
+    pub operator: String,
+}
+
+/// Version added: 0.6.0
+///
+/// ## What it does
+///
+/// Checks for use of banned operators.
+///
+/// ## Why is this bad?
+///
+/// Some operators should not appear in production code. For example, `:::`
+/// accesses a package's internal functions, and `<<-` and `->>` assign outside
+/// the current environment.
+///
+/// ## Configuration
+///
+/// By default, only `->>`, `:::`, and `<<-` are flagged. You can customize the
+/// list in `jarl.toml`:
+///
+/// To replace the default list entirely:
+///
+/// ```toml
+/// [lint.undesirable_operator]
+/// operators = ["$", "@"]
+/// ```
+///
+/// To add to the defaults or skip backtick-quoted calls to operators:
+///
+/// ```toml
+/// [lint.undesirable_operator]
+/// extend-operators = ["$", "%in%"]
+/// call-is-undesirable = false
+/// ```
+///
+/// Specifying both `operators` and `extend-operators` is an error. Setting
+/// `call-is-undesirable = false` still reports the banned operators when
+/// they are used in ordinary expressions.
+///
+/// ## Example
+///
+/// ```r
+/// package:::internal_function()  # flagged by default
+/// value <<- 1                    # flagged by default
+/// ```
+impl Violation for UndesirableOperator {
+    fn rule(&self) -> Rule {
+        Rule::UndesirableOperator
+    }
+
+    fn body(&self) -> String {
+        format!("`{}` is listed as an undesirable operator.", self.operator)
+    }
+}
+
+fn undesirable_operator(operator: &str, range: TextRange) -> Option<Diagnostic> {
+    Some(Diagnostic::new(
+        UndesirableOperator { operator: operator.to_string() },
+        range,
+        Fix::empty(),
+    ))
+}
+
+fn check_operator(
+    operator: &RSyntaxToken,
+    options: &ResolvedUndesirableOperatorOptions,
+) -> Option<Diagnostic> {
+    let operator_text = operator.text_trimmed();
+    if !options.operators.contains(operator_text) {
+        return None;
+    }
+
+    undesirable_operator(operator_text, operator.text_trimmed_range())
+}
+
+pub fn undesirable_operator_binary(
+    ast: &RBinaryExpression,
+    options: &ResolvedUndesirableOperatorOptions,
+) -> anyhow::Result<Option<Diagnostic>> {
+    Ok(check_operator(&ast.operator()?, options))
+}
+
+pub fn undesirable_operator_namespace(
+    ast: &RNamespaceExpression,
+    options: &ResolvedUndesirableOperatorOptions,
+) -> anyhow::Result<Option<Diagnostic>> {
+    Ok(check_operator(&ast.operator()?, options))
+}
+
+pub fn undesirable_operator_extract(
+    ast: &RExtractExpression,
+    options: &ResolvedUndesirableOperatorOptions,
+) -> anyhow::Result<Option<Diagnostic>> {
+    Ok(check_operator(&ast.operator()?, options))
+}
+
+pub fn undesirable_operator_call(
+    ast: &RCall,
+    options: &ResolvedUndesirableOperatorOptions,
+) -> anyhow::Result<Option<Diagnostic>> {
+    if !options.call_is_undesirable {
+        return Ok(None);
+    }
+
+    let function = ast.function()?;
+    let function_text = function.syntax().text_trimmed().to_string();
+    let Some(operator_text) = function_text
+        .strip_prefix('`')
+        .and_then(|text| text.strip_suffix('`'))
+    else {
+        return Ok(None);
+    };
+
+    if !options.operators.contains(operator_text) {
+        return Ok(None);
+    }
+
+    Ok(undesirable_operator(
+        operator_text,
+        function.syntax().text_trimmed_range(),
+    ))
+}

--- a/crates/jarl-core/src/rule_options.rs
+++ b/crates/jarl-core/src/rule_options.rs
@@ -100,6 +100,7 @@ declare_rule_options! {
     base::quotes => ResolvedQuotesOptions,
     base::true_false_symbol => ResolvedTrueFalseSymbolOptions,
     base::undesirable_function => ResolvedUndesirableFunctionOptions,
+    base::undesirable_operator => ResolvedUndesirableOperatorOptions,
     base::unreachable_code => ResolvedUnreachableCodeOptions,
     base::unused_function => ResolvedUnusedFunctionOptions,
     base::unused_object => ResolvedUnusedObjectOptions,

--- a/crates/jarl-core/src/rule_set.rs
+++ b/crates/jarl-core/src/rule_set.rs
@@ -651,6 +651,13 @@ declare_rules! {
         fix: None,
         min_r_version: None,
     },
+    UndesirableOperator => {
+        name: "undesirable_operator",
+        categories: [Corr],
+        default: Enabled,
+        fix: None,
+        min_r_version: None,
+    },
     UnnecessaryNesting => {
         name: "unnecessary_nesting",
         categories: [Read],

--- a/crates/jarl-core/src/toml.rs
+++ b/crates/jarl-core/src/toml.rs
@@ -332,9 +332,6 @@ pub struct LinterTomlOptions {
     /// Use `operators` to fully replace the default list of undesirable operators.
     /// Use `extend-operators` to add to the default list.
     /// Specifying both is an error.
-    /// Set `call-is-undesirable = false` to skip backtick-quoted calls to operators.
-    /// Banned operators are still reported when they are used in ordinary
-    /// expressions.
     #[serde(rename = "undesirable_operator")]
     pub undesirable_operator: Option<UndesirableOperatorOptions>,
 

--- a/crates/jarl-core/src/toml.rs
+++ b/crates/jarl-core/src/toml.rs
@@ -25,6 +25,7 @@ use crate::lints::base::pipe_consistency::options::PipeConsistencyOptions;
 use crate::lints::base::quotes::options::QuotesOptions;
 use crate::lints::base::true_false_symbol::options::TrueFalseSymbolOptions;
 use crate::lints::base::undesirable_function::options::UndesirableFunctionOptions;
+use crate::lints::base::undesirable_operator::options::UndesirableOperatorOptions;
 use crate::lints::base::unreachable_code::options::UnreachableCodeOptions;
 use crate::lints::base::unused_function::options::UnusedFunctionOptions;
 use crate::lints::base::unused_object::options::UnusedObjectOptions;
@@ -325,6 +326,17 @@ pub struct LinterTomlOptions {
     /// Specifying both is an error.
     #[serde(rename = "undesirable_function")]
     pub undesirable_function: Option<UndesirableFunctionOptions>,
+
+    /// # Options for the `undesirable_operator` rule
+    ///
+    /// Use `operators` to fully replace the default list of undesirable operators.
+    /// Use `extend-operators` to add to the default list.
+    /// Specifying both is an error.
+    /// Set `call-is-undesirable = false` to skip backtick-quoted calls to operators.
+    /// Banned operators are still reported when they are used in ordinary
+    /// expressions.
+    #[serde(rename = "undesirable_operator")]
+    pub undesirable_operator: Option<UndesirableOperatorOptions>,
 
     /// # Options for the `unreachable_code` rule
     ///

--- a/crates/jarl/tests/integration/toml_rule_args.rs
+++ b/crates/jarl/tests/integration/toml_rule_args.rs
@@ -611,10 +611,9 @@ select = ["undesirable_operator"]
 
 [lint.undesirable_operator]
 operators = ["$", "%>%", "%notin%"]
-call-is-undesirable = false
 "#,
         ),
-        ("test.R", "x$y\nx %>% f()\nx %notin% y\n`$`(x, y)\nx <<- 1"),
+        ("test.R", "x$y\nx %>% f()\nx %notin% y\nx <<- 1"),
     ])?;
 
     insta::assert_snapshot!(
@@ -698,7 +697,7 @@ unknown-option = ["$"]
       |
     5 | unknown-option = ["$"]
       | ^^^^^^^^^^^^^^
-    unknown field `unknown-option`, expected one of `operators`, `extend-operators`, `call-is-undesirable`
+    unknown field `unknown-option`, expected `operators` or `extend-operators`
     "#
     );
 
@@ -739,49 +738,6 @@ extend-operators = ["@"]
     jarl failed
       Cause: Invalid configuration in [TEMP_DIR]/jarl.toml:
     Cannot specify both `operators` and `extend-operators` in `[lint.undesirable_operator]`.
-    "#
-    );
-
-    Ok(())
-}
-
-#[test]
-fn test_undesirable_operator_invalid_value_is_error() -> anyhow::Result<()> {
-    let case = CliTest::with_files([
-        (
-            "jarl.toml",
-            r#"
-[lint]
-
-[lint.undesirable_operator]
-call-is-undesirable = "false"
-"#,
-        ),
-        ("test.R", "x + 1"),
-    ])?;
-
-    insta::assert_snapshot!(
-        &mut case
-            .command()
-            .arg("check")
-            .arg(".")
-            .run()
-            .normalize_os_executable_name()
-            .normalize_temp_paths(),
-        @r#"
-
-    success: false
-    exit_code: 255
-    ----- stdout -----
-
-    ----- stderr -----
-    jarl failed
-      Cause: Failed to parse [TEMP_DIR]/jarl.toml:
-    TOML parse error at line 5, column 23
-      |
-    5 | call-is-undesirable = "false"
-      |                       ^^^^^^^
-    invalid type: string "false", expected a boolean
     "#
     );
 

--- a/crates/jarl/tests/integration/toml_rule_args.rs
+++ b/crates/jarl/tests/integration/toml_rule_args.rs
@@ -598,6 +598,196 @@ pipe = "foo"
     Ok(())
 }
 
+// undesirable_operator ----------------------------------------
+
+#[test]
+fn test_undesirable_operator_options_are_applied() -> anyhow::Result<()> {
+    let case = CliTest::with_files([
+        (
+            "jarl.toml",
+            r#"
+[lint]
+select = ["undesirable_operator"]
+
+[lint.undesirable_operator]
+operators = ["$", "%>%", "%notin%"]
+call-is-undesirable = false
+"#,
+        ),
+        ("test.R", "x$y\nx %>% f()\nx %notin% y\n`$`(x, y)\nx <<- 1"),
+    ])?;
+
+    insta::assert_snapshot!(
+        &mut case
+            .command()
+            .arg("check")
+            .arg(".")
+            .run()
+            .normalize_os_executable_name()
+            .normalize_temp_paths(),
+        @r#"
+
+    success: false
+    exit_code: 1
+    ----- stdout -----
+    warning: undesirable_operator
+     --> test.R:1:2
+      |
+    1 | x$y
+      |  - `$` is listed as an undesirable operator.
+      |
+
+    warning: undesirable_operator
+     --> test.R:2:3
+      |
+    2 | x %>% f()
+      |   --- `%>%` is listed as an undesirable operator.
+      |
+
+    warning: undesirable_operator
+     --> test.R:3:3
+      |
+    3 | x %notin% y
+      |   ------- `%notin%` is listed as an undesirable operator.
+      |
+
+
+    ── Summary ──────────────────────────────────────
+    Found 3 errors.
+
+    ----- stderr -----
+    "#
+    );
+
+    Ok(())
+}
+
+#[test]
+fn test_undesirable_operator_unknown_field_is_error() -> anyhow::Result<()> {
+    let case = CliTest::with_files([
+        (
+            "jarl.toml",
+            r#"
+[lint]
+
+[lint.undesirable_operator]
+unknown-option = ["$"]
+"#,
+        ),
+        ("test.R", "x + 1"),
+    ])?;
+
+    insta::assert_snapshot!(
+        &mut case
+            .command()
+            .arg("check")
+            .arg(".")
+            .run()
+            .normalize_os_executable_name()
+            .normalize_temp_paths(),
+        @r#"
+
+    success: false
+    exit_code: 255
+    ----- stdout -----
+
+    ----- stderr -----
+    jarl failed
+      Cause: Failed to parse [TEMP_DIR]/jarl.toml:
+    TOML parse error at line 5, column 1
+      |
+    5 | unknown-option = ["$"]
+      | ^^^^^^^^^^^^^^
+    unknown field `unknown-option`, expected one of `operators`, `extend-operators`, `call-is-undesirable`
+    "#
+    );
+
+    Ok(())
+}
+
+#[test]
+fn test_undesirable_operator_cannot_replace_and_extend() -> anyhow::Result<()> {
+    let case = CliTest::with_files([
+        (
+            "jarl.toml",
+            r#"
+[lint]
+
+[lint.undesirable_operator]
+operators = ["$"]
+extend-operators = ["@"]
+"#,
+        ),
+        ("test.R", "x + 1"),
+    ])?;
+
+    insta::assert_snapshot!(
+        &mut case
+            .command()
+            .arg("check")
+            .arg(".")
+            .run()
+            .normalize_os_executable_name()
+            .normalize_temp_paths(),
+        @r#"
+
+    success: false
+    exit_code: 255
+    ----- stdout -----
+
+    ----- stderr -----
+    jarl failed
+      Cause: Invalid configuration in [TEMP_DIR]/jarl.toml:
+    Cannot specify both `operators` and `extend-operators` in `[lint.undesirable_operator]`.
+    "#
+    );
+
+    Ok(())
+}
+
+#[test]
+fn test_undesirable_operator_invalid_value_is_error() -> anyhow::Result<()> {
+    let case = CliTest::with_files([
+        (
+            "jarl.toml",
+            r#"
+[lint]
+
+[lint.undesirable_operator]
+call-is-undesirable = "false"
+"#,
+        ),
+        ("test.R", "x + 1"),
+    ])?;
+
+    insta::assert_snapshot!(
+        &mut case
+            .command()
+            .arg("check")
+            .arg(".")
+            .run()
+            .normalize_os_executable_name()
+            .normalize_temp_paths(),
+        @r#"
+
+    success: false
+    exit_code: 255
+    ----- stdout -----
+
+    ----- stderr -----
+    jarl failed
+      Cause: Failed to parse [TEMP_DIR]/jarl.toml:
+    TOML parse error at line 5, column 23
+      |
+    5 | call-is-undesirable = "false"
+      |                       ^^^^^^^
+    invalid type: string "false", expected a boolean
+    "#
+    );
+
+    Ok(())
+}
+
 // quotes ----------------------------------------
 
 #[test]

--- a/docs/_quarto.yml
+++ b/docs/_quarto.yml
@@ -159,6 +159,7 @@ website:
       - rules/system_file.md
       - rules/true_false_symbol.md
       - rules/undesirable_function.md
+      - rules/undesirable_operator.md
       - rules/unexplained_suppression.md
       - rules/unmatched_range_suppression.md
       - rules/unnecessary_nesting.md

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -27,6 +27,7 @@
   * `rep_times_ignored` (#556, @Yousa-Mirage)
   * `stopifnot_all` (#547, @Yousa-Mirage)
   * `strings_as_factors` (#546, @Yousa-Mirage)
+  * `undesirable_operator`
   * `unnecessary_parentheses` (#510, @JosephBARBIERDARNAL)
   * `unused_object` (#589)
 

--- a/docs/reference/config-file.md
+++ b/docs/reference/config-file.md
@@ -455,6 +455,22 @@ Default: `skipped-functions = []`
 skipped-functions = ["foo"]
 ```
 
+### `undesirable_operator`
+
+By default, only `->>`, `:::`, and `<<-` are flagged. You can customize the
+list in `jarl.toml`. Use `operators` to replace the default list entirely, or
+use `extend-operators` to add to the defaults. Specifying both is an error.
+
+Set `call-is-undesirable = false` to skip backtick-quoted calls to operators.
+Banned operators are still reported when they are used in ordinary
+expressions.
+
+```toml
+[lint.undesirable_operator]
+extend-operators = ["%in%"]
+call-is-undesirable = false
+```
+
 ### `unreachable_code`
 
 Use `stopping-functions` to fully replace the default list of functions that are

--- a/docs/reference/config-file.md
+++ b/docs/reference/config-file.md
@@ -461,14 +461,12 @@ By default, only `->>`, `:::`, and `<<-` are flagged. You can customize the
 list in `jarl.toml`. Use `operators` to replace the default list entirely, or
 use `extend-operators` to add to the defaults. Specifying both is an error.
 
-Set `call-is-undesirable = false` to skip backtick-quoted calls to operators.
-Banned operators are still reported when they are used in ordinary
-expressions.
+The ban applies to ordinary operator expressions and backtick-quoted calls to
+operators.
 
 ```toml
 [lint.undesirable_operator]
 extend-operators = ["%in%"]
-call-is-undesirable = false
 ```
 
 ### `unreachable_code`

--- a/docs/rules.qmd
+++ b/docs/rules.qmd
@@ -136,6 +136,7 @@ dat <- as.data.frame(
     c("system_file", "readability", "✅", ""),
     c("true_false_symbol", "readability", "❌", ""),
     c("undesirable_function", "correctness", "❌", ""),
+    c("undesirable_operator", "correctness", "❌", ""),
     c("unexplained_suppression", "comments", "❌", ""),
     c("unmatched_range_suppression", "comments", "❌", ""),
     c("unnecessary_nesting", "readability", "✅", "Disabled by default"),

--- a/docs/rules/undesirable_operator.md
+++ b/docs/rules/undesirable_operator.md
@@ -24,17 +24,14 @@ To replace the default list entirely:
 operators = ["$", "@"]
 ```
 
-To add to the defaults or skip backtick-quoted calls to operators:
+To add to the defaults:
 
 ```toml
 [lint.undesirable_operator]
 extend-operators = ["$", "%in%"]
-call-is-undesirable = false
 ```
 
-Specifying both `operators` and `extend-operators` is an error. Setting
-`call-is-undesirable = false` still reports the banned operators when
-they are used in ordinary expressions.
+Specifying both `operators` and `extend-operators` is an error.
 
 ## Example
 

--- a/docs/rules/undesirable_operator.md
+++ b/docs/rules/undesirable_operator.md
@@ -1,0 +1,44 @@
+# undesirable_operator
+::: {.callout-note title="Added in 0.6.0" .low-opacity}
+:::
+
+## What it does
+
+Checks for use of banned operators.
+
+## Why is this bad?
+
+Some operators should not appear in production code. For example, `:::`
+accesses a package's internal functions, and `<<-` and `->>` assign outside
+the current environment.
+
+## Configuration
+
+By default, only `->>`, `:::`, and `<<-` are flagged. You can customize the
+list in `jarl.toml`:
+
+To replace the default list entirely:
+
+```toml
+[lint.undesirable_operator]
+operators = ["$", "@"]
+```
+
+To add to the defaults or skip backtick-quoted calls to operators:
+
+```toml
+[lint.undesirable_operator]
+extend-operators = ["$", "%in%"]
+call-is-undesirable = false
+```
+
+Specifying both `operators` and `extend-operators` is an error. Setting
+`call-is-undesirable = false` still reports the banned operators when
+they are used in ordinary expressions.
+
+## Example
+
+```r
+package:::internal_function()  # flagged by default
+value <<- 1                    # flagged by default
+```


### PR DESCRIPTION
Part of #8. The rule in `lintr` is [`undesirable_operator_linter`](https://lintr.r-lib.org/reference/undesirable_operator_linter.html). I started with the special backtick option that `lintr` has, but that seemed to offer unnecessary complexity.

This PR adds support for the `undesirable_operator` here, closely mirroring the implementation of `undesirable_function`. I set it as "Correctness" and on by default, to match the function version. There is no auto-fix option.

One thing that I want to flag ahead is that this creates duplicate behavior for `:::`, since there's a special case for that already. It would be simple to drop that and update tests if you don't want that included.

No rush here, just a feature I would like to use when you have time to look.