### PR TITLE
fix: Prevent nested-call fixes from dropping extra unnamed arguments

### DIFF
--- a/crates/jarl-core/src/lints/base/any_duplicated/mod.rs
+++ b/crates/jarl-core/src/lints/base/any_duplicated/mod.rs
@@ -12,6 +12,7 @@ mod tests {
     #[test]
     fn test_no_lint_any_duplicated() {
         expect_no_lint("any(x)", "any_duplicated", None);
+        expect_no_lint("any(duplicated(x), duplicated(y))", "any_duplicated", None);
         expect_no_lint("duplicated(x)", "any_duplicated", None);
         expect_no_lint("any(!duplicated(x))", "any_duplicated", None);
         expect_no_lint("any(!duplicated(foo(x)))", "any_duplicated", None);

--- a/crates/jarl-core/src/lints/base/any_is_na/mod.rs
+++ b/crates/jarl-core/src/lints/base/any_is_na/mod.rs
@@ -12,6 +12,7 @@ mod tests {
     #[test]
     fn test_no_lint_any_na() {
         expect_no_lint("any(x)", "any_is_na", None);
+        expect_no_lint("any(is.na(x), is.na(y))", "any_is_na", None);
         expect_no_lint("is.na(x)", "any_is_na", None);
         expect_no_lint("any(!is.na(x))", "any_is_na", None);
         expect_no_lint("any(!is.na(foo(x)))", "any_is_na", None);

--- a/crates/jarl-core/src/lints/base/condition_message/condition_message.rs
+++ b/crates/jarl-core/src/lints/base/condition_message/condition_message.rs
@@ -33,41 +33,31 @@ pub fn condition_message(ast: &RCall, fn_name: &str) -> anyhow::Result<Option<Di
         return Ok(None);
     }
 
-    let (inner_content, outer_syntax, is_direct_nested) =
-        if let Some(inner_content) = get_direct_nested_paste0_content(ast)? {
-            (inner_content, ast.syntax().clone(), true)
+    // When `paste0()` is a direct argument of the call, the other arguments must
+    // be kept in the fix, so remember which argument holds it.
+    let (inner_content, outer_syntax, paste_arg_index) =
+        if let Some((inner_content, index)) = get_direct_nested_paste0_content(ast)? {
+            (inner_content, ast.syntax().clone(), Some(index))
         } else {
             let (inner_content, outer_syntax) = unwrap_or_return_none!(
                 get_nested_functions_content(ast, fn_name, fn_name, "paste0")?
             );
-            (inner_content, outer_syntax, false)
+            (inner_content, outer_syntax, None)
         };
 
     // `stop()` doesn't have equivalents for recycle0 or collapse args, so bail
     // early
-    if let Some(paste_call) = outer_syntax
-        .descendants()
-        .filter_map(RCall::cast)
-        .find(|call| call.function().ok().map(get_function_name).as_deref() == Some("paste0"))
-    {
-        let paste_args = paste_call.arguments()?.items();
-        if get_arg_by_name(&paste_args, "collapse").is_some()
-            || get_arg_by_name(&paste_args, "recycle0").is_some()
-        {
-            return Ok(None);
-        }
+    if paste0_has_unsupported_args(&outer_syntax)? {
+        return Ok(None);
     }
 
-    let mut skipped_nested = false;
-    let extra_args = ast.arguments()?.items().into_iter().filter_map(|arg| {
-        let arg = arg.ok()?;
-        if is_direct_nested && !skipped_nested && arg.name_clause().is_none() {
-            skipped_nested = true;
-            None
-        } else {
-            Some(arg.to_trimmed_string())
-        }
-    });
+    let extra_args = ast
+        .arguments()?
+        .items()
+        .into_iter()
+        .enumerate()
+        .filter(|(index, _)| Some(*index) != paste_arg_index)
+        .filter_map(|(_, arg)| Some(arg.ok()?.to_trimmed_string()));
     let new_content = std::iter::once(inner_content)
         .chain(extra_args)
         .collect::<Vec<_>>()
@@ -89,13 +79,16 @@ pub fn condition_message(ast: &RCall, fn_name: &str) -> anyhow::Result<Option<Di
     )))
 }
 
-fn get_direct_nested_paste0_content(call: &RCall) -> anyhow::Result<Option<String>> {
+/// Returns the content of a `paste0()` call used as a direct argument, along
+/// with the index of the argument holding it.
+fn get_direct_nested_paste0_content(call: &RCall) -> anyhow::Result<Option<(String, usize)>> {
     let argument = call
         .arguments()?
         .items()
         .into_iter()
-        .find(|arg| arg.as_ref().is_ok_and(|arg| arg.name_clause().is_none()));
-    let argument = unwrap_or_return_none!(argument);
+        .enumerate()
+        .find(|(_, arg)| arg.as_ref().is_ok_and(|arg| arg.name_clause().is_none()));
+    let (index, argument) = unwrap_or_return_none!(argument);
     let inner = unwrap_or_return_none!(argument?.value());
     let inner_call = unwrap_or_return_none!(inner.as_r_call());
 
@@ -104,5 +97,20 @@ fn get_direct_nested_paste0_content(call: &RCall) -> anyhow::Result<Option<Strin
     }
 
     let inner_content = inner_call.arguments()?.items().into_syntax().to_string();
-    Ok(Some(inner_content))
+    Ok(Some((inner_content, index)))
+}
+
+/// Whether the `paste0()` call in `node` uses arguments that `stop()` and
+/// `warning()` have no equivalent for.
+fn paste0_has_unsupported_args(node: &RSyntaxNode) -> anyhow::Result<bool> {
+    let paste_call = node
+        .descendants()
+        .filter_map(RCall::cast)
+        .find(|call| call.function().ok().map(get_function_name).as_deref() == Some("paste0"));
+    let Some(paste_call) = paste_call else {
+        return Ok(false);
+    };
+    let paste_args = paste_call.arguments()?.items();
+    Ok(get_arg_by_name(&paste_args, "collapse").is_some()
+        || get_arg_by_name(&paste_args, "recycle0").is_some())
 }

--- a/crates/jarl-core/src/lints/base/condition_message/condition_message.rs
+++ b/crates/jarl-core/src/lints/base/condition_message/condition_message.rs
@@ -34,8 +34,8 @@ pub fn condition_message(ast: &RCall, fn_name: &str) -> anyhow::Result<Option<Di
     }
 
     let (inner_content, outer_syntax, is_direct_nested) =
