### PR TITLE
fix: Tweak the message of `unused_function`

### DIFF
--- a/crates/jarl-core/src/analyze/document.rs
+++ b/crates/jarl-core/src/analyze/document.rs
@@ -133,7 +133,7 @@ pub(crate) fn check_document(
             checker.report_diagnostic(Some(Diagnostic::new(
                 ViolationData::new(
                     Rule::UnusedFunction,
-                    format!("`{name}` is defined but never called in this package."),
+                    format!("`{name}` is defined but is never called in this package nor is it exported in NAMESPACE."),
                     Some(help.clone()),
                 ),
                 *range,

--- a/crates/jarl-core/src/lints/base/unused_function/mod.rs
+++ b/crates/jarl-core/src/lints/base/unused_function/mod.rs
@@ -789,16 +789,16 @@ mod tests {
          --> [PKG]/R/unused_1.R:1:1
           |
         1 | unused_fn_1 <- function() 1
-          | ----------- `unused_fn_1` is defined but never called in this package.
+          | ----------- `unused_fn_1` is defined but is never called in this package nor is it exported in NAMESPACE.
           |
-          = help: Defined at [PKG]/R/unused_1.R:1:1 but never called
+          = help: Defined at [PKG]/R/unused_1.R:1:1.
         warning: unused_function
          --> [PKG]/R/unused_2.R:1:1
           |
         1 | unused_fn_2 <- function() 2
-          | ----------- `unused_fn_2` is defined but never called in this package.
+          | ----------- `unused_fn_2` is defined but is never called in this package nor is it exported in NAMESPACE.
           |
-          = help: Defined at [PKG]/R/unused_2.R:1:1 but never called
+          = help: Defined at [PKG]/R/unused_2.R:1:1.
         Found 2 errors.
         "
         );

--- a/crates/jarl-core/src/lints/base/unused_function/unused_function.rs
+++ b/crates/jarl-core/src/lints/base/unused_function/unused_function.rs
@@ -24,6 +24,9 @@ use crate::package::{FileScope, SharedFileData};
 /// refactoring. Removing it keeps the codebase easier to understand and
 /// maintain.
 ///
+/// While exported functions may not be called by other functions, they must be
+/// declared in the package's NAMESPACE file before they are visible to users.
+///
 /// ## Limitations
 ///
 /// There are many ways to call a function in R code (e.g. `foo()`,
@@ -57,6 +60,7 @@ use crate::package::{FileScope, SharedFileData};
 /// # `check_length()` isn't exported but and isn't used anywhere, so it is
 /// # reported.
 /// ```
+///
 // ## Implementation
 //
 // Operates on the already-scanned `SharedFileData` of a package rather than
@@ -197,7 +201,7 @@ pub(crate) fn compute_unused_from_shared(
 
                 if occurrences <= definitions && !extra_symbol_set.contains(name.as_str()) {
                     let help = format!(
-                        "Defined at {path}:{line}:{col} but never called",
+                        "Defined at {path}:{line}:{col}.",
                         path = file.rel_path.display()
                     );
                     unused.push((name.clone(), *range, help));

--- a/crates/jarl-core/src/lints/base/unused_function/unused_function.rs
+++ b/crates/jarl-core/src/lints/base/unused_function/unused_function.rs
@@ -20,12 +20,10 @@ use crate::package::{FileScope, SharedFileData};
 ///
 /// ## Why is this bad?
 ///
-/// An internal function that is never called is likely dead code left over from
-/// refactoring. Removing it keeps the codebase easier to understand and
-/// maintain.
-///
-/// While exported functions may not be called by other functions, they must be
-/// declared in the package's NAMESPACE file before they are visible to users.
+/// Functions must be documented in NAMESPACE to be exported to end users. A
+/// unction that is never called nor exported is likely dead code left over
+/// from refactoring. Removing unused internal functions keeps the codebase
+/// easier to understand and maintain.
 ///
 /// ## Limitations
 ///

--- a/crates/jarl-core/src/lints/base/unused_function/unused_function.rs
+++ b/crates/jarl-core/src/lints/base/unused_function/unused_function.rs
@@ -21,7 +21,7 @@ use crate::package::{FileScope, SharedFileData};
 /// ## Why is this bad?
 ///
 /// Functions must be documented in NAMESPACE to be exported to end users. A
-/// unction that is never called nor exported is likely dead code left over
+/// function that is never called nor exported is likely dead code left over
 /// from refactoring. Removing unused internal functions keeps the codebase
 /// easier to understand and maintain.
 ///
@@ -58,7 +58,6 @@ use crate::package::{FileScope, SharedFileData};
 /// # `check_length()` isn't exported but and isn't used anywhere, so it is
 /// # reported.
 /// ```
-///
 // ## Implementation
 //
 // Operates on the already-scanned `SharedFileData` of a package rather than

--- a/docs/_quarto.yml
+++ b/docs/_quarto.yml
@@ -2,7 +2,6 @@ project:
   type: website
   pre-render: copy_readme.R
 filters:
-- linkify-github-refs.lua
 - newpagelink.lua
 format:
   html:

--- a/docs/rules/unused_function.md
+++ b/docs/rules/unused_function.md
@@ -19,6 +19,9 @@ An internal function that is never called is likely dead code left over from
 refactoring. Removing it keeps the codebase easier to understand and
 maintain.
 
+While exported functions may not be called by other functions, they must be
+declared in the package's NAMESPACE file before they are visible to users.
+
 ## Limitations
 
 There are many ways to call a function in R code (e.g. `foo()`,
@@ -52,3 +55,4 @@ check_length <- function(x, y) {
 # `check_length()` isn't exported but and isn't used anywhere, so it is
 # reported.
 ```
+

--- a/docs/rules/unused_function.md
+++ b/docs/rules/unused_function.md
@@ -15,12 +15,10 @@ Checks for unused functions in R packages. It looks for:
 
 ## Why is this bad?
 
-An internal function that is never called is likely dead code left over from
-refactoring. Removing it keeps the codebase easier to understand and
-maintain.
-
-While exported functions may not be called by other functions, they must be
-declared in the package's NAMESPACE file before they are visible to users.
+Functions must be documented in NAMESPACE to be exported to end users. A
+unction that is never called nor exported is likely dead code left over
+from refactoring. Removing unused internal functions keeps the codebase
+easier to understand and maintain.
 
 ## Limitations
 

--- a/docs/rules/unused_function.md
+++ b/docs/rules/unused_function.md
@@ -16,7 +16,7 @@ Checks for unused functions in R packages. It looks for:
 ## Why is this bad?
 
 Functions must be documented in NAMESPACE to be exported to end users. A
-unction that is never called nor exported is likely dead code left over
+function that is never called nor exported is likely dead code left over
 from refactoring. Removing unused internal functions keeps the codebase
 easier to understand and maintain.
 
@@ -53,4 +53,3 @@ check_length <- function(x, y) {
 # `check_length()` isn't exported but and isn't used anywhere, so it is
 # reported.
 ```
-


### PR DESCRIPTION
Fixes #682, providing clearer warning/message when a function intended to be exported has not yet been listed in `NAMESPACE`.

Warning message for unused functions now reads:

`` `{name}` is defined but is never called in this package nor is it exported in NAMESPACE. Defined at {path}:{line}:{col}.``

Documentation also updated as follows:

```
While exported functions may not be called by other functions, they must be
declared in the package's NAMESPACE file before they are visible to users.
```

`cargo insta` snapshots have been re-run, all tests in `cargo test` passing.

`just lint` and `just document` were also run.