### PR TITLE
fix: Avoid invalid `pipe_consistency` fixes for bare RHS

### DIFF
--- a/crates/jarl-core/src/lints/base/pipe_consistency/mod.rs
+++ b/crates/jarl-core/src/lints/base/pipe_consistency/mod.rs
@@ -135,6 +135,36 @@ mod tests {
     }
 
     #[test]
+    fn test_lint_pipe_consistency_bare_rhs_no_fix() {
+        // The native pipe requires a call on the RHS, so `x %>% sum` can't be
+        // fixed by swapping the operator alone (`x |> sum` doesn't parse).
+        // The lint is still reported but without a fix.
+        assert_snapshot!(
+            format_diagnostics("x %>% sum", "pipe_consistency", Some("4.2")),
+            @r"
+        warning: pipe_consistency
+         --> <test>:1:3
+          |
+        1 | x %>% sum
+          |   --- `%>%` is inconsistent with the preferred pipe `|>`.
+          |
+          = help: Use `|>` instead.
+        Found 1 error.
+        "
+        );
+
+        assert_snapshot!(
+            "fix_output_bare_rhs",
+            get_unsafe_fixed_text_with_settings(
+                vec!["x %>% sum", "x %>% sum %>% plot()"],
+                "pipe_consistency",
+                Some("4.2"),
+                None,
+            )
+        );
+    }
+
+    #[test]
     fn test_pipe_consistency_with_comments_no_fix() {
         // Detect the lint but skip the fix when comments are present.
         assert_snapshot!(

--- a/crates/jarl-core/src/lints/base/pipe_consistency/mod.rs
+++ b/crates/jarl-core/src/lints/base/pipe_consistency/mod.rs
@@ -135,7 +135,7 @@ mod tests {
     }
 
     #[test]
-    fn test_lint_pipe_consistency_bare_rhs_no_fix() {
+    fn test_lint_pipe_consistency_bare_identifier_rhs() {
         assert_snapshot!(
             format_diagnostics("x %>% sum", "pipe_consistency", Some("4.2")),
             @r"
@@ -154,6 +154,19 @@ mod tests {
             "fix_output_bare_rhs",
             get_unsafe_fixed_text_with_settings(
                 vec!["x %>% sum", "x %>% sum %>% plot()"],
+                "pipe_consistency",
+                Some("4.2"),
+                None,
+            )
+        );
+    }
+
+    #[test]
+    fn test_lint_pipe_consistency_non_call_rhs_no_fix() {
+        assert_snapshot!(
+            "fix_output_non_call_rhs",
+            get_unsafe_fixed_text_with_settings(
+                vec!["x %>% { 1 }", "x %>% (sum + 1)", "x %>% 1"],
                 "pipe_consistency",
                 Some("4.2"),
                 None,

--- a/crates/jarl-core/src/lints/base/pipe_consistency/mod.rs
+++ b/crates/jarl-core/src/lints/base/pipe_consistency/mod.rs
@@ -136,9 +136,6 @@ mod tests {
 
     #[test]
     fn test_lint_pipe_consistency_bare_rhs_no_fix() {
-        // The native pipe requires a call on the RHS, so `x %>% sum` can't be
-        // fixed by swapping the operator alone (`x |> sum` doesn't parse).
-        // The lint is still reported but without a fix.
         assert_snapshot!(
             format_diagnostics("x %>% sum", "pipe_consistency", Some("4.2")),
             @r"

--- a/crates/jarl-core/src/lints/base/pipe_consistency/pipe_consistency.rs
+++ b/crates/jarl-core/src/lints/base/pipe_consistency/pipe_consistency.rs
@@ -109,10 +109,23 @@ pub fn pipe_consistency(
     };
 
     let bin_range = ast.syntax().text_trimmed_range();
+    let op_range = operator.text_trimmed_range();
+
+    if preferred_is_base && right.as_r_call().is_none() {
+        return Ok(Some(Diagnostic::new(
+            ViolationData::new(
+                Rule::PipeConsistency,
+                body.to_string(),
+                Some(suggestion.to_string()),
+            ),
+            op_range,
+            Fix::empty(),
+        )));
+    }
+
     let bin_start: u32 = bin_range.start().into();
     let mut content = ast.to_trimmed_string();
 
-    let op_range = operator.text_trimmed_range();
     let mut edits: Vec<(usize, usize, &str)> = Vec::with_capacity(2);
     edits.push((
         (u32::from(op_range.start()) - bin_start) as usize,

--- a/crates/jarl-core/src/lints/base/pipe_consistency/pipe_consistency.rs
+++ b/crates/jarl-core/src/lints/base/pipe_consistency/pipe_consistency.rs
@@ -111,7 +111,8 @@ pub fn pipe_consistency(
     let bin_range = ast.syntax().text_trimmed_range();
     let op_range = operator.text_trimmed_range();
 
-    if preferred_is_base && right.as_r_call().is_none() {
+    let rhs_is_identifier = right.as_r_identifier().is_some();
+    if preferred_is_base && right.as_r_call().is_none() && !rhs_is_identifier {
         return Ok(Some(Diagnostic::new(
             ViolationData::new(
                 Rule::PipeConsistency,
@@ -126,7 +127,7 @@ pub fn pipe_consistency(
     let bin_start: u32 = bin_range.start().into();
     let mut content = ast.to_trimmed_string();
 
-    let mut edits: Vec<(usize, usize, &str)> = Vec::with_capacity(2);
+    let mut edits: Vec<(usize, usize, &str)> = Vec::with_capacity(3);
     edits.push((
         (u32::from(op_range.start()) - bin_start) as usize,
         (u32::from(op_range.end()) - bin_start) as usize,
@@ -138,6 +139,11 @@ pub fn pipe_consistency(
             (u32::from(r.end()) - bin_start) as usize,
             new_placeholder,
         ));
+    }
+    if preferred_is_base && rhs_is_identifier {
+        let rhs_end = right.syntax().text_trimmed_range().end();
+        let rhs_end = (u32::from(rhs_end) - bin_start) as usize;
+        edits.push((rhs_end, rhs_end, "()"));
     }
     // Apply edits from the back so earlier offsets remain valid.
     edits.sort_by_key(|e| std::cmp::Reverse(e.0));

--- a/crates/jarl-core/src/lints/base/pipe_consistency/snapshots/jarl_core__lints__base__pipe_consistency__tests__fix_output_bare_rhs.snap
+++ b/crates/jarl-core/src/lints/base/pipe_consistency/snapshots/jarl_core__lints__base__pipe_consistency__tests__fix_output_bare_rhs.snap
@@ -7,11 +7,11 @@ OLD:
 x %>% sum
 NEW:
 ====
-x %>% sum
+x |> sum()
 
 OLD:
 ====
 x %>% sum %>% plot()
 NEW:
 ====
-x %>% sum |> plot()
+x |> sum() |> plot()

--- a/crates/jarl-core/src/lints/base/pipe_consistency/snapshots/jarl_core__lints__base__pipe_consistency__tests__fix_output_bare_rhs.snap
+++ b/crates/jarl-core/src/lints/base/pipe_consistency/snapshots/jarl_core__lints__base__pipe_consistency__tests__fix_output_bare_rhs.snap
@@ -1,0 +1,17 @@
+---
+source: crates/jarl-core/src/lints/base/pipe_consistency/mod.rs
+expression: "get_unsafe_fixed_text_with_settings(vec![\"x %>% sum\", \"x %>% sum %>% plot()\"],\n\"pipe_consistency\", Some(\"4.2\"), None,)"
+---
+OLD:
+====
+x %>% sum
+NEW:
+====
+x %>% sum
+
+OLD:
+====
+x %>% sum %>% plot()
+NEW:
+====
+x %>% sum |> plot()

--- a/crates/jarl-core/src/lints/base/pipe_consistency/snapshots/jarl_core__lints__base__pipe_consistency__tests__fix_output_non_call_rhs.snap
+++ b/crates/jarl-core/src/lints/base/pipe_consistency/snapshots/jarl_core__lints__base__pipe_consistency__tests__fix_output_non_call_rhs.snap
@@ -1,0 +1,24 @@
+---
+source: crates/jarl-core/src/lints/base/pipe_consistency/mod.rs
+expression: "get_unsafe_fixed_text_with_settings(vec![\"x %>% { 1 }\", \"x %>% (sum + 1)\",\n\"x %>% 1\"], \"pipe_consistency\", Some(\"4.2\"), None,)"
+---
+OLD:
+====
+x %>% { 1 }
+NEW:
+====
+x %>% { 1 }
+
+OLD:
+====
+x %>% (sum + 1)
+NEW:
+====
+x %>% (sum + 1)
+
+OLD:
+====
+x %>% 1
+NEW:
+====
+x %>% 1

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -33,7 +33,7 @@
   (#678, @Yousa-Mirage).
 
 * The `pipe_consistency` rule no longer emits invalid fixes when converting
-  magrittr pipes with a non-call RHS, such as `x %>% sum` (#683, @Yousa-Mirage).
+  `magrittr` pipes with a non-call RHS, such as `x %>% sum` (#683, @Yousa-Mirage).
 
 * Prevent incorrect `dplyr_filter_out` fixes caused by matching `is.na()` guard
   arguments as substrings of other identifiers (#681, @Yousa-Mirage).

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -22,6 +22,9 @@
 * Avoid invalid `literal_coercion` fixes for strings containing quotes
   (#678, @Yousa-Mirage).
 
+* The `pipe_consistency` rule no longer emits invalid fixes when converting
+  magrittr pipes with a non-call RHS, such as `x %>% sum` (#683, @Yousa-Mirage).
+
 ## 0.6.0
 
 ::: {.callout-note icon=false title="Released on 2026-08-24" .low-opacity}


### PR DESCRIPTION
Before:

```r
x %>% sum
```

After `jarl check test.R --select pipe_consistency --fix --unsafe-fixes --min-r-version 4.2`:

```r
x |> sum
```

The code is broken.