### PR TITLE
fix: Avoid false positives for quote-only strings in `nzchar`

### DIFF
--- a/crates/jarl-core/src/lints/base/nzchar/mod.rs
+++ b/crates/jarl-core/src/lints/base/nzchar/mod.rs
@@ -40,11 +40,26 @@ mod tests {
         );
 
         assert_snapshot!(
+            snapshot_lint(r#"x == r"()""#),
+            @r#"
+        warning: nzchar
+         --> <test>:1:1
+          |
+        1 | x == r"()"
+          | ---------- `x == ""` is inefficient.
+          |
+          = help: Use `!nzchar(x)` instead.
+        Found 1 error.
+        "#
+        );
+
+        assert_snapshot!(
             "fix_output",
             get_unsafe_fixed_text(
                 vec![
                     "x == ''",
                     "x != ''",
+                    r#"x == r"()""#,
                     "foo(x(y)) == ''",
                     "'' == x",
                     "which(c(a, b, c) == '')"

--- a/crates/jarl-core/src/lints/base/nzchar/mod.rs
+++ b/crates/jarl-core/src/lints/base/nzchar/mod.rs
@@ -62,6 +62,14 @@ mod tests {
         expect_no_lint("x %in% ''", "nzchar", None);
 
         expect_no_lint("x + ''", "nzchar", None);
+
+        expect_no_lint(r#"x == "'"#, "nzchar", None);
+
+        expect_no_lint(r#"x != "'"#, "nzchar", None);
+
+        expect_no_lint(r#"x == "''"#, "nzchar", None);
+
+        expect_no_lint(r#"x != "''"#, "nzchar", None);
     }
 
     #[test]

--- a/crates/jarl-core/src/lints/base/nzchar/nzchar.rs
+++ b/crates/jarl-core/src/lints/base/nzchar/nzchar.rs
@@ -3,7 +3,7 @@ use crate::rule_set::Rule;
 use crate::utils::node_contains_comments;
 use air_r_syntax::*;
 use biome_rowan::AstNode;
-use oak_core::syntax_ext::RStringValueExt;
+use jarl_semantic::strings::get_string_literal_contents;
 
 /// Version added: 0.5.0
 ///
@@ -54,13 +54,11 @@ pub fn nzchar(ast: &RBinaryExpression) -> anyhow::Result<Option<Diagnostic>> {
 
     let left_is_empty_string = left
         .as_any_r_value()
-        .and_then(|value| value.as_r_string_value())
-        .and_then(|string| string.string_text())
+        .and_then(|value| get_string_literal_contents(&value.to_trimmed_string()))
         .is_some_and(|content| content.is_empty());
     let right_is_empty_string = right
         .as_any_r_value()
-        .and_then(|value| value.as_r_string_value())
-        .and_then(|string| string.string_text())
+        .and_then(|value| get_string_literal_contents(&value.to_trimmed_string()))
         .is_some_and(|content| content.is_empty());
 
     if (left_is_empty_string && right_is_empty_string)

--- a/crates/jarl-core/src/lints/base/nzchar/nzchar.rs
+++ b/crates/jarl-core/src/lints/base/nzchar/nzchar.rs
@@ -3,6 +3,7 @@ use crate::rule_set::Rule;
 use crate::utils::node_contains_comments;
 use air_r_syntax::*;
 use biome_rowan::AstNode;
+use oak_core::syntax_ext::RStringValueExt;
 
 /// Version added: 0.5.0
 ///
@@ -52,15 +53,15 @@ pub fn nzchar(ast: &RBinaryExpression) -> anyhow::Result<Option<Diagnostic>> {
     };
 
     let left_is_empty_string = left
-        .to_trimmed_string()
-        .trim_matches('"')
-        .trim_matches('\'')
-        .is_empty();
+        .as_any_r_value()
+        .and_then(|value| value.as_r_string_value())
+        .and_then(|string| string.string_text())
+        .is_some_and(|content| content.is_empty());
     let right_is_empty_string = right
-        .to_trimmed_string()
-        .trim_matches('"')
-        .trim_matches('\'')
-        .is_empty();
+        .as_any_r_value()
+        .and_then(|value| value.as_r_string_value())
+        .and_then(|string| string.string_text())
+        .is_some_and(|content| content.is_empty());
 
     if (left_is_empty_string && right_is_empty_string)
         || (!left_is_empty_string && !right_is_empty_string)

--- a/crates/jarl-core/src/lints/base/nzchar/snapshots/jarl_core__lints__base__nzchar__tests__fix_output.snap
+++ b/crates/jarl-core/src/lints/base/nzchar/snapshots/jarl_core__lints__base__nzchar__tests__fix_output.snap
@@ -1,6 +1,6 @@
 ---
 source: crates/jarl-core/src/lints/base/nzchar/mod.rs
-expression: "get_unsafe_fixed_text(vec![\"x == ''\", \"x != ''\", \"foo(x(y)) == ''\", \"'' == x\",\n\"which(c(a, b, c) == '')\"], \"nzchar\",)"
+expression: "get_unsafe_fixed_text(vec![\"x == ''\", \"x != ''\", r#\"x == r\"()\"\"#,\n\"foo(x(y)) == ''\", \"'' == x\", \"which(c(a, b, c) == '')\"], \"nzchar\",)"
 ---
 OLD:
 ====
@@ -15,6 +15,13 @@ x != ''
 NEW:
 ====
 nzchar(x)
+
+OLD:
+====
+x == r"()"
+NEW:
+====
+!nzchar(x)
 
 OLD:
 ====

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -16,6 +16,8 @@
 
 ### Bug fixes
 
+* Prevent the `nzchar` rule from treating characters like `"'"` as empty strings.
+
 * Prevent the `sample_int` rule from panicking on calls with missing arguments
   (#687, @Yousa-Mirage).
 

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -16,8 +16,8 @@
 
 ### Bug fixes
 
-* Prevent the `nzchar` rule from treating characters like `"'"` as empty strings
-  (#696, @Yousa-Mirage).
+* Prevent the `nzchar` rule from treating quote characters as empty strings and
+  support empty raw string literals (#696, @Yousa-Mirage).
 
 * Prevent the `sample_int` rule from panicking on calls with missing arguments
   (#687, @Yousa-Mirage).

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -16,7 +16,8 @@
 
 ### Bug fixes
 
-* Prevent the `nzchar` rule from treating characters like `"'"` as empty strings.
+* Prevent the `nzchar` rule from treating characters like `"'"` as empty strings
+  (#696, @Yousa-Mirage).
 
 * Prevent the `sample_int` rule from panicking on calls with missing arguments
   (#687, @Yousa-Mirage).


### PR DESCRIPTION
See:

```r
# jarl check test.R --select nzchar

x == "'"  # will report `x == ""`
x != "'"  # will report `x != ""`
x == "''"  # will report `x == ""`
x != "''"  # will report `x != ""`
```

I use `oak_core::syntax_ext::RStringValueExt::string_text()` to get the string contents without surrounding quotes, instead of cleaning quotes manually.

Furthermore, I believe this rule should also check for patterns like `nchar(x) == 0`, consistent with [lintr's `nzchar_linter`](https://lintr.r-lib.org/reference/nzchar_linter.html). I noted your comment at https://github.com/etiennebacher/jarl/pull/406#discussion_r2964881347 stating that *"it's not part of the rule"*, but I feel this is essentially the same issue and that both cases should be replaced with `nzchar()`.

What's your opinion @etiennebacher ?

---

`lintr` checks all comparison expressions here:

```r
comparison_msg_map <- c(
  GT = 'Use nzchar(x) instead of x > "". ',
  NE = 'Use nzchar(x) instead of x != "". ',
  LE = 'Use !nzchar(x) instead of x <= "". ',
  EQ = 'Use !nzchar(x) instead of x == "". ',
  GE = 'x >= "" is always true, maybe you want nzchar(x)? ',
  LT = 'x < "" is always false, maybe you want !nzchar(x)? '
)

nchar_msg_map <- c(
  GT = "Use nzchar(x) instead of nchar(x) > 0. ",
  NE = "Use nzchar(x) instead of nchar(x) != 0. ",
  LE = "Use !nzchar(x) instead of nchar(x) <= 0. ",
  EQ = "Use !nzchar(x) instead of nchar(x) == 0. ",
  GE = "nchar(x) >= 0 is always true, maybe you want nzchar(x)? ",
  LT = "nchar(x) < 0 is always false, maybe you want !nzchar(x)? "
)
```