### PR TITLE
fix: Ensure `--fix` works with multibyte characters

### DIFF
--- a/crates/jarl-core/src/fix.rs
+++ b/crates/jarl-core/src/fix.rs
@@ -20,9 +20,6 @@ pub fn apply_fixes(fixes: &[Diagnostic], contents: &str) -> String {
     // length.
     let mut last_original_end: usize = 0;
 
-    // fix.start()/end() are byte offsets into the source, so the shift applied
-    // to later fixes must be a byte delta; a char-count delta misplaces them as
-    // soon as an earlier fix touches multi-byte characters.
     let old_length = old_content.len() as i32;
     let mut new_length = old_length;
 
@@ -42,43 +39,4 @@ pub fn apply_fixes(fixes: &[Diagnostic], contents: &str) -> String {
     }
 
     new_content
-}
-
-#[cfg(test)]
-mod tests {
-    use super::apply_fixes;
-    use crate::diagnostic::{Diagnostic, Fix, ViolationData};
-    use crate::rule_set::Rule;
-    use biome_rowan::{TextRange, TextSize};
-
-    fn fix_at(start: usize, end: usize, content: &str) -> Diagnostic {
-        let range = TextRange::new(TextSize::from(start as u32), TextSize::from(end as u32));
-        Diagnostic::new(
-            ViolationData::new(Rule::AnyIsNa, "test violation".to_string(), None),
-            range,
-            Fix::new(range, content.to_string(), false),
-        )
-    }
-
-    #[test]
-    fn later_fix_shifted_correctly_when_earlier_fix_drops_multibyte_text() {
-        let content = "分数[order(分数)]\nany(is.na(\"数据\"))\n";
-        let fixes = [
-            fix_at(0, 21, "sort(分数)"),
-            fix_at(22, 42, "anyNA(\"数据\")"),
-        ];
-
-        assert_eq!(
-            apply_fixes(&fixes, content),
-            "sort(分数)\nanyNA(\"数据\")\n"
-        );
-    }
-
-    #[test]
-    fn removing_multibyte_comment_line_keeps_later_fix_aligned() {
-        let content = "# jarl-ignore seq: 原因一\nx <- 1\nany(is.na(y))\n";
-        let fixes = [fix_at(0, 29, ""), fix_at(36, 49, "anyNA(y)")];
-
-        assert_eq!(apply_fixes(&fixes, content), "x <- 1\nanyNA(y)\n");
-    }
 }

