### PR TITLE
fix: Stop `lengths` rule from panicking on `sapply(FUN = length)`

### DIFF
--- a/crates/jarl-core/src/lints/base/lengths/lengths.rs
+++ b/crates/jarl-core/src/lints/base/lengths/lengths.rs
@@ -77,13 +77,14 @@ pub fn lengths(ast: &RCall, fn_name: &str) -> anyhow::Result<Option<Diagnostic>>
             .text_trimmed()
             == "length"
     {
+        let arg_x = unwrap_or_return_none!(arg_x.and_then(|arg| arg.value()));
         let range = ast.syntax().text_trimmed_range();
         let diagnostic = Diagnostic::new(
             Lengths,
             range,
             Fix::new(
                 range,
-                format!("lengths({})", arg_x.unwrap().into_syntax().text_trimmed()),
+                format!("lengths({})", arg_x.into_syntax().text_trimmed()),
                 node_contains_comments(ast.syntax()),
             ),
         );

--- a/crates/jarl-core/src/lints/base/lengths/mod.rs
+++ b/crates/jarl-core/src/lints/base/lengths/mod.rs
@@ -75,6 +75,7 @@ mod tests {
                 vec![
                     "sapply(x, length)",
                     "sapply(x, FUN = length)",
+                    "sapply(X = x, FUN = length)",
                     "vapply(mtcars, length, integer(1))",
                 ],
                 "lengths",
@@ -91,6 +92,15 @@ mod tests {
         expect_no_lint("sapply(x, sqrt, simplify = length(x))", "lengths", None);
         expect_no_lint("lapply(x, length)", "lengths", None);
         expect_no_lint("map(x, length)", "lengths", None);
+        expect_no_lint("sapply(FUN = length)", "lengths", None);
+        expect_no_lint(
+            "vapply(FUN = length, FUN.VALUE = integer(1))",
+            "lengths",
+            None,
+        );
+        expect_no_lint("map_dbl(.f = length)", "lengths", None);
+        expect_no_lint("x |> sapply(FUN = length)", "lengths", None);
+        expect_no_lint("sapply(, length)", "lengths", None);
     }
 
     #[test]

--- a/crates/jarl-core/src/lints/base/lengths/snapshots/jarl_core__lints__base__lengths__tests__fix_output.snap
+++ b/crates/jarl-core/src/lints/base/lengths/snapshots/jarl_core__lints__base__lengths__tests__fix_output.snap
@@ -1,6 +1,6 @@
 ---
 source: crates/jarl-core/src/lints/base/lengths/mod.rs
-expression: "get_fixed_text(vec![\"sapply(x, length)\", \"sapply(x, FUN = length)\",\n\"vapply(mtcars, length, integer(1))\",], \"lengths\", None)"
+expression: "get_fixed_text(vec![\"sapply(x, length)\", \"sapply(x, FUN = length)\",\n\"sapply(X = x, FUN = length)\", \"vapply(mtcars, length, integer(1))\",],\n\"lengths\", None)"
 ---
 OLD:
 ====
@@ -12,6 +12,13 @@ lengths(x)
 OLD:
 ====
 sapply(x, FUN = length)
+NEW:
+====
+lengths(x)
+
+OLD:
+====
+sapply(X = x, FUN = length)
 NEW:
 ====
 lengths(x)

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -7,6 +7,13 @@
 * The `jarl.toml` argument `assignment` (deprecated since 0.5.0) is removed. Use
   the rule-specific option `[lint.assignment]` instead (#663).
 
+### Bug fixes
+
+* The `lengths` rule no longer crashes on calls where `X` is missing from the
+  syntax tree, e.g. `sapply(FUN = length)` or `x |> sapply(FUN = length)`. The
+  autofix now also produces `lengths(x)` instead of the invalid
+  `lengths(X = x)` when `X` is passed by name.
+
 ## 0.6.0
 
 ::: {.callout-note icon=false title="Released on 2026-08-24" .low-opacity}

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -12,7 +12,7 @@
 * The `lengths` rule no longer crashes on calls where `X` is missing from the
   syntax tree, e.g. `sapply(FUN = length)` or `x |> sapply(FUN = length)`. The
   autofix now also produces `lengths(x)` instead of the invalid
-  `lengths(X = x)` when `X` is passed by name.
+  `lengths(X = x)` when `X` is passed by name (#671, @Yousa-Mirage).
 
 ## 0.6.0
 


### PR DESCRIPTION
## Reproduce

A `test.R` like this:

``` r
x <- list(a = 1:2, b = 4:6)
x |> sapply(FUN = length)
#> a b 
#> 2 3

# The same as `x |> purrr::map_dbl(.f = length)`
```

will cause panic:

```bash
$jarl check test.R

thread 'main' (114726) panicked at crates/jarl-core/src/lints/base/lengths/lengths.rs:86:46:
called `Option::unwrap()` on a `None` value
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```

And the auto-fix on this `test.R`:

``` r
x <- list(a = 1:2, b = 4:6)

sapply(X = x, FUN = length)
#> a b 
#> 2 3
sapply(, length)
#> Error in `sapply()`:
#> ! argument "X" is missing, with no default
```

result this below:

``` r
x <- list(a = 1:2, b = 4:6)

lengths(X = x)  # ! unused argument (X = x)
lengths()  # Shouldn't be fixed
```

## Change

Use `let arg_x = unwrap_or_return_none!(arg_x.and_then(|arg| arg.value()));` instead of `arg_x.unwrap()`.

Now `x |> sapply(FUN = length)` will not panic. And the auto-fix will result this:

``` r
x <- list(a = 1:2, b = 4:6)

lengths(x)  # ✅
sapply(, length)  # No change because of another error
```