-        if let Some((inner_content, outer_syntax)) = get_direct_nested_paste0_content(ast)? {
-            (inner_content, outer_syntax, true)
+        if let Some(inner_content) = get_direct_nested_paste0_content(ast)? {
+            (inner_content, ast.syntax().clone(), true)
         } else {
             let (inner_content, outer_syntax) = unwrap_or_return_none!(
                 get_nested_functions_content(ast, fn_name, fn_name, "paste0")?
@@ -89,7 +89,7 @@ pub fn condition_message(ast: &RCall, fn_name: &str) -> anyhow::Result<Option<Di
     )))
 }
 
-fn get_direct_nested_paste0_content(call: &RCall) -> anyhow::Result<Option<(String, RSyntaxNode)>> {
+fn get_direct_nested_paste0_content(call: &RCall) -> anyhow::Result<Option<String>> {
     let argument = call
         .arguments()?
         .items()
@@ -105,15 +105,10 @@ fn get_direct_nested_paste0_content(call: &RCall) -> anyhow::Result<Option<(Stri
     let Some(inner_call) = inner.as_r_call() else {
         return Ok(None);
     };
-    if get_function_name(inner_call.as_fields().function?) != "paste0" {
+    if get_function_name(inner_call.function()?) != "paste0" {
         return Ok(None);
     }
 
-    let inner_content = inner_call
-        .as_fields()
-        .arguments?
-        .items()
-        .into_syntax()
-        .to_string();
-    Ok(Some((inner_content, call.syntax().clone())))
+    let inner_content = inner_call.arguments()?.items().into_syntax().to_string();
+    Ok(Some(inner_content))
 }

--- a/crates/jarl-core/src/lints/base/condition_message/condition_message.rs
+++ b/crates/jarl-core/src/lints/base/condition_message/condition_message.rs
@@ -95,16 +95,10 @@ fn get_direct_nested_paste0_content(call: &RCall) -> anyhow::Result<Option<Strin
         .items()
         .into_iter()
         .find(|arg| arg.as_ref().is_ok_and(|arg| arg.name_clause().is_none()));
-    let Some(argument) = argument else {
-        return Ok(None);
-    };
+    let argument = unwrap_or_return_none!(argument);
+    let inner = unwrap_or_return_none!(argument?.value());
+    let inner_call = unwrap_or_return_none!(inner.as_r_call());
 
-    let Some(inner) = argument?.value() else {
-        return Ok(None);
-    };
-    let Some(inner_call) = inner.as_r_call() else {
-        return Ok(None);
-    };
     if get_function_name(inner_call.function()?) != "paste0" {
         return Ok(None);
     }

--- a/crates/jarl-core/src/lints/base/condition_message/condition_message.rs
+++ b/crates/jarl-core/src/lints/base/condition_message/condition_message.rs
@@ -33,9 +33,15 @@ pub fn condition_message(ast: &RCall, fn_name: &str) -> anyhow::Result<Option<Di
         return Ok(None);
     }
 
-    let (inner_content, outer_syntax) = unwrap_or_return_none!(get_nested_functions_content(
-        ast, fn_name, fn_name, "paste0"
-    )?);
+    let (inner_content, outer_syntax, is_direct_nested) =
+        if let Some((inner_content, outer_syntax)) = get_direct_nested_paste0_content(ast)? {
+            (inner_content, outer_syntax, true)
+        } else {
+            let (inner_content, outer_syntax) = unwrap_or_return_none!(
+                get_nested_functions_content(ast, fn_name, fn_name, "paste0")?
+            );
+            (inner_content, outer_syntax, false)
+        };
 
     // `stop()` doesn't have equivalents for recycle0 or collapse args, so bail
     // early
@@ -52,18 +58,16 @@ pub fn condition_message(ast: &RCall, fn_name: &str) -> anyhow::Result<Option<Di
         }
     }
 
