### PR TITLE
fix: `expect_length` no longer reports `expect_equal(*, length(x))`

### DIFF
--- a/crates/jarl-core/src/lints/testthat/expect_length/expect_length.rs
+++ b/crates/jarl-core/src/lints/testthat/expect_length/expect_length.rs
@@ -31,14 +31,12 @@ const FORMALS_LENGTH: Formals = &["x"];
 /// ```r
 /// expect_equal(length(x), 2)
 /// expect_identical(length(x), n)
-/// expect_equal(2L, length(x))
 /// ```
 ///
 /// Use instead:
 /// ```r
 /// expect_length(x, 2)
 /// expect_length(x, n)
-/// expect_length(x, 2L)
 /// ```
 pub fn expect_length(ast: &RCall, fn_name: &str) -> anyhow::Result<Option<Diagnostic>> {
     // Only check expect_equal and expect_identical
@@ -84,17 +82,6 @@ pub fn expect_length(ast: &RCall, fn_name: &str) -> anyhow::Result<Option<Diagno
             } else {
                 return Ok(None);
             }
-        } else {
-            return Ok(None);
-        }
-    } else if let Some(expected_call) = expected_value.as_r_call() {
-
-        // If we're here, it means that the `object` isn't `length(...)`, so if
-        // `expected` also isn't `length(...)` we stop.
-        let exp_fn = expected_call.function()?;
-        let exp_fn_name = get_function_name(exp_fn);
-        if exp_fn_name == "length" {
-            (expected_call, object_value)
         } else {
             return Ok(None);
         }

--- a/crates/jarl-core/src/lints/testthat/expect_length/mod.rs
+++ b/crates/jarl-core/src/lints/testthat/expect_length/mod.rs
@@ -33,6 +33,10 @@ mod tests {
         expect_no_lint("expect_equal(length(x), length(y))", "expect_length", None);
         expect_no_lint("expect_equal(foo(x), bar(y))", "expect_length", None);
 
+        // Don't invert the logic
+        // https://github.com/etiennebacher/jarl/issues/571
+        expect_no_lint("expect_equal(1, length(x)", "expect_length", None);
+
         // Not the functions we're looking for
         expect_no_lint("expect_equal(x, 1)", "expect_length", None);
         expect_no_lint("some_other_function(length(x), n)", "expect_length", None);
@@ -85,32 +89,6 @@ mod tests {
         "
         );
         assert_snapshot!(
-            snapshot_lint("expect_equal(2, length(x))"),
-            @"
-        warning: expect_length
-         --> <test>:1:1
-          |
-        1 | expect_equal(2, length(x))
-          | -------------------------- `expect_length(x, n)` is better than `expect_equal(length(x), n)`.
-          |
-          = help: Use `expect_length(x, n)` instead.
-        Found 1 error.
-        "
-        );
-        assert_snapshot!(
-            snapshot_lint("expect_equal(2L, length(x))"),
-            @"
-        warning: expect_length
-         --> <test>:1:1
-          |
-        1 | expect_equal(2L, length(x))
-          | --------------------------- `expect_length(x, n)` is better than `expect_equal(length(x), n)`.
-          |
-          = help: Use `expect_length(x, n)` instead.
-        Found 1 error.
-        "
-        );
-        assert_snapshot!(
             snapshot_lint("expect_equal(foo(y), length(x))"),
             @"
         warning: expect_length
@@ -129,7 +107,6 @@ mod tests {
             get_fixed_text(
                 vec![
                     "expect_equal(length(x), 2L)",
-                    "expect_equal(2, length(x))",
                     "expect_equal(length(x), foo(y))",
                     "expect_equal(foo(y), length(x))",
                     "testthat::expect_equal(base::length(x), 2)",

--- a/crates/jarl-core/src/lints/testthat/expect_length/snapshots/jarl_core__lints__testthat__expect_length__tests__fix_output.snap
+++ b/crates/jarl-core/src/lints/testthat/expect_length/snapshots/jarl_core__lints__testthat__expect_length__tests__fix_output.snap
@@ -1,6 +1,6 @@
 ---
 source: crates/jarl-core/src/lints/testthat/expect_length/mod.rs
-expression: "get_fixed_text(vec![\"expect_equal(length(x), 2L)\",\n\"expect_equal(2, length(x))\", \"expect_equal(length(x), foo(y))\",\n\"expect_equal(foo(y), length(x))\",\n\"testthat::expect_equal(base::length(x), 2)\",], \"expect_length\", None,)"
+expression: "get_fixed_text(vec![\"expect_equal(length(x), 2L)\",\n\"expect_equal(length(x), foo(y))\", \"expect_equal(foo(y), length(x))\",\n\"testthat::expect_equal(base::length(x), 2)\",], \"expect_length\", None,)"
 ---
 OLD:
 ====
@@ -8,13 +8,6 @@ expect_equal(length(x), 2L)
 NEW:
 ====
 expect_length(x, 2L)
-
-OLD:
-====
-expect_equal(2, length(x))
-NEW:
-====
-expect_length(x, 2)
 
 OLD:
 ====

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -7,6 +7,11 @@
 * The `jarl.toml` argument `assignment` (deprecated since 0.5.0) is removed. Use
   the rule-specific option `[lint.assignment]` instead (#663).
 
+### Changes
+
+* `expect_length` no longer reports cases where `length()` is in the `expected`
+  argument, e.g. `expect_equal(nrow(x), length(y))` (#684).
+
 ### Bug fixes
 
 * Prevent fixes for `any_is_na`, `any_duplicated`, and `condition_message`
@@ -18,7 +23,7 @@
   syntax tree, e.g. `sapply(FUN = length)` or `x |> sapply(FUN = length)`. The
   autofix now also produces `lengths(x)` instead of the invalid
   `lengths(X = x)` when `X` is passed by name (#671, @Yousa-Mirage).
-  
+
 * Fix language server suppression quickfix positions for non-ASCII text
   (#676, @Yousa-Mirage).
 

--- a/docs/rules/expect_length.md
+++ b/docs/rules/expect_length.md
@@ -20,12 +20,10 @@ This rule is **disabled by default**. Select it either with the rule name
 ```r
 expect_equal(length(x), 2)
 expect_identical(length(x), n)
-expect_equal(2L, length(x))
 ```
 
 Use instead:
 ```r
 expect_length(x, 2)
 expect_length(x, n)
-expect_length(x, 2L)
 ```


### PR DESCRIPTION
Fixes #571