### PR TITLE
feat: Implement `object_name` linter

### DIFF
--- a/artifacts/jarl.schema.json
+++ b/artifacts/jarl.schema.json
@@ -291,7 +291,7 @@
         },
         "object_name": {
           "title": "Options for the `object_name` rule",
-          "description": "Use `styles` to select built-in naming styles and `regexes` to add named\nregular expressions.",
+          "description": "Use `styles` to select built-in naming styles, `regexes` to add named\nregular expressions, and `special-names` / `extend-special-names` to\nconfigure names that are exempt from style checks.",
           "anyOf": [
             {
               "$ref": "#/$defs/ObjectNameOptions"
@@ -474,15 +474,33 @@
       "additionalProperties": false
     },
     "ObjectNameOptions": {
-      "description": "TOML options for `[lint.object_name]`.\n\n`styles` selects the built-in naming styles. `regexes` adds named regular\nexpressions that can be used alongside the selected styles.",
+      "description": "TOML options for `[lint.object_name]`.\n\n`styles` selects the built-in naming styles. `regexes` adds named regular\nexpressions that can be used alongside the selected styles. `special-names`\nreplaces the built-in names that are exempt from style checks, while\n`extend-special-names` adds to them.",
       "type": "object",
       "properties": {
+        "extend-special-names": {
+          "type": [
+            "array",
+            "null"
+          ],
+          "items": {
+            "type": "string"
+          }
+        },
         "regexes": {
           "type": [
             "object",
             "null"
           ],
           "additionalProperties": {
+            "type": "string"
+          }
+        },
+        "special-names": {
+          "type": [
+            "array",
+            "null"
+          ],
+          "items": {
             "type": "string"
           }
         },

--- a/artifacts/jarl.schema.json
+++ b/artifacts/jarl.schema.json
@@ -289,6 +289,18 @@
             }
           ]
         },
+        "object_name": {
+          "title": "Options for the `object_name` rule",
+          "description": "Use `styles` to select built-in naming styles and `regexes` to add named\nregular expressions.",
+          "anyOf": [
+            {
+              "$ref": "#/$defs/ObjectNameOptions"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
         "per-file-ignores": {
           "title": "Per-file rule ignores",
           "description": "A mapping of glob patterns to lists of rules that should be ignored in\nthe files matching each pattern. Patterns are gitignore-style and\nresolved relative to the directory containing `jarl.toml` (the same\nformat used by `include` and `exclude`). Rule names and rule groups\n(e.g. `PERF`) are both accepted.\n\nA pattern can be negated with a leading `!`, in which case its rules are\nignored in every file that does *not* match the pattern. When several\npatterns match a file, the rules from all of them are ignored.\n\nFor example:\n\n```toml\n[lint.per-file-ignores]\n\"foo.R\" = [\"true_false_symbol\"]\n# ignore everywhere but in the R folder\n\"!R/**.R\" = [\"any_is_na\"]\n```",
@@ -450,6 +462,31 @@
           }
         },
         "skipped-functions": {
+          "type": [
+            "array",
+            "null"
+          ],
+          "items": {
+            "type": "string"
+          }
+        }
+      },
+      "additionalProperties": false
+    },
+    "ObjectNameOptions": {
+      "description": "TOML options for `[lint.object_name]`.\n\n`styles` selects the built-in naming styles. `regexes` adds named regular\nexpressions that can be used alongside the selected styles.",
+      "type": "object",
+      "properties": {
+        "regexes": {
+          "type": [
+            "object",
+            "null"
+          ],
+          "additionalProperties": {
+            "type": "string"
+          }
+        },
+        "styles": {
           "type": [
             "array",
             "null"

--- a/crates/jarl-core/src/analyze/document.rs
+++ b/crates/jarl-core/src/analyze/document.rs
@@ -5,6 +5,7 @@ use oak_semantic::semantic_index::SemanticIndex;
 use crate::checker::Checker;
 use crate::diagnostic::*;
 use crate::lints::base::empty_file::empty_file::empty_file;
+use crate::lints::base::object_name::object_name::object_name;
 use crate::lints::base::unreachable_code::unreachable_code::unreachable_code_top_level;
 use crate::lints::base::unused_object::unused_object::unused_object;
 use crate::lints::comments::blanket_suppression::blanket_suppression::blanket_suppression;
@@ -31,6 +32,12 @@ pub(crate) fn check_document(
     // --- Document-level analysis ---
 
     let expressions: Vec<RSyntaxNode> = expressions.iter().map(|e| e.syntax().clone()).collect();
+
+    if checker.is_rule_enabled(Rule::ObjectName) {
+        for diagnostic in object_name(syntax, &checker.rule_options.object_name) {
+            checker.report_diagnostic(Some(diagnostic));
+        }
+    }
 
     // Check for unreachable code at top level
     if checker.is_rule_enabled(Rule::UnreachableCode) {

--- a/crates/jarl-core/src/lints/base/mod.rs
+++ b/crates/jarl-core/src/lints/base/mod.rs
@@ -37,6 +37,7 @@ pub(crate) mod nested_pipe;
 pub(crate) mod notin;
 pub(crate) mod numeric_leading_zero;
 pub(crate) mod nzchar;
+pub(crate) mod object_name;
 pub(crate) mod outer_negation;
 pub(crate) mod pipe_consistency;
 pub(crate) mod pipe_return;

--- a/crates/jarl-core/src/lints/base/object_name/mod.rs
+++ b/crates/jarl-core/src/lints/base/object_name/mod.rs
@@ -1,0 +1,92 @@
+pub(crate) mod object_name;
+pub(crate) mod options;
+
+#[cfg(test)]
+mod tests {
+    use std::collections::BTreeMap;
+
+    use crate::lints::base::object_name::options::{ObjectNameOptions, ResolvedObjectNameOptions};
+    use crate::rule_options::ResolvedRuleOptions;
+    use crate::settings::{LinterSettings, Settings};
+    use crate::utils_test::check_code;
+
+    fn reported_names(code: &str, settings: Option<Settings>) -> Vec<String> {
+        let diagnostics =
+            crate::utils_test::check_code_with_settings(code, "object_name", None, settings);
+        diagnostics
+            .iter()
+            .map(|diagnostic| {
+                let start: usize = diagnostic.range.start().into();
+                let end: usize = diagnostic.range.end().into();
+                code[start..end].to_string()
+            })
+            .collect()
+    }
+
+    fn settings_with_options(options: ObjectNameOptions) -> Settings {
+        Settings {
+            linter: LinterSettings {
+                rule_options: ResolvedRuleOptions {
+                    object_name: ResolvedObjectNameOptions::resolve(Some(&options)).unwrap(),
+                    ..Default::default()
+                },
+                ..Default::default()
+            },
+        }
+    }
+
+    #[test]
+    fn reports_assignment_targets_and_formals() {
+        let code = "badName <- 1\nf <- function(badArg, good_name, ...) badArg";
+        assert_eq!(reported_names(code, None), ["badName", "badArg"]);
+    }
+
+    #[test]
+    fn reports_extract_assignment_roots() {
+        let code = "badName$member <- 1\nbadName@slot <- 1\n1 -> badName$member";
+        assert_eq!(
+            reported_names(code, None),
+            ["badName", "badName", "badName"]
+        );
+    }
+
+    #[test]
+    fn distinguishes_named_arguments() {
+        assert!(reported_names("call(badName = 1)", None).is_empty());
+    }
+
+    #[test]
+    fn supports_custom_styles_and_regexes() {
+        let styles = ObjectNameOptions {
+            styles: Some(vec!["CamelCase".to_string()]),
+            regexes: None,
+        };
+        assert_eq!(
+            reported_names(
+                "GoodName <- 1\nbadName <- 1",
+                Some(settings_with_options(styles))
+            ),
+            ["badName"]
+        );
+
+        let regexes = ObjectNameOptions {
+            styles: Some(Vec::new()),
+            regexes: Some(BTreeMap::from([(
+                "prefixed".to_string(),
+                r"^x_[a-z]+$".to_string(),
+            )])),
+        };
+        assert_eq!(
+            reported_names(
+                "x_good <- 1\ngood_name <- 1",
+                Some(settings_with_options(regexes)),
+            ),
+            ["good_name"]
+        );
+    }
+
+    #[test]
+    fn accepts_default_symbol_names() {
+        assert!(check_code("%>% <- function(x) x", "object_name", None).is_empty());
+    }
+}

--- a/crates/jarl-core/src/lints/base/object_name/mod.rs
+++ b/crates/jarl-core/src/lints/base/object_name/mod.rs
@@ -59,7 +59,7 @@ mod tests {
     fn supports_custom_styles_and_regexes() {
         let styles = ObjectNameOptions {
             styles: Some(vec!["CamelCase".to_string()]),
-            regexes: None,
+            ..Default::default()
         };
         assert_eq!(
             reported_names(
@@ -75,6 +75,7 @@ mod tests {
                 "prefixed".to_string(),
                 r"^x_[a-z]+$".to_string(),
             )])),
+            ..Default::default()
         };
         assert_eq!(
             reported_names(
@@ -88,5 +89,67 @@ mod tests {
     #[test]
     fn accepts_default_symbol_names() {
         assert!(check_code("%>% <- function(x) x", "object_name", None).is_empty());
+    }
+
+    #[test]
+    fn accepts_default_special_names() {
+        let code = concat!(
+            ".onLoad <- function(...) TRUE\n",
+            ".onAttach <- function(...) TRUE\n",
+            ".onUnload <- function(...) TRUE\n",
+            ".onDetach <- function(...) TRUE\n",
+            ".Last.lib <- function(...) TRUE\n",
+            ".First <- function(...) TRUE\n",
+            ".Last <- function(...) TRUE\n",
+            "badName <- 1",
+        );
+
+        assert_eq!(reported_names(code, None), ["badName"]);
+    }
+
+    #[test]
+    fn extends_special_names() {
+        let options = ObjectNameOptions {
+            extend_special_names: Some(vec!["mySpecial".to_string()]),
+            ..Default::default()
+        };
+
+        let code = ".onLoad <- function(...) TRUE\nmySpecial <- 1\nbadName <- 1";
+
+        assert_eq!(
+            reported_names(code, Some(settings_with_options(options))),
+            ["badName"]
+        );
+    }
+
+    #[test]
+    fn replaces_special_names() {
+        let options = ObjectNameOptions {
+            special_names: Some(vec!["mySpecial".to_string()]),
+            ..Default::default()
+        };
+
+        let code = ".onLoad <- function(...) TRUE\nmySpecial <- 1";
+
+        assert_eq!(
+            reported_names(code, Some(settings_with_options(options))),
+            [".onLoad"]
+        );
+    }
+
+    #[test]
+    fn rejects_both_special_name_lists() {
+        let options = ObjectNameOptions {
+            special_names: Some(vec!["mySpecial".to_string()]),
+            extend_special_names: Some(vec!["anotherSpecial".to_string()]),
+            ..Default::default()
+        };
+
+        let error = ResolvedObjectNameOptions::resolve(Some(&options)).unwrap_err();
+
+        assert_eq!(
+            error.to_string(),
+            "Cannot specify both `special-names` and `extend-special-names` in `[lint.object_name]`."
+        );
     }
 }

--- a/crates/jarl-core/src/lints/base/object_name/object_name.rs
+++ b/crates/jarl-core/src/lints/base/object_name/object_name.rs
@@ -6,7 +6,33 @@ use crate::diagnostic::{Diagnostic, Fix, ViolationData};
 use crate::lints::base::object_name::options::ResolvedObjectNameOptions;
 use crate::rule_set::Rule;
 
-/// Check naming styles for assignment targets, function formals, and accessor roots.
+/// Version added: 0.6.0
+///
+/// ## What it does
+///
+/// Checks the names of variables and arguments used in assignments and function
+/// definitions. For `$` and `@` assignments, it checks only the base object
+/// name.
+///
+/// ## Why is this bad?
+///
+/// Consistent names make code easier to read and maintain.
+///
+/// ## Example
+///
+/// ```r
+/// badName <- 1
+/// f <- function(badArg) badArg
+/// badName$member <- 1
+/// ```
+///
+/// Use instead:
+///
+/// ```r
+/// bad_name <- 1
+/// f <- function(bad_arg) bad_arg
+/// bad_name$member <- 1
+/// ```
 pub fn object_name(
     syntax: &air_r_syntax::RSyntaxNode,
     options: &ResolvedObjectNameOptions,

--- a/crates/jarl-core/src/lints/base/object_name/object_name.rs
+++ b/crates/jarl-core/src/lints/base/object_name/object_name.rs
@@ -1,0 +1,97 @@
+use air_r_syntax::{AnyRExpression, AnyRValue, RBinaryExpression, RParameter, RSyntaxKind};
+use biome_rowan::{AstNode, TextRange};
+use oak_core::syntax_ext::{RIdentifierExt, RStringValueExt};
+
+use crate::diagnostic::{Diagnostic, Fix, ViolationData};
+use crate::lints::base::object_name::options::ResolvedObjectNameOptions;
+use crate::rule_set::Rule;
+
+/// Check naming styles for assignment targets, function formals, and accessor roots.
+pub fn object_name(
+    syntax: &air_r_syntax::RSyntaxNode,
+    options: &ResolvedObjectNameOptions,
+) -> Vec<Diagnostic> {
+    let mut diagnostics = Vec::new();
+
+    for node in syntax.descendants() {
+        if let Some(parameter) = RParameter::cast(node.clone())
+            && let Ok(air_r_syntax::AnyRParameterName::RIdentifier(identifier)) = parameter.name()
+            && let Some(diagnostic) = name_diagnostic(
+                &identifier.name_text(),
+                identifier.syntax().text_trimmed_range(),
+                options,
+            )
+        {
+            diagnostics.push(diagnostic);
+        }
+
+        if let Some(binary) = RBinaryExpression::cast(node)
+            && let Ok(operator) = binary.operator()
+            && let Some(target) = assignment_target(&binary, operator.kind())
+            && let Some(diagnostic) = name_diagnostic(&target.0, target.1, options)
+        {
+            diagnostics.push(diagnostic);
+        }
+    }
+
+    diagnostics
+}
+
+fn assignment_target(
+    binary: &RBinaryExpression,
+    operator: RSyntaxKind,
+) -> Option<(String, TextRange)> {
+    let expression = match operator {
+        RSyntaxKind::ASSIGN | RSyntaxKind::EQUAL | RSyntaxKind::SUPER_ASSIGN => {
+            binary.left().ok()?
+        }
+        RSyntaxKind::ASSIGN_RIGHT | RSyntaxKind::SUPER_ASSIGN_RIGHT => binary.right().ok()?,
+        _ => return None,
+    };
+
+    root_name(&expression)
+}
+
+fn root_name(expression: &AnyRExpression) -> Option<(String, TextRange)> {
+    match expression {
+        AnyRExpression::RIdentifier(identifier) => Some((
+            identifier.name_text(),
+            identifier.syntax().text_trimmed_range(),
+        )),
+        AnyRExpression::AnyRValue(AnyRValue::RStringValue(value)) => {
+            Some((value.string_text()?, value.syntax().text_trimmed_range()))
+        }
+        AnyRExpression::RExtractExpression(extract) => {
+            let operator = extract.operator().ok()?;
+            if !matches!(operator.kind(), RSyntaxKind::DOLLAR | RSyntaxKind::AT) {
+                return None;
+            }
+            let left = extract.left().ok()?;
+            root_name(&left)
+        }
+        _ => None,
+    }
+}
+
+fn name_diagnostic(
+    name: &str,
+    range: TextRange,
+    options: &ResolvedObjectNameOptions,
+) -> Option<Diagnostic> {
+    if options.matches(name) {
+        return None;
+    }
+
+    Some(Diagnostic::new(
+        ViolationData::new(
+            Rule::ObjectName,
+            format!(
+                "Variable and function name style should match {}.",
+                options.expected()
+            ),
+            None,
+        ),
+        range,
+        Fix::empty(),
+    ))
+}

--- a/crates/jarl-core/src/lints/base/object_name/object_name.rs
+++ b/crates/jarl-core/src/lints/base/object_name/object_name.rs
@@ -104,7 +104,7 @@ fn name_diagnostic(
     range: TextRange,
     options: &ResolvedObjectNameOptions,
 ) -> Option<Diagnostic> {
-    if options.matches(name) {
+    if options.is_special_name(name) || options.matches(name) {
         return None;
     }
 

--- a/crates/jarl-core/src/lints/base/object_name/options.rs
+++ b/crates/jarl-core/src/lints/base/object_name/options.rs
@@ -1,0 +1,108 @@
+use std::collections::BTreeMap;
+
+use regex::Regex;
+use serde::Deserialize;
+
+const DEFAULT_STYLES: &[&str] = &["snake_case", "symbols"];
+const STYLE_NAMES: &str =
+    "CamelCase, camelCase, snake_case, SNAKE_CASE, dotted.case, lowercase, UPPERCASE, or symbols";
+
+/// TOML options for `[lint.object_name]`.
+///
+/// `styles` selects the built-in naming styles. `regexes` adds named regular
+/// expressions that can be used alongside the selected styles.
+#[derive(Clone, Debug, PartialEq, Eq, Default, Deserialize)]
+#[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
+#[serde(deny_unknown_fields, rename_all = "kebab-case")]
+pub struct ObjectNameOptions {
+    pub styles: Option<Vec<String>>,
+    pub regexes: Option<BTreeMap<String, String>>,
+}
+
+/// Resolved options for the `object_name` rule.
+#[derive(Clone, Debug)]
+pub struct ResolvedObjectNameOptions {
+    patterns: Vec<ObjectNamePattern>,
+}
+
+#[derive(Clone, Debug)]
+struct ObjectNamePattern {
+    label: String,
+    regex: Regex,
+}
+
+impl ResolvedObjectNameOptions {
+    pub fn resolve(options: Option<&ObjectNameOptions>) -> anyhow::Result<Self> {
+        let custom_regexes = options.and_then(|options| options.regexes.as_ref());
+        let custom_only = custom_regexes.is_some_and(|regexes| !regexes.is_empty());
+
+        let styles = match options.and_then(|options| options.styles.as_ref()) {
+            Some(styles) => styles.clone(),
+            None if custom_only => Vec::new(),
+            None => DEFAULT_STYLES
+                .iter()
+                .map(|style| (*style).to_string())
+                .collect(),
+        };
+
+        let mut patterns = Vec::new();
+        for style in styles {
+            let Some(pattern) = builtin_pattern(&style) else {
+                return Err(anyhow::anyhow!(
+                    "Invalid style for `[lint.object_name]`: \"{style}\". Expected {STYLE_NAMES}."
+                ));
+            };
+            patterns.push(ObjectNamePattern {
+                label: style,
+                regex: Regex::new(pattern).expect("built-in object name pattern should compile"),
+            });
+        }
+
+        if let Some(regexes) = custom_regexes {
+            for (name, pattern) in regexes {
+                let regex = Regex::new(pattern).map_err(|error| {
+                    anyhow::anyhow!(
+                        "Invalid regular expression for `{name}` in `[lint.object_name]`: {error}"
+                    )
+                })?;
+                patterns.push(ObjectNamePattern { label: name.clone(), regex });
+            }
+        }
+
+        if patterns.is_empty() {
+            return Err(anyhow::anyhow!(
+                "At least one style or regular expression must be specified for `[lint.object_name]`."
+            ));
+        }
+
+        Ok(Self { patterns })
+    }
+
+    pub(crate) fn matches(&self, name: &str) -> bool {
+        self.patterns
+            .iter()
+            .any(|pattern| pattern.regex.is_match(name))
+    }
+
+    pub(crate) fn expected(&self) -> String {
+        self.patterns
+            .iter()
+            .map(|pattern| format!("`{}`", pattern.label))
+            .collect::<Vec<_>>()
+            .join(" or ")
+    }
+}
+
+fn builtin_pattern(style: &str) -> Option<&'static str> {
+    match style {
+        "symbols" => Some(r"^[^[:alnum:]]+$"),
+        "CamelCase" => Some(r"^[.]?[A-Z][A-Za-z0-9]*$"),
+        "camelCase" => Some(r"^[.]?[a-z][A-Za-z0-9]*$"),
+        "snake_case" => Some(r"^[.]?[a-z0-9][a-z0-9_]*$"),
+        "SNAKE_CASE" => Some(r"^[.]?[A-Z0-9][A-Z0-9_]*$"),
+        "dotted.case" => Some(r"^[.]?[a-z0-9]+(?:\.[a-z0-9]+)*$"),
+        "lowercase" => Some(r"^[.]?[a-z0-9]+$"),
+        "UPPERCASE" => Some(r"^[.]?[A-Z0-9]+$"),
+        _ => None,
+    }
+}

--- a/crates/jarl-core/src/lints/base/object_name/options.rs
+++ b/crates/jarl-core/src/lints/base/object_name/options.rs
@@ -1,28 +1,44 @@
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, HashSet};
 
 use regex::Regex;
 use serde::Deserialize;
 
+use crate::rule_options::resolve_with_extend;
+
 const DEFAULT_STYLES: &[&str] = &["snake_case", "symbols"];
+const DEFAULT_SPECIAL_NAMES: &[&str] = &[
+    ".onLoad",
+    ".onAttach",
+    ".onUnload",
+    ".onDetach",
+    ".Last.lib",
+    ".First",
+    ".Last",
+];
 const STYLE_NAMES: &str =
     "CamelCase, camelCase, snake_case, SNAKE_CASE, dotted.case, lowercase, UPPERCASE, or symbols";
 
 /// TOML options for `[lint.object_name]`.
 ///
 /// `styles` selects the built-in naming styles. `regexes` adds named regular
-/// expressions that can be used alongside the selected styles.
+/// expressions that can be used alongside the selected styles. `special-names`
+/// replaces the built-in names that are exempt from style checks, while
+/// `extend-special-names` adds to them.
 #[derive(Clone, Debug, PartialEq, Eq, Default, Deserialize)]
 #[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 #[serde(deny_unknown_fields, rename_all = "kebab-case")]
 pub struct ObjectNameOptions {
     pub styles: Option<Vec<String>>,
     pub regexes: Option<BTreeMap<String, String>>,
+    pub special_names: Option<Vec<String>>,
+    pub extend_special_names: Option<Vec<String>>,
 }
 
 /// Resolved options for the `object_name` rule.
 #[derive(Clone, Debug)]
 pub struct ResolvedObjectNameOptions {
     patterns: Vec<ObjectNamePattern>,
+    special_names: HashSet<String>,
 }
 
 #[derive(Clone, Debug)]
@@ -35,6 +51,21 @@ impl ResolvedObjectNameOptions {
     pub fn resolve(options: Option<&ObjectNameOptions>) -> anyhow::Result<Self> {
         let custom_regexes = options.and_then(|options| options.regexes.as_ref());
         let custom_only = custom_regexes.is_some_and(|regexes| !regexes.is_empty());
+        let (base_special_names, extend_special_names) = match options {
+            Some(options) => (
+                options.special_names.as_ref(),
+                options.extend_special_names.as_ref(),
+            ),
+            None => (None, None),
+        };
+
+        let special_names = resolve_with_extend(
+            base_special_names,
+            extend_special_names,
+            DEFAULT_SPECIAL_NAMES,
+            "object_name",
+            "special-names",
+        )?;
 
         let styles = match options.and_then(|options| options.styles.as_ref()) {
             Some(styles) => styles.clone(),
@@ -75,13 +106,17 @@ impl ResolvedObjectNameOptions {
             ));
         }
 
-        Ok(Self { patterns })
+        Ok(Self { patterns, special_names })
     }
 
     pub(crate) fn matches(&self, name: &str) -> bool {
         self.patterns
             .iter()
             .any(|pattern| pattern.regex.is_match(name))
+    }
+
+    pub(crate) fn is_special_name(&self, name: &str) -> bool {
+        self.special_names.contains(name)
     }
 
     pub(crate) fn expected(&self) -> String {

--- a/crates/jarl-core/src/rule_options.rs
+++ b/crates/jarl-core/src/rule_options.rs
@@ -96,6 +96,7 @@ declare_rule_options! {
     base::implicit_assignment => ResolvedImplicitAssignmentOptions,
     base::missing_argument => ResolvedMissingArgumentOptions,
     base::nested_pipe => ResolvedNestedPipeOptions,
+    base::object_name => ResolvedObjectNameOptions,
     base::pipe_consistency => ResolvedPipeConsistencyOptions,
     base::quotes => ResolvedQuotesOptions,
     base::true_false_symbol => ResolvedTrueFalseSymbolOptions,

--- a/crates/jarl-core/src/rule_set.rs
+++ b/crates/jarl-core/src/rule_set.rs
@@ -518,6 +518,13 @@ declare_rules! {
         fix: Unsafe,
         min_r_version: None,
     },
+    ObjectName => {
+        name: "object_name",
+        categories: [Read],
+        default: Disabled,
+        fix: None,
+        min_r_version: None,
+    },
     OuterNegation => {
         name: "outer_negation",
         categories: [Perf, Read],

--- a/crates/jarl-core/src/toml.rs
+++ b/crates/jarl-core/src/toml.rs
@@ -300,8 +300,9 @@ pub struct LinterTomlOptions {
 
     /// # Options for the `object_name` rule
     ///
-    /// Use `styles` to select built-in naming styles and `regexes` to add named
-    /// regular expressions.
+    /// Use `styles` to select built-in naming styles, `regexes` to add named
+    /// regular expressions, and `special-names` / `extend-special-names` to
+    /// configure names that are exempt from style checks.
     #[serde(rename = "object_name")]
     pub object_name: Option<ObjectNameOptions>,
 

--- a/crates/jarl-core/src/toml.rs
+++ b/crates/jarl-core/src/toml.rs
@@ -21,6 +21,7 @@ use crate::lints::base::if_not_else::options::IfNotElseOptions;
 use crate::lints::base::implicit_assignment::options::ImplicitAssignmentOptions;
 use crate::lints::base::missing_argument::options::MissingArgumentOptions;
 use crate::lints::base::nested_pipe::options::NestedPipeOptions;
+use crate::lints::base::object_name::options::ObjectNameOptions;
 use crate::lints::base::pipe_consistency::options::PipeConsistencyOptions;
 use crate::lints::base::quotes::options::QuotesOptions;
 use crate::lints::base::true_false_symbol::options::TrueFalseSymbolOptions;
@@ -296,6 +297,13 @@ pub struct LinterTomlOptions {
     /// Specifying both is an error.
     #[serde(rename = "nested_pipe")]
     pub nested_pipe: Option<NestedPipeOptions>,
+
+    /// # Options for the `object_name` rule
+    ///
+    /// Use `styles` to select built-in naming styles and `regexes` to add named
+    /// regular expressions.
+    #[serde(rename = "object_name")]
+    pub object_name: Option<ObjectNameOptions>,
 
     /// # Options for the `pipe_consistency` rule
     ///

--- a/crates/jarl-core/src/utils_test.rs
+++ b/crates/jarl-core/src/utils_test.rs
@@ -169,6 +169,16 @@ pub fn check_code(text: &str, rule: &str, min_r_version: Option<&str>) -> Vec<Di
     run_check(text, rule, min_r_version, None, None)
 }
 
+/// Check code with custom settings and return its diagnostics.
+pub fn check_code_with_settings(
+    text: &str,
+    rule: &str,
+    min_r_version: Option<&str>,
+    settings: Option<Settings>,
+) -> Vec<Diagnostic> {
+    run_check(text, rule, min_r_version, settings, None)
+}
+
 /// Convenience function to assert that code has no lint
 pub fn expect_no_lint(text: &str, rule: &str, min_r_version: Option<&str>) {
     let diagnostics = run_check(text, rule, min_r_version, None, None);

--- a/crates/jarl/tests/integration/toml_rule_args.rs
+++ b/crates/jarl/tests/integration/toml_rule_args.rs
@@ -513,6 +513,136 @@ unknown-option = ["try"]
     Ok(())
 }
 
+// object_name ----------------------------------------
+
+#[test]
+fn test_object_name_unknown_field_is_error() -> anyhow::Result<()> {
+    let case = CliTest::with_files([
+        (
+            "jarl.toml",
+            r#"
+[lint.object_name]
+unknown-option = ["snake_case"]
+"#,
+        ),
+        ("test.R", "badName <- 1"),
+    ])?;
+
+    insta::assert_snapshot!(
+        &mut case
+            .command()
+            .arg("check")
+            .arg(".")
+            .run()
+            .normalize_os_executable_name()
+            .normalize_temp_paths(),
+        @r#"
+
+    success: false
+    exit_code: 255
+    ----- stdout -----
+
+    ----- stderr -----
+    jarl failed
+      Cause: Failed to parse [TEMP_DIR]/jarl.toml:
+    TOML parse error at line 3, column 1
+      |
+    3 | unknown-option = ["snake_case"]
+      | ^^^^^^^^^^^^^^
+    unknown field `unknown-option`, expected `styles` or `regexes`
+    "#
+    );
+
+    Ok(())
+}
+
+#[test]
+fn test_object_name_invalid_style_is_error() -> anyhow::Result<()> {
+    let case = CliTest::with_files([
+        (
+            "jarl.toml",
+            r#"
+[lint]
+select = ["object_name"]
+
+[lint.object_name]
+styles = ["not_a_style"]
+"#,
+        ),
+        ("test.R", "badName <- 1"),
+    ])?;
+
+    insta::assert_snapshot!(
+        &mut case
+            .command()
+            .arg("check")
+            .arg(".")
+            .run()
+            .normalize_os_executable_name()
+            .normalize_temp_paths(),
+        @r#"
+
+    success: false
+    exit_code: 255
+    ----- stdout -----
+
+    ----- stderr -----
+    jarl failed
+      Cause: Invalid configuration in [TEMP_DIR]/jarl.toml:
+    Invalid style for `[lint.object_name]`: "not_a_style". Expected CamelCase, camelCase, snake_case, SNAKE_CASE, dotted.case, lowercase, UPPERCASE, or symbols.
+    "#
+    );
+
+    Ok(())
+}
+
+#[test]
+fn test_object_name_options_change_reported_names() -> anyhow::Result<()> {
+    let case = CliTest::with_files([
+        (
+            "jarl.toml",
+            r#"
+[lint]
+select = ["object_name"]
+
+[lint.object_name]
+styles = ["CamelCase"]
+"#,
+        ),
+        ("test.R", "GoodName <- 1\nbadName <- 1"),
+    ])?;
+
+    insta::assert_snapshot!(
+        &mut case
+            .command()
+            .arg("check")
+            .arg(".")
+            .run()
+            .normalize_os_executable_name()
+            .normalize_temp_paths(),
+        @r#"
+
+    success: false
+    exit_code: 1
+    ----- stdout -----
+    warning: object_name
+     --> test.R:2:1
+      |
+    2 | badName <- 1
+      | ------- Variable and function name style should match `CamelCase`.
+      |
+
+
+    ── Summary ──────────────────────────────────────
+    Found 1 error.
+
+    ----- stderr -----
+    "#
+    );
+
+    Ok(())
+}
+
 // pipe_consistency ----------------------------------------
 
 #[test]

--- a/crates/jarl/tests/integration/toml_rule_args.rs
+++ b/crates/jarl/tests/integration/toml_rule_args.rs
@@ -549,7 +549,7 @@ unknown-option = ["snake_case"]
       |
     3 | unknown-option = ["snake_case"]
       | ^^^^^^^^^^^^^^
-    unknown field `unknown-option`, expected `styles` or `regexes`
+    unknown field `unknown-option`, expected one of `styles`, `regexes`, `special-names`, `extend-special-names`
     "#
     );
 
@@ -630,6 +630,56 @@ styles = ["CamelCase"]
       |
     2 | badName <- 1
       | ------- Variable and function name style should match `CamelCase`.
+      |
+
+
+    ── Summary ──────────────────────────────────────
+    Found 1 error.
+
+    ----- stderr -----
+    "#
+    );
+
+    Ok(())
+}
+
+#[test]
+fn test_object_name_special_names_can_be_extended() -> anyhow::Result<()> {
+    let case = CliTest::with_files([
+        (
+            "jarl.toml",
+            r#"
+[lint]
+select = ["object_name"]
+
+[lint.object_name]
+extend-special-names = ["mySpecial"]
+"#,
+        ),
+        (
+            "test.R",
+            ".onLoad <- function(...) TRUE\nmySpecial <- 1\nbadName <- 1",
+        ),
+    ])?;
+
+    insta::assert_snapshot!(
+        &mut case
+            .command()
+            .arg("check")
+            .arg(".")
+            .run()
+            .normalize_os_executable_name()
+            .normalize_temp_paths(),
+        @r#"
+
+    success: false
+    exit_code: 1
+    ----- stdout -----
+    warning: object_name
+     --> test.R:3:1
+      |
+    3 | badName <- 1
+      | ------- Variable and function name style should match `snake_case` or `symbols`.
       |
 
 

--- a/docs/_quarto.yml
+++ b/docs/_quarto.yml
@@ -139,6 +139,7 @@ website:
       - rules/notin.md
       - rules/numeric_leading_zero.md
       - rules/nzchar.md
+      - rules/object_name.md
       - rules/outdated_suppression.md
       - rules/outer_negation.md
       - rules/pipe_consistency.md

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -22,6 +22,7 @@
   * `missing_argument` (#506)
   * `nested_pipe` (#516)
   * `notin` (#459, @Yousa-Mirage)
+  * `object_name` (#8)
   * `pipe_consistency` (#482)
   * `pipe_return` (#502)
   * `rep_times_ignored` (#556, @Yousa-Mirage)

--- a/docs/reference/config-file.md
+++ b/docs/reference/config-file.md
@@ -416,12 +416,18 @@ Available built-in styles are `CamelCase`, `camelCase`, `snake_case`,
 `SNAKE_CASE`, `dotted.case`, `lowercase`, `UPPERCASE`, and `symbols`.
 Any combination of default styles can be included.
 
+The special names `.onLoad`, `.onAttach`, `.onUnload`, `.onDetach`, `.Last.lib`,
+`.First`, and `.Last` are exempt from style checks by default. Use
+`extend-special-names` to add names to this set, or `special-names` to replace
+it entirely. Do not specify both options.
+
 ```toml
 [lint]
 ...
 
 [lint.object_name]
 styles = ["snake_case", "symbols"]
+extend-special-names = ["my_special_hook"]
 ```
 
 Additional acceptable names can be added via `regexes` when `styles` is set:

--- a/docs/reference/config-file.md
+++ b/docs/reference/config-file.md
@@ -404,6 +404,36 @@ Default: `skipped-functions = [
 skipped-functions = ["my_function"]
 ```
 
+### `object_name`
+
+This rule checks the names of variables and arguments used in assignments
+and function definitions.
+For `$` and `@` assignments, it checks only the base object name.
+The rule is disabled by default.
+
+The default styles are `snake_case` and `symbols`.
+Available built-in styles are `CamelCase`, `camelCase`, `snake_case`,
+`SNAKE_CASE`, `dotted.case`, `lowercase`, `UPPERCASE`, and `symbols`.
+Any combination of default styles can be included.
+
+```toml
+[lint]
+...
+
+[lint.object_name]
+styles = ["snake_case", "symbols"]
+```
+
+Additional acceptable names can be added via `regexes` when `styles` is set:
+
+```toml
+[lint.object_name.regexes]
+prefixed = "^x_[a-z]+$"
+```
+
+If `styles` is omitted while `regexes` is supplied, the regular expressions are
+used to define the accepted styles.
+
 ### `pipe_consistency`
 
 This takes a single value (`"|>"` or `"%>%"`) indicating the preferred

--- a/docs/rules.qmd
+++ b/docs/rules.qmd
@@ -106,6 +106,7 @@ dat <- as.data.frame(
     c("notin", "readability", "✅", "R >= 4.6"),
     c("numeric_leading_zero", "readability", "✅", ""),
     c("nzchar", "performance", "❗", "Disabled by default"),
+    c("object_name", "readability", "❌", "Disabled by default"),
     c("outdated_suppression", "comments", "✅", ""),
     c("outer_negation", "performance, readability", "✅", ""),
     c(

--- a/docs/rules/object_name.md
+++ b/docs/rules/object_name.md
@@ -47,6 +47,20 @@ Built-in styles are `CamelCase`, `camelCase`, `snake_case`, `SNAKE_CASE`,
 `dotted.case`, `lowercase`, `UPPERCASE`, and `symbols`.
 Any combination of default styles can be included.
 
+The following special names are exempt from style checks by default:
+`.onLoad`, `.onAttach`, `.onUnload`, `.onDetach`, `.Last.lib`, `.First`, and
+`.Last`.
+Use `extend-special-names` to add project-specific special names while keeping
+the defaults:
+
+```toml
+[lint.object_name]
+extend-special-names = ["my_special_hook"]
+```
+
+Use `special-names` to replace the default set entirely. Do not specify both
+`special-names` and `extend-special-names`.
+
 Additional acceptable names can be added via `regexes` when `styles` is set:
 
 ```toml

--- a/docs/rules/object_name.md
+++ b/docs/rules/object_name.md
@@ -4,13 +4,17 @@
 
 ## What it does
 
-This rule checks the names of variables and arguments introduced by assignments
+This rule checks the names of variables and arguments used in assignments
 and function definitions.
 For `$` and `@` assignments, it checks only the base object name.
 
 This rule is disabled by default.
 
 The default styles are `snake_case` and `symbols`:
+
+## Why is this bad?
+
+Consistent names make code easier to read and maintain.
 
 ## Example
 

--- a/docs/rules/object_name.md
+++ b/docs/rules/object_name.md
@@ -1,0 +1,54 @@
+# object_name
+::: {.callout-note title="Added in 0.6.0" .low-opacity}
+:::
+
+## What it does
+
+This rule checks the names of variables and arguments introduced by assignments
+and function definitions.
+For `$` and `@` assignments, it checks only the base object name.
+
+This rule is disabled by default.
+
+The default styles are `snake_case` and `symbols`:
+
+## Example
+
+```r
+badName <- 1
+f <- function(badArg) {
+  badArg
+}
+badName$member <- 1
+```
+
+Use instead:
+
+```r
+bad_name <- 1
+f <- function(bad_arg) {
+  bad_arg
+}
+bad_name$member <- 1
+```
+
+## Configuration
+
+```toml
+[lint.object_name]
+styles = ["snake_case", "symbols"]
+```
+
+Built-in styles are `CamelCase`, `camelCase`, `snake_case`, `SNAKE_CASE`,
+`dotted.case`, `lowercase`, `UPPERCASE`, and `symbols`.
+Any combination of default styles can be included.
+
+Additional acceptable names can be added via `regexes` when `styles` is set:
+
+```toml
+[lint.object_name.regexes]
+prefixed = "^x_[a-z]+$"
+```
+
+If `styles` is omitted while `regexes` is supplied, the regular expressions are
+used to define the accepted styles.


### PR DESCRIPTION
Another component of #8.

This provides features for assignment-based variable naming conventions. It offers several base cases, similar to other linters, and then also allows users to provide regex for acceptable names.