-    let args = ast.arguments()?.items();
-    let call_arg = get_arg_by_name(&args, "call.");
-    let domain_arg = get_arg_by_name(&args, "domain");
-
-    // In warning() only
-    let immediate_arg = get_arg_by_name(&args, "immediate.");
-    let nobreaks_arg = get_arg_by_name(&args, "noBreaks.");
-
-    let extra_args = [call_arg, domain_arg, immediate_arg, nobreaks_arg]
-        .into_iter()
-        .flatten()
-        .map(|arg| arg.to_trimmed_string());
+    let mut skipped_nested = false;
+    let extra_args = ast.arguments()?.items().into_iter().filter_map(|arg| {
+        let arg = arg.ok()?;
+        if is_direct_nested && !skipped_nested && arg.name_clause().is_none() {
+            skipped_nested = true;
+            None
+        } else {
+            Some(arg.to_trimmed_string())
+        }
+    });
     let new_content = std::iter::once(inner_content)
         .chain(extra_args)
         .collect::<Vec<_>>()
@@ -83,4 +87,33 @@ pub fn condition_message(ast: &RCall, fn_name: &str) -> anyhow::Result<Option<Di
             node_contains_comments(&outer_syntax),
         ),
     )))
+}
+
+fn get_direct_nested_paste0_content(call: &RCall) -> anyhow::Result<Option<(String, RSyntaxNode)>> {
+    let argument = call
+        .arguments()?
+        .items()
+        .into_iter()
+        .find(|arg| arg.as_ref().is_ok_and(|arg| arg.name_clause().is_none()));
+    let Some(argument) = argument else {
+        return Ok(None);
+    };
+
+    let Some(inner) = argument?.value() else {
+        return Ok(None);
+    };
+    let Some(inner_call) = inner.as_r_call() else {
+        return Ok(None);
+    };
+    if get_function_name(inner_call.as_fields().function?) != "paste0" {
+        return Ok(None);
+    }
+
+    let inner_content = inner_call
+        .as_fields()
+        .arguments?
+        .items()
+        .into_syntax()
+        .to_string();
+    Ok(Some((inner_content, call.syntax().clone())))
 }