--- a/crates/jarl-core/src/fix.rs
+++ b/crates/jarl-core/src/fix.rs
@@ -20,7 +20,10 @@ pub fn apply_fixes(fixes: &[Diagnostic], contents: &str) -> String {
     // length.
     let mut last_original_end: usize = 0;
 
-    let old_length = old_content.chars().count() as i32;
+    // fix.start()/end() are byte offsets into the source, so the shift applied
+    // to later fixes must be a byte delta; a char-count delta misplaces them as
+    // soon as an earlier fix touches multi-byte characters.
+    let old_length = old_content.len() as i32;
     let mut new_length = old_length;
 
     for fix in fixes {
@@ -34,9 +37,48 @@ pub fn apply_fixes(fixes: &[Diagnostic], contents: &str) -> String {
         let end = (fix.end() as i32 + diff_length) as usize;
 
         new_content.replace_range(start..end, &fix.content);
-        new_length = new_content.chars().count() as i32;
+        new_length = new_content.len() as i32;
         last_original_end = fix.end();
     }
 
     new_content
+}
+
+#[cfg(test)]
+mod tests {
+    use super::apply_fixes;
+    use crate::diagnostic::{Diagnostic, Fix, ViolationData};
+    use crate::rule_set::Rule;
+    use biome_rowan::{TextRange, TextSize};
+
+    fn fix_at(start: usize, end: usize, content: &str) -> Diagnostic {
+        let range = TextRange::new(TextSize::from(start as u32), TextSize::from(end as u32));
+        Diagnostic::new(
+            ViolationData::new(Rule::AnyIsNa, "test violation".to_string(), None),
+            range,
+            Fix::new(range, content.to_string(), false),
+        )
+    }
+
+    #[test]
+    fn later_fix_shifted_correctly_when_earlier_fix_drops_multibyte_text() {
+        let content = "分数[order(分数)]\nany(is.na(\"数据\"))\n";
+        let fixes = [
+            fix_at(0, 21, "sort(分数)"),
+            fix_at(22, 42, "anyNA(\"数据\")"),
+        ];
+
+        assert_eq!(
+            apply_fixes(&fixes, content),
+            "sort(分数)\nanyNA(\"数据\")\n"
+        );
+    }
+
+    #[test]
+    fn removing_multibyte_comment_line_keeps_later_fix_aligned() {
+        let content = "# jarl-ignore seq: 原因一\nx <- 1\nany(is.na(y))\n";
+        let fixes = [fix_at(0, 29, ""), fix_at(36, 49, "anyNA(y)")];
+
+        assert_eq!(apply_fixes(&fixes, content), "x <- 1\nanyNA(y)\n");
+    }
 }

--- a/crates/jarl/tests/integration/edge_cases.rs
+++ b/crates/jarl/tests/integration/edge_cases.rs
@@ -148,6 +148,7 @@ fn test_jarl_with_tabs() -> anyhow::Result<()> {
     Ok(())
 }
 
+// https://github.com/etiennebacher/jarl/pull/672
 #[test]
 fn test_multibyte_fix_offsets() -> anyhow::Result<()> {
     // The suppression fixes remove complete comment lines containing

--- a/crates/jarl/tests/integration/edge_cases.rs
+++ b/crates/jarl/tests/integration/edge_cases.rs
@@ -147,3 +147,37 @@ fn test_jarl_with_tabs() -> anyhow::Result<()> {
 
     Ok(())
 }
+
+#[test]
+fn test_multibyte_fix_offsets() -> anyhow::Result<()> {
+    // The suppression fixes remove complete comment lines containing
+    // multi-byte characters, while the later fixes must still use their
+    // original byte offsets correctly.
+    let case = CliTest::with_file(
+        "test.R",
+        r#"# jarl-ignore seq: 原因一
+x <- 1
+# jarl-ignore browser: 原因二
+y <- 2
+
+排序 <- 分数[order(分数)]
+any(is.na("数据"))
+"#,
+    )?;
+
+    let output = case
+        .command()
+        .arg("check")
+        .arg(".")
+        .arg("--fix")
+        .arg("--allow-no-vcs")
+        .run();
+
+    assert!(output.status.success(), "jarl failed:\n{output}");
+    assert_eq!(
+        case.read_file("test.R")?,
+        "x <- 1\ny <- 2\n\n排序 <- sort(分数)\nanyNA(\"数据\")\n"
+    );
+
+    Ok(())
+}

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -7,6 +7,10 @@
 * The `jarl.toml` argument `assignment` (deprecated since 0.5.0) is removed. Use
   the rule-specific option `[lint.assignment]` instead (#663).
 
+### Bug fixes
+
+* Fix `--fix` corrupting files containing multi-byte characters (#672, @Yousa-Mirage).
+
 ## 0.6.0
 
 ::: {.callout-note icon=false title="Released on 2026-08-24" .low-opacity}

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -9,7 +9,7 @@
 
 ### Bug fixes
 
-* Fix `--fix` corrupting files containing multi-byte characters (#672, @Yousa-Mirage).
+* Ensure that `--fix` works with multi-byte characters (#672, @Yousa-Mirage).
 
 ## 0.6.0
 


### PR DESCRIPTION
Before:

```r
# jarl-ignore seq: 原因一
x <- 1
# jarl-ignore browser: 原因二
y <- 2
```

After `--fix`:

```r
x <- 1
# jarl
```

Before:

```r
排序 <- 分数[order(分数)]
any(is.na("数据"))
```

`--fix` panicked:

```bash
$jarl check test.R --fix

thread 'main' (229944) panicked at /rustc/88d9e12ae178fab0fb5cc050a94da85685d449ea/library/core/src/slice/index.rs:1009:51:
range end index 47 out of range for slice of length 44
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```

Change the content length difference before and after repair to be calculated based on UTF-8 bytes, and update the subsequent repair interval with byte displacement to avoid multi-byte characters (like Chinese) causing misalignment, data corruption or panic.

By the way, I'm not sure where to put these tests🥲.