### PR TITLE
fix: Prevent `outer_negation` from rewriting `+` and `-` operators

### DIFF
--- a/crates/jarl-core/src/lints/base/outer_negation/mod.rs
+++ b/crates/jarl-core/src/lints/base/outer_negation/mod.rs
@@ -23,6 +23,8 @@ mod tests {
         expect_no_lint("any(!a, b)", "outer_negation", None);
         expect_no_lint("any(!!a)", "outer_negation", None);
         expect_no_lint("any(!!!a)", "outer_negation", None);
+        expect_no_lint("any(-a)", "outer_negation", None);
+        expect_no_lint("any(+a)", "outer_negation", None);
         expect_no_lint("all(a, !b)", "outer_negation", None);
         expect_no_lint("any(a, !b, na.rm = TRUE)", "outer_negation", None);
         // ditto when na.rm is passed quoted

--- a/crates/jarl-core/src/lints/base/outer_negation/outer_negation.rs
+++ b/crates/jarl-core/src/lints/base/outer_negation/outer_negation.rs
@@ -57,8 +57,9 @@ pub fn outer_negation(ast: &RCall) -> anyhow::Result<Option<Diagnostic>> {
     }
 
     let arg_value = unwrap_or_return_none!(first_arg.value());
-    // Check if the argument is a unary expression (negation)
-    if arg_value.syntax().kind() != RSyntaxKind::R_UNARY_EXPRESSION {
+    let unary_expr = unwrap_or_return_none!(arg_value.as_r_unary_expression());
+    let operator = unwrap_or_return_none!(unary_expr.operator().ok());
+    if operator.kind() != RSyntaxKind::BANG {
         return Ok(None);
     }
 

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -16,6 +16,9 @@
 
 ### Bug fixes
 
+* Prevent the `outer_negation` rule from rewriting unary `+` and `-` expressions
+  as logical negations.
+
 * Prevent fixes for `any_is_na`, `any_duplicated`, and `condition_message`
   from dropping extra unnamed arguments (#677, @Yousa-Mirage).
 

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -17,7 +17,7 @@
 ### Bug fixes
 
 * Prevent the `outer_negation` rule from rewriting unary `+` and `-` expressions
-  as logical negations.
+  as logical negations (#688, @Yousa-Mirage).
 
 * Prevent fixes for `any_is_na`, `any_duplicated`, and `condition_message`
   from dropping extra unnamed arguments (#677, @Yousa-Mirage).


### PR DESCRIPTION
Before `test.R`:

```r
x <- c(TRUE, TRUE)

any(+x)
#> TRUE
any(-x)
#> TRUE
```

After fix:

```r
x <- c(TRUE, TRUE)

!all(x)
#> FALSE
!all(x)
#> FALSE
```

This is because the current code treats `+` and `-` as unary operators like `!` and applies the same fix to them.