### PR TITLE
fix: Stop `expect_type` rule from duplicating `expect_null` lints

### DIFF
--- a/crates/jarl-core/src/lints/testthat/expect_type/expect_type.rs
+++ b/crates/jarl-core/src/lints/testthat/expect_type/expect_type.rs
@@ -140,7 +140,6 @@ fn check_expect_true_is_type(ast: &RCall) -> anyhow::Result<Option<Diagnostic>> 
         "is.character" => "\"character\"",
         "is.raw" => "\"raw\"",
         "is.list" => "\"list\"",
-        "is.null" => "\"NULL\"",
         "is.symbol" => "\"symbol\"",
         "is.expression" => "\"expression\"",
         "is.language" => "\"language\"",

--- a/crates/jarl-core/src/lints/testthat/expect_type/mod.rs
+++ b/crates/jarl-core/src/lints/testthat/expect_type/mod.rs
@@ -17,6 +17,9 @@ mod tests {
         // other is.<x> calls are not suitable for expect_type in particular
         expect_no_lint("expect_true(is.data.frame(x))", "expect_type", None);
 
+        // is.null is covered by the expect_null rule
+        expect_no_lint("expect_true(is.null(x))", "expect_type", None);
+
         // expect_type(x, ...) cannot be cleanly used here:
         expect_no_lint(
             "expect_true(typeof(x) %in% c('builtin', 'closure'))",

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -22,6 +22,9 @@
 * Avoid invalid `literal_coercion` fixes for strings containing quotes
   (#678, @Yousa-Mirage).
 
+* The `expect_type` rule no longer lints `expect_true(is.null(x))`, which was
+  already reported by the `expect_null` rule (#680, @Yousa-Mirage).
+
 ## 0.6.0
 
 ::: {.callout-note icon=false title="Released on 2026-08-24" .low-opacity}


### PR DESCRIPTION
`test.R`:

```r
expect_true(is.null(x))
```

Then run check:
```bash
$jarl check test.R --select=TESTTHAT

warning: expect_null
 --> test.R:1:1
  |
1 | expect_true(is.null(x))
  | ----------------------- `expect_true(is.null(x))` is not as clear as `expect_null(x)`.
  |
  = help: Use `expect_null(x)` instead.

warning: expect_type
 --> test.R:1:1
  |
1 | expect_true(is.null(x))
  | ----------------------- `expect_true(is.<t>(x))` can be hard to read.
  |
  = help: Use `expect_type(x, t)` instead.


── Summary ──────────────────────────────────────
Found 2 errors.
2 fixable with the `--fix` option.
```

Actually it's the same problem. But it was reported twice by `expect_null` and `expect_type`.

I removed the check in `expect_type`. And `expect_equal(typeof(x), "NULL")` will still be reported by `expect_type` rule.