--- a/crates/jarl-core/src/lints/base/condition_message/mod.rs
+++ b/crates/jarl-core/src/lints/base/condition_message/mod.rs
@@ -13,8 +13,6 @@ mod tests {
     fn test_no_lint_condition_message() {
         expect_no_lint("stop('boom')", "condition_message", None);
         expect_no_lint("stop('hello', 'there')", "condition_message", None);
-        expect_no_lint("stop(paste0('a'), 'b')", "condition_message", None);
-        expect_no_lint("warning(paste0('a'), 'b')", "condition_message", None);
         expect_no_lint("stop('boom', call. = FALSE)", "condition_message", None);
         expect_no_lint(
             "stop('hello', call. = FALSE, 'there')",
@@ -49,6 +47,19 @@ mod tests {
           |
         1 | stop(paste0('hello ', 'there'))
           | ------------------------------- `stop(paste0(...))` can be simplified.
+          |
+          = help: Use `stop(...)` instead.
+        Found 1 error.
+        "
+        );
+        assert_snapshot!(
+            snapshot_lint("stop(paste0('hello ', 'there'), call. = FALSE, ' again')"),
+            @"
+        warning: condition_message
+         --> <test>:1:1
+          |
+        1 | stop(paste0('hello ', 'there'), call. = FALSE, ' again')
+          | -------------------------------------------------------- `stop(paste0(...))` can be simplified.
           |
           = help: Use `stop(...)` instead.
         Found 1 error.
@@ -117,6 +128,19 @@ mod tests {
           |
         1 | warning(paste0('hello ', 'there'))
           | ---------------------------------- `warning(paste0(...))` can be simplified.
+          |
+          = help: Use `warning(...)` instead.
+        Found 1 error.
+        "
+        );
+        assert_snapshot!(
+            snapshot_lint("warning(paste0('hello ', 'there'), call. = FALSE, ' again')"),
+            @"
+        warning: condition_message
+         --> <test>:1:1
+          |
+        1 | warning(paste0('hello ', 'there'), call. = FALSE, ' again')
+          | ----------------------------------------------------------- `warning(paste0(...))` can be simplified.
           |
           = help: Use `warning(...)` instead.
         Found 1 error.
@@ -210,10 +234,12 @@ mod tests {
                 vec![
                     "stop(paste0('hello ', 'there'))",
                     "stop(paste0('hello ', 'there'), call. = FALSE)",
+                    "stop(paste0('hello ', 'there'), call. = FALSE, ' again')",
                     "stop(paste0('hello ', 'there'), domain = foo)",
                     "stop(call. = FALSE, paste0('hello ', 'there'), domain = foo)",
                     "warning(paste0('hello ', 'there'))",
                     "warning(paste0('hello ', 'there'), call. = FALSE)",
+                    "warning(paste0('hello ', 'there'), call. = FALSE, ' again')",
                     "warning(paste0('hello ', 'there'), domain = foo)",
                     "warning(paste0('hello ', 'there'), immediate. = FALSE)",
                     "warning(paste0('hello ', 'there'), noBreaks. = FALSE)",

--- a/crates/jarl-core/src/lints/base/condition_message/mod.rs
+++ b/crates/jarl-core/src/lints/base/condition_message/mod.rs
@@ -244,6 +244,8 @@ mod tests {
                     "warning(paste0('hello ', 'there'), immediate. = FALSE)",
                     "warning(paste0('hello ', 'there'), noBreaks. = FALSE)",
                     "warning(call. = FALSE, paste0('hello ', 'there'), domain = foo)",
+                    "paste0('hello ', 'there') |> stop()",
+                    "'hello ' |> paste0() |> warning(domain = foo)",
                 ],
                 "condition_message",
             )

--- a/crates/jarl-core/src/lints/base/condition_message/mod.rs
+++ b/crates/jarl-core/src/lints/base/condition_message/mod.rs
@@ -13,6 +13,8 @@ mod tests {
     fn test_no_lint_condition_message() {
         expect_no_lint("stop('boom')", "condition_message", None);
         expect_no_lint("stop('hello', 'there')", "condition_message", None);
+        expect_no_lint("stop(paste0('a'), 'b')", "condition_message", None);
+        expect_no_lint("warning(paste0('a'), 'b')", "condition_message", None);
         expect_no_lint("stop('boom', call. = FALSE)", "condition_message", None);
         expect_no_lint(
             "stop('hello', call. = FALSE, 'there')",
@@ -73,19 +75,6 @@ mod tests {
           |
         1 | stop(call. = FALSE, paste0('hello ', 'there'))
           | ---------------------------------------------- `stop(paste0(...))` can be simplified.
-          |
-          = help: Use `stop(...)` instead.
-        Found 1 error.
-        "
-        );
-        assert_snapshot!(
-            snapshot_lint("stop(paste0('hello ', 'there'), call. = FALSE, ' again')"),
-            @"
-        warning: condition_message
-         --> <test>:1:1
-          |
-        1 | stop(paste0('hello ', 'there'), call. = FALSE, ' again')
-          | -------------------------------------------------------- `stop(paste0(...))` can be simplified.
           |
           = help: Use `stop(...)` instead.
         Found 1 error.
@@ -154,19 +143,6 @@ mod tests {
           |
         1 | warning(call. = FALSE, paste0('hello ', 'there'))
           | ------------------------------------------------- `warning(paste0(...))` can be simplified.
-          |
-          = help: Use `warning(...)` instead.
-        Found 1 error.
-        "
-        );
-        assert_snapshot!(
-            snapshot_lint("warning(paste0('hello ', 'there'), call. = FALSE, ' again')"),
-            @"
-        warning: condition_message
-         --> <test>:1:1
-          |
-        1 | warning(paste0('hello ', 'there'), call. = FALSE, ' again')
-          | ----------------------------------------------------------- `warning(paste0(...))` can be simplified.
           |
           = help: Use `warning(...)` instead.
         Found 1 error.

--- a/crates/jarl-core/src/lints/base/condition_message/snapshots/jarl_core__lints__base__condition_message__tests__fix_output.snap
+++ b/crates/jarl-core/src/lints/base/condition_message/snapshots/jarl_core__lints__base__condition_message__tests__fix_output.snap
@@ -1,6 +1,6 @@
 ---
 source: crates/jarl-core/src/lints/base/condition_message/mod.rs
-expression: "get_unsafe_fixed_text(vec![\"stop(paste0('hello ', 'there'))\",\n\"stop(paste0('hello ', 'there'), call. = FALSE)\",\n\"stop(paste0('hello ', 'there'), call. = FALSE, ' again')\",\n\"stop(paste0('hello ', 'there'), domain = foo)\",\n\"stop(call. = FALSE, paste0('hello ', 'there'), domain = foo)\",\n\"warning(paste0('hello ', 'there'))\",\n\"warning(paste0('hello ', 'there'), call. = FALSE)\",\n\"warning(paste0('hello ', 'there'), call. = FALSE, ' again')\",\n\"warning(paste0('hello ', 'there'), domain = foo)\",\n\"warning(paste0('hello ', 'there'), immediate. = FALSE)\",\n\"warning(paste0('hello ', 'there'), noBreaks. = FALSE)\",\n\"warning(call. = FALSE, paste0('hello ', 'there'), domain = foo)\",],\n\"condition_message\",)"
+expression: "get_unsafe_fixed_text(vec![\"stop(paste0('hello ', 'there'))\",\n\"stop(paste0('hello ', 'there'), call. = FALSE)\",\n\"stop(paste0('hello ', 'there'), call. = FALSE, ' again')\",\n\"stop(paste0('hello ', 'there'), domain = foo)\",\n\"stop(call. = FALSE, paste0('hello ', 'there'), domain = foo)\",\n\"warning(paste0('hello ', 'there'))\",\n\"warning(paste0('hello ', 'there'), call. = FALSE)\",\n\"warning(paste0('hello ', 'there'), call. = FALSE, ' again')\",\n\"warning(paste0('hello ', 'there'), domain = foo)\",\n\"warning(paste0('hello ', 'there'), immediate. = FALSE)\",\n\"warning(paste0('hello ', 'there'), noBreaks. = FALSE)\",\n\"warning(call. = FALSE, paste0('hello ', 'there'), domain = foo)\",\n\"paste0('hello ', 'there') |> stop()\",\n\"'hello ' |> paste0() |> warning(domain = foo)\",], \"condition_message\",)"
 ---
 OLD:
 ====
@@ -85,3 +85,17 @@ warning(call. = FALSE, paste0('hello ', 'there'), domain = foo)
 NEW:
 ====
 warning('hello ', 'there', call. = FALSE, domain = foo)
+
+OLD:
+====
+paste0('hello ', 'there') |> stop()
+NEW:
+====
+stop('hello ', 'there')
+
+OLD:
+====
+'hello ' |> paste0() |> warning(domain = foo)
+NEW:
+====
+warning('hello ', domain = foo)

--- a/crates/jarl-core/src/lints/base/condition_message/snapshots/jarl_core__lints__base__condition_message__tests__fix_output.snap
+++ b/crates/jarl-core/src/lints/base/condition_message/snapshots/jarl_core__lints__base__condition_message__tests__fix_output.snap
@@ -1,6 +1,6 @@
 ---
 source: crates/jarl-core/src/lints/base/condition_message/mod.rs
-expression: "get_unsafe_fixed_text(vec![\"stop(paste0('hello ', 'there'))\",\n\"stop(paste0('hello ', 'there'), call. = FALSE)\",\n\"stop(paste0('hello ', 'there'), domain = foo)\",\n\"stop(call. = FALSE, paste0('hello ', 'there'), domain = foo)\",\n\"warning(paste0('hello ', 'there'))\",\n\"warning(paste0('hello ', 'there'), call. = FALSE)\",\n\"warning(paste0('hello ', 'there'), domain = foo)\",\n\"warning(paste0('hello ', 'there'), immediate. = FALSE)\",\n\"warning(paste0('hello ', 'there'), noBreaks. = FALSE)\",\n\"warning(call. = FALSE, paste0('hello ', 'there'), domain = foo)\",],\n\"condition_message\",)"
+expression: "get_unsafe_fixed_text(vec![\"stop(paste0('hello ', 'there'))\",\n\"stop(paste0('hello ', 'there'), call. = FALSE)\",\n\"stop(paste0('hello ', 'there'), call. = FALSE, ' again')\",\n\"stop(paste0('hello ', 'there'), domain = foo)\",\n\"stop(call. = FALSE, paste0('hello ', 'there'), domain = foo)\",\n\"warning(paste0('hello ', 'there'))\",\n\"warning(paste0('hello ', 'there'), call. = FALSE)\",\n\"warning(paste0('hello ', 'there'), call. = FALSE, ' again')\",\n\"warning(paste0('hello ', 'there'), domain = foo)\",\n\"warning(paste0('hello ', 'there'), immediate. = FALSE)\",\n\"warning(paste0('hello ', 'there'), noBreaks. = FALSE)\",\n\"warning(call. = FALSE, paste0('hello ', 'there'), domain = foo)\",],\n\"condition_message\",)"
 ---
 OLD:
 ====
@@ -15,6 +15,13 @@ stop(paste0('hello ', 'there'), call. = FALSE)
 NEW:
 ====
 stop('hello ', 'there', call. = FALSE)
+
+OLD:
+====
+stop(paste0('hello ', 'there'), call. = FALSE, ' again')
+NEW:
+====
+stop('hello ', 'there', call. = FALSE, ' again')
 
 OLD:
 ====
@@ -43,6 +50,13 @@ warning(paste0('hello ', 'there'), call. = FALSE)
 NEW:
 ====
 warning('hello ', 'there', call. = FALSE)
+
+OLD:
+====
+warning(paste0('hello ', 'there'), call. = FALSE, ' again')
+NEW:
+====
+warning('hello ', 'there', call. = FALSE, ' again')
 
 OLD:
 ====

--- a/crates/jarl-core/src/utils.rs
+++ b/crates/jarl-core/src/utils.rs
@@ -277,12 +277,18 @@ pub fn get_nested_functions_content(
         return Ok(None);
     }
 
-    // Try nested case: outer_fn(inner_fn(content))
-    let unnamed_arg = call
+    // Try nested case: outer_fn(inner_fn(content)). The replacement is based
+    // on this argument, so there must not be another unnamed argument that
+    // would be discarded.
+    let mut unnamed_args = call
         .arguments()?
         .items()
         .into_iter()
-        .find(|x| x.as_ref().is_ok_and(|arg| arg.name_clause().is_none()));
+        .filter(|x| x.as_ref().is_ok_and(|arg| arg.name_clause().is_none()));
+    let unnamed_arg = match (unnamed_args.next(), unnamed_args.next()) {
+        (Some(arg), None) => Some(arg),
+        _ => None,
+    };
 
     if let Some(arg) = unnamed_arg {
         let value = arg?.value();

--- a/crates/jarl-core/src/utils.rs
+++ b/crates/jarl-core/src/utils.rs
@@ -277,9 +277,7 @@ pub fn get_nested_functions_content(
         return Ok(None);
     }
 
-    // Try nested case: outer_fn(inner_fn(content)). The replacement is based
-    // on this argument, so there must not be another unnamed argument that
-    // would be discarded.
+    // Try nested case: outer_fn(inner_fn(content))
     let mut unnamed_args = call
         .arguments()?
         .items()

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -9,6 +9,9 @@
 
 ### Bug fixes
 
+* Prevent fixes for `any_is_na`, `any_duplicated`, and `condition_message`
+  from dropping extra unnamed arguments (#677, @Yousa-Mirage).
+
 * Ensure that `--fix` works with multi-byte characters (#672, @Yousa-Mirage).
 
 * The `lengths` rule no longer crashes on calls where `X` is missing from the


### PR DESCRIPTION
Before `test.R`:

```r
any(is.na(x), is.na(y))
any(duplicated(x), duplicated(y))
stop(paste0("a"), "b")
```

After fix with `jarl check test.R --fix --select=any_is_na,any_duplicated,condition_message`:

```r
anyNA(x)
anyDuplicated(x) > 0
stop("a")
```

This obviously breaks the code.

Nested-call autofixes for `any_is_na`, `any_duplicated`, and `condition_message` could silently drop extra unnamed arguments while replacing the entire outer call. The root cause was `get_nested_functions_content` selecting only the first unnamed argument without verifying that it was the only one.