### PR TITLE
fix: Avoid panic on missing sample arguments

### DIFF
--- a/crates/jarl-core/src/lints/base/sample_int/mod.rs
+++ b/crates/jarl-core/src/lints/base/sample_int/mod.rs
@@ -21,6 +21,7 @@ mod tests {
         expect_no_lint("sample(10:1, m)", "sample_int", None);
         expect_no_lint("sample(replace = TRUE, letters)", "sample_int", None);
         expect_no_lint("x$sample(1:2, 1)", "sample_int", None);
+        expect_no_lint("sample(, 1)", "sample_int", None);
     }
 
     #[test]

--- a/crates/jarl-core/src/lints/base/sample_int/sample_int.rs
+++ b/crates/jarl-core/src/lints/base/sample_int/sample_int.rs
@@ -58,7 +58,7 @@ pub fn sample_int(ast: &RCall, fn_name: &str) -> anyhow::Result<Option<Diagnosti
     // Is the `n` argument of the form `1:x`? If so, keep the `x` part so it
     // can be reused in the fix.
     let right_value = if let Some(n) = n {
-        let n_value = n.value().unwrap();
+        let n_value = unwrap_or_return_none!(n.value());
         if let Some(n_value) = n_value.as_r_binary_expression() {
             let RBinaryExpressionFields { left, operator, right } = n_value.as_fields();
             let left = left?;

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -16,6 +16,9 @@
 
 ### Bug fixes
 
+* Prevent the `sample_int` rule from crashing on calls with missing arguments
+  (#687, @Yousa-Mirage).
+
 * Prevent fixes for `any_is_na`, `any_duplicated`, and `condition_message`
   from dropping extra unnamed arguments (#677, @Yousa-Mirage).
 

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -16,7 +16,7 @@
 
 ### Bug fixes
 
-* Prevent the `sample_int` rule from crashing on calls with missing arguments
+* Prevent the `sample_int` rule from panicking on calls with missing arguments
   (#687, @Yousa-Mirage).
 
 * Prevent fixes for `any_is_na`, `any_duplicated`, and `condition_message`


### PR DESCRIPTION
Before `test.R`:

```r
sample(, 1)
```

will cause panic:

```bash
$jarl check test.R --select sample_int

thread 'main' (20586) panicked at crates/jarl-core/src/lints/base/sample_int/sample_int.rs:61:33:
called `Option::unwrap()` on a `None` value
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```

A minor modification.