### PR TITLE
fix: Traverse namespace, extractions, and selector nodes

### DIFF
--- a/crates/jarl-core/src/analyze/expression.rs
+++ b/crates/jarl-core/src/analyze/expression.rs
@@ -1,10 +1,22 @@
 use air_r_syntax::{
-    AnyRExpression, RBinaryExpressionFields, RForStatementFields, RIfStatementFields,
+    AnyRExpression, AnyRSelector, RBinaryExpressionFields, RForStatementFields, RIfStatementFields,
     RWhileStatementFields,
 };
 
 use crate::analyze;
 use crate::checker::Checker;
+
+/// Apply value-level checks to string selectors.
+///
+/// Selectors use a separate AST type because identifiers in `$`, `@`, and
+/// namespace expressions are names rather than ordinary expressions. String
+/// selectors are values and should therefore be passed to the regular value checks.
+fn check_selector(selector: &AnyRSelector, checker: &mut Checker) -> anyhow::Result<()> {
+    if let AnyRSelector::RStringValue(value) = selector {
+        analyze::anyvalue::anyvalue(&value.clone().into(), checker)?;
+    }
+    Ok(())
+}
 
 /// Dispatch an expression to its appropriate set of rules and recurse into children.
 ///
@@ -41,9 +53,7 @@ pub(crate) fn check_expression(
         AnyRExpression::RCall(children) => {
             analyze::call::call(children, checker)?;
 
-            if let Some(ns_expr) = children.function()?.as_r_namespace_expression() {
-                analyze::namespace_expression::namespace_expression(ns_expr, checker)?;
-            }
+            check_expression(&children.function()?, checker)?;
 
             for arg in children.arguments()?.items() {
                 if let Some(expr) = arg?.as_fields().value {
@@ -53,6 +63,7 @@ pub(crate) fn check_expression(
         }
         AnyRExpression::RExtractExpression(children) => {
             check_expression(&children.left()?, checker)?;
+            check_selector(&children.right()?, checker)?;
         }
         AnyRExpression::RForStatement(children) => {
             analyze::for_loop::for_loop(children, checker)?;
@@ -92,6 +103,8 @@ pub(crate) fn check_expression(
         }
         AnyRExpression::RNamespaceExpression(children) => {
             analyze::namespace_expression::namespace_expression(children, checker)?;
+            check_selector(&children.left()?, checker)?;
+            check_selector(&children.right()?, checker)?;
         }
         AnyRExpression::RParenthesizedExpression(children) => {
             analyze::parenthesized_expression::parenthesized_expression(children, checker)?;

--- a/crates/jarl-core/src/analyze/expression.rs
+++ b/crates/jarl-core/src/analyze/expression.rs
@@ -1,22 +1,11 @@
 use air_r_syntax::{
-    AnyRExpression, AnyRSelector, RBinaryExpressionFields, RForStatementFields, RIfStatementFields,
+    AnyRExpression, RBinaryExpressionFields, RForStatementFields, RIfStatementFields,
     RWhileStatementFields,
 };
+use biome_rowan::AstNode;
 
 use crate::analyze;
 use crate::checker::Checker;
-
-/// Apply value-level checks to string selectors.
-///
-/// Selectors use a separate AST type because identifiers in `$`, `@`, and
-/// namespace expressions are names rather than ordinary expressions. String
-/// selectors are values and should therefore be passed to the regular value checks.
-fn check_selector(selector: &AnyRSelector, checker: &mut Checker) -> anyhow::Result<()> {
-    if let AnyRSelector::RStringValue(value) = selector {
-        analyze::anyvalue::anyvalue(&value.clone().into(), checker)?;
-    }
-    Ok(())
-}
 
 /// Dispatch an expression to its appropriate set of rules and recurse into children.
 ///
@@ -63,7 +52,9 @@ pub(crate) fn check_expression(
         }
         AnyRExpression::RExtractExpression(children) => {
             check_expression(&children.left()?, checker)?;
-            check_selector(&children.right()?, checker)?;
+            if let Some(right) = AnyRExpression::cast(children.right()?.into_syntax()) {
+                check_expression(&right, checker)?;
+            }
         }
         AnyRExpression::RForStatement(children) => {
             analyze::for_loop::for_loop(children, checker)?;
@@ -103,8 +94,12 @@ pub(crate) fn check_expression(
         }
         AnyRExpression::RNamespaceExpression(children) => {
             analyze::namespace_expression::namespace_expression(children, checker)?;
-            check_selector(&children.left()?, checker)?;
-            check_selector(&children.right()?, checker)?;
+            if let Some(left) = AnyRExpression::cast(children.left()?.into_syntax()) {
+                check_expression(&left, checker)?;
+            }
+            if let Some(right) = AnyRExpression::cast(children.right()?.into_syntax()) {
+                check_expression(&right, checker)?;
+            }
         }
         AnyRExpression::RParenthesizedExpression(children) => {
             analyze::parenthesized_expression::parenthesized_expression(children, checker)?;

--- a/crates/jarl-core/src/analyze/expression.rs
+++ b/crates/jarl-core/src/analyze/expression.rs
@@ -1,11 +1,22 @@
 use air_r_syntax::{
-    AnyRExpression, RBinaryExpressionFields, RForStatementFields, RIfStatementFields,
-    RWhileStatementFields,
+    AnyRExpression, AnyRSelector, AnyRValue, RBinaryExpressionFields, RForStatementFields,
+    RIfStatementFields, RWhileStatementFields,
 };
-use biome_rowan::AstNode;
 
 use crate::analyze;
 use crate::checker::Checker;
+
+/// Convert a selector to the equivalent expression.
+///
+/// This allows better code coverage than `if let Some(...) = AnyRExpression::cast(...)`
+fn selector_to_expression(selector: AnyRSelector) -> AnyRExpression {
+    match selector {
+        AnyRSelector::RDotDotI(x) => AnyRExpression::RDotDotI(x),
+        AnyRSelector::RDots(x) => AnyRExpression::RDots(x),
+        AnyRSelector::RIdentifier(x) => AnyRExpression::RIdentifier(x),
+        AnyRSelector::RStringValue(x) => AnyRExpression::AnyRValue(AnyRValue::RStringValue(x)),
+    }
+}
 
 /// Dispatch an expression to its appropriate set of rules and recurse into children.
 ///
@@ -52,9 +63,7 @@ pub(crate) fn check_expression(
         }
         AnyRExpression::RExtractExpression(children) => {
             check_expression(&children.left()?, checker)?;
-            if let Some(right) = AnyRExpression::cast(children.right()?.into_syntax()) {
-                check_expression(&right, checker)?;
-            }
+            check_expression(&selector_to_expression(children.right()?), checker)?;
         }
         AnyRExpression::RForStatement(children) => {
             analyze::for_loop::for_loop(children, checker)?;
@@ -94,12 +103,8 @@ pub(crate) fn check_expression(
         }
         AnyRExpression::RNamespaceExpression(children) => {
             analyze::namespace_expression::namespace_expression(children, checker)?;
-            if let Some(left) = AnyRExpression::cast(children.left()?.into_syntax()) {
-                check_expression(&left, checker)?;
-            }
-            if let Some(right) = AnyRExpression::cast(children.right()?.into_syntax()) {
-                check_expression(&right, checker)?;
-            }
+            check_expression(&selector_to_expression(children.left()?), checker)?;
+            check_expression(&selector_to_expression(children.right()?), checker)?;
         }
         AnyRExpression::RParenthesizedExpression(children) => {
             analyze::parenthesized_expression::parenthesized_expression(children, checker)?;

--- a/crates/jarl-core/src/lints/base/quotes/mod.rs
+++ b/crates/jarl-core/src/lints/base/quotes/mod.rs
@@ -100,6 +100,48 @@ mod tests {
     }
 
     #[test]
+    fn test_quotes_in_extract_and_call_function() {
+        assert_snapshot!(
+            snapshot_lint(
+                "df$'col'\ndf@'slot'\npkg::'fn'()\n('fn')()\n(function() 'body')()"
+            ),
+            @"
+        warning: quotes
+         --> <test>:1:4
+          |
+        1 | df$'col'
+          |    ----- Prefer double quotes for string delimiters.
+          |
+        warning: quotes
+         --> <test>:2:4
+          |
+        2 | df@'slot'
+          |    ------ Prefer double quotes for string delimiters.
+          |
+        warning: quotes
+         --> <test>:3:6
+          |
+        3 | pkg::'fn'()
+          |      ---- Prefer double quotes for string delimiters.
+          |
+        warning: quotes
+         --> <test>:4:2
+          |
+        4 | ('fn')()
+          |  ---- Prefer double quotes for string delimiters.
+          |
+        warning: quotes
+         --> <test>:5:13
+          |
+        5 | (function() 'body')()
+          |             ------ Prefer double quotes for string delimiters.
+          |
+        Found 5 errors.
+        "
+        );
+    }
+
+    #[test]
     fn test_quotes_single_quote_allows_needed_and_preferred_forms() {
         let settings = settings_with_options(QuotesOptions { quote: Some("single".to_string()) });
 

--- a/crates/jarl-core/src/lints/base/quotes/mod.rs
+++ b/crates/jarl-core/src/lints/base/quotes/mod.rs
@@ -103,37 +103,42 @@ mod tests {
     fn test_quotes_in_extract_and_call_function() {
         assert_snapshot!(
             snapshot_lint(
-                "df$'col'\ndf@'slot'\npkg::'fn'()\n('fn')()\n(function() 'body')()"
+                "
+df$'col'
+df@'slot'
+pkg::'fn'()
+('fn')()
+(function() 'body')()"
             ),
             @"
         warning: quotes
-         --> <test>:1:4
+         --> <test>:2:4
           |
-        1 | df$'col'
+        2 | df$'col'
           |    ----- Prefer double quotes for string delimiters.
           |
         warning: quotes
-         --> <test>:2:4
+         --> <test>:3:4
           |
-        2 | df@'slot'
+        3 | df@'slot'
           |    ------ Prefer double quotes for string delimiters.
           |
         warning: quotes
-         --> <test>:3:6
+         --> <test>:4:6
           |
-        3 | pkg::'fn'()
+        4 | pkg::'fn'()
           |      ---- Prefer double quotes for string delimiters.
           |
         warning: quotes
-         --> <test>:4:2
+         --> <test>:5:2
           |
-        4 | ('fn')()
+        5 | ('fn')()
           |  ---- Prefer double quotes for string delimiters.
           |
         warning: quotes
-         --> <test>:5:13
+         --> <test>:6:13
           |
-        5 | (function() 'body')()
+        6 | (function() 'body')()
           |             ------ Prefer double quotes for string delimiters.
           |
         Found 5 errors.

--- a/crates/jarl-core/src/lints/base/true_false_symbol/mod.rs
+++ b/crates/jarl-core/src/lints/base/true_false_symbol/mod.rs
@@ -52,6 +52,9 @@ mod tests {
         expect_no_lint("mtcars$F", "true_false_symbol", None);
         expect_no_lint("mtcars$T", "true_false_symbol", None);
         expect_no_lint("T$F", "true_false_symbol", None);
+        expect_no_lint("pkg::T", "true_false_symbol", None);
+        expect_no_lint("pkg:::F", "true_false_symbol", None);
+        expect_no_lint("T::foo", "true_false_symbol", None);
     }
 
     #[test]

--- a/crates/jarl-core/src/lints/base/true_false_symbol/true_false_symbol.rs
+++ b/crates/jarl-core/src/lints/base/true_false_symbol/true_false_symbol.rs
@@ -74,11 +74,13 @@ pub fn true_false_symbol(
         }
     }
 
-    // Allow `T[1]`, `F[[1]]`, `df$T`, and `obj@F`, where `T` and `F` are
-    // object, column, or slot names rather than logical values.
+    // Allow `T[1]`, `F[[1]]`, `df$T`, `obj@F`, and `pkg::T`, where `T` and `F`
+    // are object, column, slot, or namespace member names rather than logical
+    // values.
     if ast.parent::<RSubset>().is_some()
         || ast.parent::<RSubset2>().is_some()
         || ast.parent::<RExtractExpression>().is_some()
+        || ast.parent::<RNamespaceExpression>().is_some()
     {
         return Ok(None);
     }

--- a/crates/jarl/tests/integration/edge_cases.rs
+++ b/crates/jarl/tests/integration/edge_cases.rs
@@ -182,3 +182,43 @@ any(is.na("数据"))
 
     Ok(())
 }
+
+// `...` and `..i` are selector kinds of `$`, `@`, `::` and `:::` on which no
+// rule fires, so they must traverse silently. The identifier and string
+// selectors are covered by the `true_false_symbol` and `quotes` unit tests.
+#[test]
+fn test_jarl_supports_dots_selectors() -> anyhow::Result<()> {
+    let case = CliTest::with_file(
+        "test.R",
+        r#"
+f <- function(...) {
+    x$...
+    x$..1
+    x@...
+    x@..1
+    pkg::...
+}
+"#,
+    )?;
+
+    insta::assert_snapshot!(
+        &mut case
+            .command()
+            .arg("check")
+            .arg(".")
+            .run()
+            .normalize_os_executable_name(),
+        @"
+
+    success: true
+    exit_code: 0
+    ----- stdout -----
+    ── Summary ──────────────────────────────────────
+    All checks passed!
+
+    ----- stderr -----
+    "
+    );
+
+    Ok(())
+}

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -16,6 +16,9 @@
 
 ### Bug fixes
 
+* The `quotes` rule now checks strings used as extract and call selectors
+  (#697, @Yousa-Mirage).
+
 * Prevent the `sample_int` rule from panicking on calls with missing arguments
   (#687, @Yousa-Mirage).
 

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -16,8 +16,8 @@
 
 ### Bug fixes
 
-* The `quotes` rule now checks strings used as extract and call selectors
-  (#697, @Yousa-Mirage).
+* Jarl now properly checks the components of selector, extraction, and namespace
+  AST nodes (`[[`, `@`, `$`, `::`, `:::`) (#697, @Yousa-Mirage).
 
 * Prevent the `sample_int` rule from panicking on calls with missing arguments
   (#687, @Yousa-Mirage).


### PR DESCRIPTION
See:

```r
# jarl check test.R --select quotes

df['col']
foo('arg')
df$'col'  # No lint
df@'slot'  # No lint
pkg::'fn'()  # No lint
('fn')()  # No lint
(function() 'body')()  # No lint
```

The expression walker skipped extract and call-position subtrees, so quoted selectors were never passed to the `quotes` rule.