### PR TITLE
fix: Report parse errors in GitHub and SARIF output correctly

### DIFF
--- a/crates/jarl/src/output_format.rs
+++ b/crates/jarl/src/output_format.rs
@@ -297,9 +297,10 @@ impl Emitter for GithubEmitter {
         &self,
         writer: &mut W,
         diagnostics: &[&Diagnostic],
-        _errors: &[(String, anyhow::Error)],
+        errors: &[(String, anyhow::Error)],
     ) -> anyhow::Result<()> {
         let mut writer = BufWriter::new(writer);
+        emit_errors_concise(errors);
         for diagnostic in diagnostics {
             let (row, col) = match diagnostic.location {
                 Some(loc) => (loc.row(), loc.column() + 1), // Convert to 1-based for display
@@ -506,9 +507,10 @@ impl Emitter for SarifEmitter {
         &self,
         writer: &mut W,
         diagnostics: &[&Diagnostic],
-        _errors: &[(String, anyhow::Error)],
+        errors: &[(String, anyhow::Error)],
     ) -> anyhow::Result<()> {
         let mut writer = BufWriter::new(writer);
+        emit_errors_concise(errors);
 
         // Cache each file's contents so ranges can be converted to line/column
         // regions without re-reading the source.

--- a/crates/jarl/tests/integration/output_format.rs
+++ b/crates/jarl/tests/integration/output_format.rs
@@ -8,7 +8,7 @@ fn test_output_default() -> anyhow::Result<()> {
     ])?;
 
     insta::assert_snapshot!(
-        &mut case
+        &mut casepi --session 01a06d8d-0c58-77ca-bdc1-5f71aa297cf3
             .command()
             .arg("check")
             .arg(".")
@@ -666,7 +666,24 @@ fn test_with_parsing_error() -> anyhow::Result<()> {
     ::warning title=Jarl (any_is_na),file=test.R,line=1,col=1::test.R:1:1 [any_is_na] `any(is.na(...))` is inefficient. Use `anyNA(...)` instead.
 
     ----- stderr -----
+    Error: test2.R:1:5 expected `)` but instead the file ends
     "
+    );
+
+    let sarif = case
+        .command()
+        .arg("check")
+        .arg(".")
+        .arg("--output-format")
+        .arg("sarif")
+        .run()
+        .normalize_os_executable_name();
+
+    assert_eq!(sarif.status.code(), Some(255));
+    assert!(
+        sarif
+            .stderr
+            .contains("Error: test2.R:1:5 expected `)` but instead the file ends")
     );
 
     Ok(())

--- a/crates/jarl/tests/integration/output_format.rs
+++ b/crates/jarl/tests/integration/output_format.rs
@@ -8,7 +8,7 @@ fn test_output_default() -> anyhow::Result<()> {
     ])?;
 
     insta::assert_snapshot!(
-        &mut casepi --session 01a06d8d-0c58-77ca-bdc1-5f71aa297cf3
+        &mut case
             .command()
             .arg("check")
             .arg(".")

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -17,7 +17,7 @@
 ### Bug fixes
 
 * The `github` and `sarif` output formats now report parsing errors to stderr
-  instead of silently dropping them.
+  instead of silently dropping them (#695, @Yousa-Mirage).
 
 * Prevent the `sample_int` rule from panicking on calls with missing arguments
   (#687, @Yousa-Mirage).

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -16,6 +16,9 @@
 
 ### Bug fixes
 
+* The `github` and `sarif` output formats now report parsing errors to stderr
+  instead of silently dropping them.
+
 * Prevent the `sample_int` rule from panicking on calls with missing arguments
   (#687, @Yousa-Mirage).
 


### PR DESCRIPTION
This is a `test.R` with parse errors: 

```r
if (x {
    print("after")
  }
```

Errors found will normally be reported:

```bash
$jarl check test.R
error: expected `)` but instead found `{`
 --> test.R:1:7
  |
1 | if (x {
  |       ^
  |
error: expected an expression
 --> test.R:3:3
  |
3 |   }
  |   ^
  |
```

But in `github` and `sarif` output formats, no output is produced:

```bash
$jarl check test.R --output-format github

# code 255 but nothing output
```

```bash
$jarl check test.R --output-format sarif

{
  "$schema": "https://json.schemastore.org/sarif-2.1.0.json",
  "version": "2.1.0",
  "runs": [
    {
      "tool": {
        "driver": {
          "name": "jarl",
          "informationUri": "https://github.com/etiennebacher/jarl",
          "version": "0.6.0",
          "rules": []
        }
      },
      "columnKind": "utf16CodeUnits",
      "originalUriBaseIds": {
        "ROOTPATH": {
          "uri": "file:///home/Yousa-Mirage/Projects/jarl/"
        }
      },
      "results": []
    }
  ]
}
```