### PR TITLE
fix: Match `dplyr_filter_out` guards by identifier

### DIFF
--- a/crates/jarl-core/src/lints/dplyr/dplyr_filter_out/dplyr_filter_out.rs
+++ b/crates/jarl-core/src/lints/dplyr/dplyr_filter_out/dplyr_filter_out.rs
@@ -181,11 +181,14 @@ fn convert_conditions(args: &[AnyRExpression]) -> Option<Vec<String>> {
     for value in args {
         let (cond, is_na_call) = extract_is_na_guard(value)?;
 
-        // Verify the is.na() argument appears in the condition.
-        // This avoids matching `a > 1 | is.na(b)` where the guard is for
-        // a different variable.
         let is_na_arg = extract_is_na_arg(&is_na_call)?;
-        if !contains_identifier(&cond, &is_na_arg) {
+        let contains_identifier = cond
+            .as_r_identifier()
+            .cloned()
+            .into_iter()
+            .chain(cond.syntax().descendants().filter_map(RIdentifier::cast))
+            .any(|ident| ident.to_trimmed_text() == is_na_arg.as_str());
+        if !contains_identifier {
             return None;
         }
 
@@ -193,19 +196,6 @@ fn convert_conditions(args: &[AnyRExpression]) -> Option<Vec<String>> {
     }
 
     Some(negated_conds)
-}
-
-/// Check whether an expression contains an identifier with the exact target
-/// name. A textual substring check would incorrectly match names such as `x2`
-/// when the `is.na()` guard refers to `x`.
-fn contains_identifier(expr: &AnyRExpression, target: &str) -> bool {
-    expr.as_r_identifier()
-        .is_some_and(|ident| ident.to_trimmed_text() == target)
-        || expr
-            .syntax()
-            .descendants()
-            .filter_map(RIdentifier::cast)
-            .any(|ident| ident.to_trimmed_text() == target)
 }
 
 /// Extract the two sides of a `cond | is.na(var)` expression.

--- a/crates/jarl-core/src/lints/dplyr/dplyr_filter_out/dplyr_filter_out.rs
+++ b/crates/jarl-core/src/lints/dplyr/dplyr_filter_out/dplyr_filter_out.rs
@@ -185,8 +185,7 @@ fn convert_conditions(args: &[AnyRExpression]) -> Option<Vec<String>> {
         // This avoids matching `a > 1 | is.na(b)` where the guard is for
         // a different variable.
         let is_na_arg = extract_is_na_arg(&is_na_call)?;
-        let cond_text = cond.syntax().text_trimmed().to_string();
-        if !cond_text.contains(&is_na_arg) {
+        if !contains_identifier(&cond, &is_na_arg) {
             return None;
         }
 
@@ -194,6 +193,19 @@ fn convert_conditions(args: &[AnyRExpression]) -> Option<Vec<String>> {
     }
 
     Some(negated_conds)
+}
+
+/// Check whether an expression contains an identifier with the exact target
+/// name. A textual substring check would incorrectly match names such as `x2`
+/// when the `is.na()` guard refers to `x`.
+fn contains_identifier(expr: &AnyRExpression, target: &str) -> bool {
+    expr.as_r_identifier()
+        .is_some_and(|ident| ident.to_trimmed_text() == target)
+        || expr
+            .syntax()
+            .descendants()
+            .filter_map(RIdentifier::cast)
+            .any(|ident| ident.to_trimmed_text() == target)
 }
 
 /// Extract the two sides of a `cond | is.na(var)` expression.

--- a/crates/jarl-core/src/lints/dplyr/dplyr_filter_out/mod.rs
+++ b/crates/jarl-core/src/lints/dplyr/dplyr_filter_out/mod.rs
@@ -82,6 +82,16 @@ mod tests {
     }
 
     #[test]
+    fn test_no_lint_is_na_guard_substring_match() {
+        // `x` must not match the prefix of the different identifier `x2`.
+        expect_no_lint(
+            "x |> dplyr::filter(x2 > 0 | is.na(x))",
+            "dplyr_filter_out",
+            None,
+        );
+    }
+
+    #[test]
     fn test_lint_is_na_guard() {
         assert_snapshot!(
             snapshot_lint("x |> dplyr::filter(a > 1 | is.na(a))"),

--- a/crates/jarl-core/src/lints/dplyr/dplyr_filter_out/mod.rs
+++ b/crates/jarl-core/src/lints/dplyr/dplyr_filter_out/mod.rs
@@ -58,6 +58,8 @@ mod tests {
             "dplyr_filter_out",
             None,
         );
+        // don't match identifiers on substring
+        // https://github.com/etiennebacher/jarl/pull/681
         expect_no_lint(
             "x |> dplyr::filter(x2 > 0 | is.na(x))",
             "dplyr_filter_out",

--- a/crates/jarl-core/src/lints/dplyr/dplyr_filter_out/mod.rs
+++ b/crates/jarl-core/src/lints/dplyr/dplyr_filter_out/mod.rs
@@ -58,6 +58,11 @@ mod tests {
             "dplyr_filter_out",
             None,
         );
+        expect_no_lint(
+            "x |> dplyr::filter(x2 > 0 | is.na(x))",
+            "dplyr_filter_out",
+            None,
+        );
         // Tidy eval splice in condition
         expect_no_lint(
             "x |> dplyr::filter(!!!args | is.na(a))",
@@ -79,16 +84,6 @@ mod tests {
         expect_no_lint("x |> dplyr::filter()", "dplyr_filter_out", None);
         // No unnamed arg
         expect_no_lint("x |> dplyr::filter(.by = a)", "dplyr_filter_out", None);
-    }
-
-    #[test]
-    fn test_no_lint_is_na_guard_substring_match() {
-        // `x` must not match the prefix of the different identifier `x2`.
-        expect_no_lint(
-            "x |> dplyr::filter(x2 > 0 | is.na(x))",
-            "dplyr_filter_out",
-            None,
-        );
     }
 
     #[test]

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -22,6 +22,9 @@
 * Avoid invalid `literal_coercion` fixes for strings containing quotes
   (#678, @Yousa-Mirage).
 
+* Prevent incorrect `dplyr_filter_out` fixes caused by matching `is.na()` guard
+  arguments as substrings of other identifiers (#681, @Yousa-Mirage).
+
 ## 0.6.0
 
 ::: {.callout-note icon=false title="Released on 2026-08-24" .low-opacity}


### PR DESCRIPTION
Before: 
```r
library(dplyr)

data <- tibble(
  row = 1:3,
  x = c(NA_real_, 1, 1),
  x2 = c(-1, -1, 1)
)

data |> filter(x2 > 0 | is.na(x))
#> # A tibble: 2 × 3
#>     row     x    x2
#>   <int> <dbl> <dbl>
#> 1     1    NA    -1
#> 2     3     1     1
```

After `jarl check test.R --fix --select=DPLYR`:

```r
data |> filter_out(x2 <= 0)
#> # A tibble: 1 × 3
#>     row     x    x2
#>   <int> <dbl> <dbl>
#> 1     3     1     1
```

The `is.na()` guard must match a complete identifier, not a substring `!cond_text.contains(&is_na_arg)`.