### PR TITLE
fix: Guard `string_boundary` fixes against mismatched widths

### DIFF
--- a/crates/jarl-core/src/lints/base/string_boundary/mod.rs
+++ b/crates/jarl-core/src/lints/base/string_boundary/mod.rs
@@ -54,6 +54,61 @@ mod tests {
         //   substring(s <- "abcdefg", 2L) == "efg" is not TRUE, but endsWith(s, "efg")
         //   is. And if `s` contains strings of varying lengths, there's no equivalent.
         expect_no_lint("substring(x, 2L)", "string_boundary", None);
+
+        for code in [
+            "substr(x, 1, 2) == 'a'",
+            "substr(x, 1, 1) == 'ab'",
+            "substr(x, 1, 2) != 'a'",
+            "'a' == substr(x, 1, 2)",
+            "'a' != substr(x, 1, 2)",
+            "substr(x, 1, nchar(x)) == 'a'",
+            "substr(x, 1L, end) == 'ab'",
+            "substr(x, 1L, end) != 'ab'",
+            "'ab' == substr(x, 1L, end)",
+            "substr(x, 3, nchar(x)) != 'ab'",
+            "substring(x, start, nchar(x)) == 'abcde'",
+            "substring(colnames(x), start, nchar(colnames(x))) == 'abc'",
+            "substring(x, nchar(x) - 1, nchar(x)) == 'b'",
+            "substring(x, nchar(x) - 1, nchar(x)) != 'b'",
+            "substr(x, nchar(x), nchar(x)) == 'ab'",
+            "substring(x, nchar(x) - 2, nchar(x)) == 'ab'",
+            "substring(x, nchar(y) - 1, nchar(x)) == 'ab'",
+            "substring(x, nchar(x) + 1, nchar(x)) == 'ab'",
+            "substring(x, nchar(x) - offset, nchar(x)) == 'ab'",
+            "substring(x, nchar(x, type = 'bytes') - 1, nchar(x)) == 'ab'",
+            "substring(x, nchar(x) - 1, nchar(x, type = 'bytes')) == 'ab'",
+            "substring(x, nchar(allowNA = x) - 1, nchar(allowNA = x)) == 'ab'",
+            "substr(x, 1, 1) == ''",
+            "substr(x, 1, 1) == r\"()\"",
+            "substr(x, 1, 1) == pattern",
+            "substr(x, 1, 1) == 1",
+            "substr(c('abc', 'def'), 1, 1) == c('a', 'a')",
+            "substr(x, 1, 3) == '你'",
+            "substring(x, nchar(x) - 2, nchar(x)) == '你'",
+            r#"substr(x, 1, 6) == "\u4f60""#,
+            r#"substr(x, 1, 1) == "\u4f60""#,
+            r#"substr(x, 1, 2) == "\n""#,
+            r#"substr(x, 1, 1) == "\n""#,
+            r#"substr(x, 1, 3) == r"(你)""#,
+            "substr(x, 1, 0) == 'a'",
+            "substr(x, 1, -1) == 'a'",
+            "substr(x, 1, 1.5) == 'a'",
+            "substr(x, 1, 1e100) == 'a'",
+            "substr(x, 1, 0x2) == 'ab'",
+            "substr(x, 1, 2147483648L) == 'a'",
+            "substr(x, 1, 9999999999999999999999999999999999999999) == 'a'",
+            "substr(x, stop = 1, start = 2) == 'ab'",
+            "substring(x, last = 1, first = 2) == 'ab'",
+            "substr(x, 1, 2, extra = 3) == 'ab'",
+            "substr(x, 1, 2,) == 'ab'",
+            "substr(x, 1,) == 'ab'",
+            "substr(, 1, 2) == 'ab'",
+            "substr(x, start = 1, start = 2) == 'ab'",
+            "substr(x, first = 1, stop = 2) == 'ab'",
+            "substr(x, sta = 1, sto = 2) == 'ab'",
+        ] {
+            expect_no_lint(code, "string_boundary", None);
+        }
     }
 
     #[test]
@@ -84,66 +139,8 @@ mod tests {
         Found 1 error.
         "
         );
-        // end doesn't matter, just anchoring to 1L
         assert_snapshot!(
-            snapshot_lint("substr(x, 1L, end) == 'ab'"),
-            @"
-        warning: string_boundary
-         --> <test>:1:1
-          |
-        1 | substr(x, 1L, end) == 'ab'
-          | -------------------------- Using `substr()` to detect an initial substring is hard to read and inefficient.
-          |
-          = help: Use `startsWith()` instead.
-        Found 1 error.
-        "
-        );
-        // != operator also works
-        assert_snapshot!(
-            snapshot_lint("substr(x, 1L, end) != 'ab'"),
-            @"
-        warning: string_boundary
-         --> <test>:1:1
-          |
-        1 | substr(x, 1L, end) != 'ab'
-          | -------------------------- Using `substr()` to detect an initial substring is hard to read and inefficient.
-          |
-          = help: Use `startsWith()` instead.
-        Found 1 error.
-        "
-        );
-        assert_snapshot!(
-            snapshot_lint("substr(x, 3, nchar(x)) != 'ab'"),
-            @"
-        warning: string_boundary
-         --> <test>:1:1
-          |
-        1 | substr(x, 3, nchar(x)) != 'ab'
-          | ------------------------------ Using `substr()` to detect a terminal substring is hard to read and inefficient.
-          |
-          = help: Use `endsWith()` instead.
-        Found 1 error.
-        "
-        );
-        // Works in the other direction
-        assert_snapshot!(
-            snapshot_lint("'ab' == substr(x, 1L, end)"),
-            @"
-        warning: string_boundary
-         --> <test>:1:1
-          |
-        1 | 'ab' == substr(x, 1L, end)
-          | -------------------------- Using `substr()` to detect an initial substring is hard to read and inefficient.
-          |
-          = help: Use `startsWith()` instead.
-        Found 1 error.
-        "
-        );
-
-        assert_snapshot!(
-
             snapshot_lint("substring(x, nchar(x) - 4L, nchar(x)) == 'abcde'"),
-
             @"
         warning: string_boundary
          --> <test>:1:1
@@ -155,66 +152,73 @@ mod tests {
         Found 1 error.
         "
         );
-        // start doesn't matter, just anchoring to nchar(x)
-        assert_snapshot!(
-            snapshot_lint("substring(x, start, nchar(x)) == 'abcde'"),
-            @"
-        warning: string_boundary
-         --> <test>:1:1
-          |
-        1 | substring(x, start, nchar(x)) == 'abcde'
-          | ---------------------------------------- Using `substring()` to detect a terminal substring is hard to read and inefficient.
-          |
-          = help: Use `endsWith()` instead.
-        Found 1 error.
-        "
-        );
-        // more complicated expressions
-        assert_snapshot!(
-            snapshot_lint("substring(colnames(x), start, nchar(colnames(x))) == 'abc'"),
-            @"
-        warning: string_boundary
-         --> <test>:1:1
-          |
-        1 | substring(colnames(x), start, nchar(colnames(x))) == 'abc'
-          | ---------------------------------------------------------- Using `substring()` to detect a terminal substring is hard to read and inefficient.
-          |
-          = help: Use `endsWith()` instead.
-        Found 1 error.
-        "
-        );
-        // comparing vectors
-        assert_snapshot!(
-            snapshot_lint("substr(c('abc', 'def'), 1, 1) == c('a', 'a')"),
-            @"
-        warning: string_boundary
-         --> <test>:1:1
-          |
-        1 | substr(c('abc', 'def'), 1, 1) == c('a', 'a')
-          | -------------------------------------------- Using `substr()` to detect an initial substring is hard to read and inefficient.
-          |
-          = help: Use `startsWith()` instead.
-        Found 1 error.
-        "
-        );
-
         assert_snapshot!(
             "fix_output",
-            get_fixed_text(
+            get_unsafe_fixed_text(
                 vec![
                     "substr(x, 1, 2) == 'ab'",
                     "substr(x, 1L, 2L) == 'ab'",
-                    "substr(x, 1L, end) == 'ab'",
-                    "substr(x, 1L, end) != 'ab'",
-                    "substr(x, 3, nchar(x)) != 'ab'",
-                    "'ab' == substr(x, 1L, end)",
+                    "substr(x, 1.0, 2.0) == 'ab'",
+                    "substr(x, 1., 2e0) == 'ab'",
+                    "substr(x, 1L, 2L) != 'ab'",
+                    "'ab' == substr(x, 1L, 2L)",
+                    "'ab' != substr(x, 1L, 2L)",
+                    "substring(x, 1, 2) == 'ab'",
+                    "substr(stop = 2, x = x, start = 1) == 'ab'",
+                    "substr(stop = 2, x, 1) == 'ab'",
+                    "substring(last = 2, text = x, first = 1) == 'ab'",
                     "substring(x, nchar(x) - 4L, nchar(x)) == 'abcde'",
-                    "substring(x, start, nchar(x)) == 'abcde'",
-                    "substring(colnames(x), start, nchar(colnames(x))) == 'abc'",
-                    "substr(c('abc', 'def'), 1, 1) == c('a', 'a')",
+                    "substr(x, nchar(x) - 1, nchar(x)) != 'ab'",
+                    "'ab' == substring(x, nchar(x) - 1, nchar(x))",
+                    "'ab' != substring(x, nchar(x) - 1, nchar(x))",
+                    "substr(x, nchar(x), nchar(x)) == 'a'",
+                    "substring(x, nchar(x) - 0L, nchar(x)) == 'a'",
+                    "substring(x, nchar(x = x) - 1, nchar(x = x)) == 'ab'",
+                    "substring(colnames(x), nchar(colnames(x)) - 2, nchar(colnames(x))) == 'abc'",
+                    "substr(x, 1, 1) == '你'",
+                    "substring(x, nchar(x) - 1, nchar(x)) == '你好'",
+                    "substr(x, 1, 2) == 'a '",
+                    "substr(x, 1, 1) == ' '",
+                    r#"substr(x, 1, 1) == r"(你)""#,
+                    r#"substring(x, nchar(x), nchar(x)) == R'---[你]---'"#,
+                    r#"substr(x, 1, 2) == r"(\n)""#,
+                ],
+                "string_boundary"
+            )
+        );
+    }
+
+    #[test]
+    fn test_string_boundary_requires_unsafe_fixes() {
+        assert_snapshot!(
+            "safe_fix_output",
+            get_fixed_text(
+                vec![
+                    "substr(x, 1, 2) == 'ab'",
+                    "substring(x, nchar(x) - 1, nchar(x)) == 'ab'",
                 ],
                 "string_boundary",
                 None
+            )
+        );
+    }
+
+    #[test]
+    fn test_string_boundary_mismatched_width_no_fix() {
+        assert_snapshot!(
+            "no_fix_mismatched_width",
+            get_unsafe_fixed_text(
+                vec![
+                    "substr(x, 1, 2) == 'a'",
+                    "substr(x, 1, 1) != 'ab'",
+                    "substring(x, nchar(x) - 1, nchar(x)) == 'b'",
+                    "substr(x, nchar(x), nchar(x)) == 'ab'",
+                    "substr(x, 1, end) == 'ab'",
+                    "substring(x, start, nchar(x)) == 'ab'",
+                    "substr(x, stop = 1, start = 2) == 'ab'",
+                    r#"substr(x, 1, 6) == "\u4f60""#,
+                ],
+                "string_boundary"
             )
         );
     }
@@ -239,14 +243,13 @@ mod tests {
         );
         assert_snapshot!(
             "no_fix_with_comments",
-            get_fixed_text(
+            get_unsafe_fixed_text(
                 vec![
                     "# leading comment\nsubstr(x, 1, 2) == 'ab'",
                     "substr(x, \n # a comment \n1, 2) == 'ab'",
                     "substr(x, 1, 2) == 'ab' # trailing comment",
                 ],
-                "string_boundary",
-                None
+                "string_boundary"
             )
         );
     }

--- a/crates/jarl-core/src/lints/base/string_boundary/snapshots/jarl_core__lints__base__string_boundary__tests__fix_output.snap
+++ b/crates/jarl-core/src/lints/base/string_boundary/snapshots/jarl_core__lints__base__string_boundary__tests__fix_output.snap
@@ -1,6 +1,6 @@
 ---
 source: crates/jarl-core/src/lints/base/string_boundary/mod.rs
-expression: "get_fixed_text(vec![\"substr(x, 1, 2) == 'ab'\", \"substr(x, 1L, 2L) == 'ab'\",\n\"substr(x, 1L, end) == 'ab'\", \"substr(x, 1L, end) != 'ab'\",\n\"substr(x, 3, nchar(x)) != 'ab'\", \"'ab' == substr(x, 1L, end)\",\n\"substring(x, nchar(x) - 4L, nchar(x)) == 'abcde'\",\n\"substring(x, start, nchar(x)) == 'abcde'\",\n\"substring(colnames(x), start, nchar(colnames(x))) == 'abc'\",\n\"substr(c('abc', 'def'), 1, 1) == c('a', 'a')\",], \"string_boundary\", None)"
+expression: "get_unsafe_fixed_text(vec![\"substr(x, 1, 2) == 'ab'\",\n\"substr(x, 1L, 2L) == 'ab'\", \"substr(x, 1.0, 2.0) == 'ab'\",\n\"substr(x, 1., 2e0) == 'ab'\", \"substr(x, 1L, 2L) != 'ab'\",\n\"'ab' == substr(x, 1L, 2L)\", \"'ab' != substr(x, 1L, 2L)\",\n\"substring(x, 1, 2) == 'ab'\", \"substr(stop = 2, x = x, start = 1) == 'ab'\",\n\"substr(stop = 2, x, 1) == 'ab'\",\n\"substring(last = 2, text = x, first = 1) == 'ab'\",\n\"substring(x, nchar(x) - 4L, nchar(x)) == 'abcde'\",\n\"substr(x, nchar(x) - 1, nchar(x)) != 'ab'\",\n\"'ab' == substring(x, nchar(x) - 1, nchar(x))\",\n\"'ab' != substring(x, nchar(x) - 1, nchar(x))\",\n\"substr(x, nchar(x), nchar(x)) == 'a'\",\n\"substring(x, nchar(x) - 0L, nchar(x)) == 'a'\",\n\"substring(x, nchar(x = x) - 1, nchar(x = x)) == 'ab'\",\n\"substring(colnames(x), nchar(colnames(x)) - 2, nchar(colnames(x))) == 'abc'\",\n\"substr(x, 1, 1) == '你'\",\n\"substring(x, nchar(x) - 1, nchar(x)) == '你好'\", \"substr(x, 1, 2) == 'a '\",\n\"substr(x, 1, 1) == ' '\", r#\"substr(x, 1, 1) == r\"(你)\"\"#,\nr#\"substring(x, nchar(x), nchar(x)) == R'---[你]---'\"#,\nr#\"substr(x, 1, 2) == r\"(\\n)\"\"#,], \"string_boundary\")"
 ---
 OLD:
 ====
@@ -18,28 +18,63 @@ startsWith(x, 'ab')
 
 OLD:
 ====
-substr(x, 1L, end) == 'ab'
+substr(x, 1.0, 2.0) == 'ab'
 NEW:
 ====
 startsWith(x, 'ab')
 
 OLD:
 ====
-substr(x, 1L, end) != 'ab'
+substr(x, 1., 2e0) == 'ab'
+NEW:
+====
+startsWith(x, 'ab')
+
+OLD:
+====
+substr(x, 1L, 2L) != 'ab'
 NEW:
 ====
 !startsWith(x, 'ab')
 
 OLD:
 ====
-substr(x, 3, nchar(x)) != 'ab'
+'ab' == substr(x, 1L, 2L)
 NEW:
 ====
-!endsWith(x, 'ab')
+startsWith(x, 'ab')
 
 OLD:
 ====
-'ab' == substr(x, 1L, end)
+'ab' != substr(x, 1L, 2L)
+NEW:
+====
+!startsWith(x, 'ab')
+
+OLD:
+====
+substring(x, 1, 2) == 'ab'
+NEW:
+====
+startsWith(x, 'ab')
+
+OLD:
+====
+substr(stop = 2, x = x, start = 1) == 'ab'
+NEW:
+====
+startsWith(x, 'ab')
+
+OLD:
+====
+substr(stop = 2, x, 1) == 'ab'
+NEW:
+====
+startsWith(x, 'ab')
+
+OLD:
+====
+substring(last = 2, text = x, first = 1) == 'ab'
 NEW:
 ====
 startsWith(x, 'ab')
@@ -53,21 +88,98 @@ endsWith(x, 'abcde')
 
 OLD:
 ====
-substring(x, start, nchar(x)) == 'abcde'
+substr(x, nchar(x) - 1, nchar(x)) != 'ab'
 NEW:
 ====
-endsWith(x, 'abcde')
+!endsWith(x, 'ab')
 
 OLD:
 ====
-substring(colnames(x), start, nchar(colnames(x))) == 'abc'
+'ab' == substring(x, nchar(x) - 1, nchar(x))
+NEW:
+====
+endsWith(x, 'ab')
+
+OLD:
+====
+'ab' != substring(x, nchar(x) - 1, nchar(x))
+NEW:
+====
+!endsWith(x, 'ab')
+
+OLD:
+====
+substr(x, nchar(x), nchar(x)) == 'a'
+NEW:
+====
+endsWith(x, 'a')
+
+OLD:
+====
+substring(x, nchar(x) - 0L, nchar(x)) == 'a'
+NEW:
+====
+endsWith(x, 'a')
+
+OLD:
+====
+substring(x, nchar(x = x) - 1, nchar(x = x)) == 'ab'
+NEW:
+====
+endsWith(x, 'ab')
+
+OLD:
+====
+substring(colnames(x), nchar(colnames(x)) - 2, nchar(colnames(x))) == 'abc'
 NEW:
 ====
 endsWith(colnames(x), 'abc')
 
 OLD:
 ====
-substr(c('abc', 'def'), 1, 1) == c('a', 'a')
+substr(x, 1, 1) == '你'
 NEW:
 ====
-startsWith(c('abc', 'def'), c('a', 'a'))
+startsWith(x, '你')
+
+OLD:
+====
+substring(x, nchar(x) - 1, nchar(x)) == '你好'
+NEW:
+====
+endsWith(x, '你好')
+
+OLD:
+====
+substr(x, 1, 2) == 'a '
+NEW:
+====
+startsWith(x, 'a ')
+
+OLD:
+====
+substr(x, 1, 1) == ' '
+NEW:
+====
+startsWith(x, ' ')
+
+OLD:
+====
+substr(x, 1, 1) == r"(你)"
+NEW:
+====
+startsWith(x, r"(你)")
+
+OLD:
+====
+substring(x, nchar(x), nchar(x)) == R'---[你]---'
+NEW:
+====
+endsWith(x, R'---[你]---')
+
+OLD:
+====
+substr(x, 1, 2) == r"(\n)"
+NEW:
+====
+startsWith(x, r"(\n)")

--- a/crates/jarl-core/src/lints/base/string_boundary/snapshots/jarl_core__lints__base__string_boundary__tests__no_fix_mismatched_width.snap
+++ b/crates/jarl-core/src/lints/base/string_boundary/snapshots/jarl_core__lints__base__string_boundary__tests__no_fix_mismatched_width.snap
@@ -1,0 +1,59 @@
+---
+source: crates/jarl-core/src/lints/base/string_boundary/mod.rs
+expression: "get_unsafe_fixed_text(vec![\"substr(x, 1, 2) == 'a'\",\n\"substr(x, 1, 1) != 'ab'\", \"substring(x, nchar(x) - 1, nchar(x)) == 'b'\",\n\"substr(x, nchar(x), nchar(x)) == 'ab'\", \"substr(x, 1, end) == 'ab'\",\n\"substring(x, start, nchar(x)) == 'ab'\",\n\"substr(x, stop = 1, start = 2) == 'ab'\", r#\"substr(x, 1, 6) == \"\\u4f60\"\"#,],\n\"string_boundary\")"
+---
+OLD:
+====
+substr(x, 1, 2) == 'a'
+NEW:
+====
+substr(x, 1, 2) == 'a'
+
+OLD:
+====
+substr(x, 1, 1) != 'ab'
+NEW:
+====
+substr(x, 1, 1) != 'ab'
+
+OLD:
+====
+substring(x, nchar(x) - 1, nchar(x)) == 'b'
+NEW:
+====
+substring(x, nchar(x) - 1, nchar(x)) == 'b'
+
+OLD:
+====
+substr(x, nchar(x), nchar(x)) == 'ab'
+NEW:
+====
+substr(x, nchar(x), nchar(x)) == 'ab'
+
+OLD:
+====
+substr(x, 1, end) == 'ab'
+NEW:
+====
+substr(x, 1, end) == 'ab'
+
+OLD:
+====
+substring(x, start, nchar(x)) == 'ab'
+NEW:
+====
+substring(x, start, nchar(x)) == 'ab'
+
+OLD:
+====
+substr(x, stop = 1, start = 2) == 'ab'
+NEW:
+====
+substr(x, stop = 1, start = 2) == 'ab'
+
+OLD:
+====
+substr(x, 1, 6) == "\u4f60"
+NEW:
+====
+substr(x, 1, 6) == "\u4f60"

--- a/crates/jarl-core/src/lints/base/string_boundary/snapshots/jarl_core__lints__base__string_boundary__tests__safe_fix_output.snap
+++ b/crates/jarl-core/src/lints/base/string_boundary/snapshots/jarl_core__lints__base__string_boundary__tests__safe_fix_output.snap
@@ -1,0 +1,17 @@
+---
+source: crates/jarl-core/src/lints/base/string_boundary/mod.rs
+expression: "get_fixed_text(vec![\"substr(x, 1, 2) == 'ab'\",\n\"substring(x, nchar(x) - 1, nchar(x)) == 'ab'\",], \"string_boundary\", None)"
+---
+OLD:
+====
+substr(x, 1, 2) == 'ab'
+NEW:
+====
+substr(x, 1, 2) == 'ab'
+
+OLD:
+====
+substring(x, nchar(x) - 1, nchar(x)) == 'ab'
+NEW:
+====
+substring(x, nchar(x) - 1, nchar(x)) == 'ab'

--- a/crates/jarl-core/src/lints/base/string_boundary/string_boundary.rs
+++ b/crates/jarl-core/src/lints/base/string_boundary/string_boundary.rs
@@ -1,8 +1,9 @@
 use crate::diagnostic::*;
 use crate::rule_set::Rule;
-use crate::utils::{get_function_name, node_contains_comments};
+use crate::utils::{Formals, get_arg, get_function_name, node_contains_comments};
 use air_r_syntax::*;
-use biome_rowan::AstNode;
+use biome_rowan::{AstNode, AstSeparatedList};
+use oak_core::syntax_ext::RStringValueExt;
 
 /// Version added: 0.3.0
 ///
@@ -10,13 +11,17 @@ use biome_rowan::AstNode;
 ///
 /// Checks for `substr()` and `substring()` calls that can be replaced with
 /// `startsWith()` or `endsWith()`.
+/// Only comparisons to non-empty string literals with matching substring
+/// boundaries are reported. Ordinary strings containing escapes are skipped.
 ///
 /// ## Why is this bad?
 ///
 /// Using `startsWith()` and `endsWith()` is both more readable and more efficient
 /// than extracting substrings and comparing them.
 ///
-/// This rule has a safe fix.
+/// This rule has an unsafe fix because the replacement can drop names and other
+/// attributes, no longer coerces non-character inputs, and may evaluate repeated
+/// expressions fewer times.
 ///
 /// ## Example
 ///
@@ -64,30 +69,28 @@ pub fn string_boundary(ast: &RBinaryExpression) -> anyhow::Result<Option<Diagnos
         return Ok(None);
     }
 
-    // Get arguments
-    let arguments = call.arguments()?;
-    let args: Vec<_> = arguments
-        .items()
-        .into_iter()
-        .filter_map(|a| a.ok())
-        .collect();
-
-    // Need at least 3 arguments (x, start, end)
-    if args.len() < 3 {
+    if call.arguments()?.items().len() != 3 {
         return Ok(None);
     }
 
-    // Extract the expression values from arguments
-    let x_arg = unwrap_or_return_none!(args[0].value());
-    let start_arg = unwrap_or_return_none!(args[1].value());
-    let end_arg = unwrap_or_return_none!(args[2].value());
+    let formals: Formals = if func_name == "substr" {
+        &["x", "start", "stop"]
+    } else {
+        &["text", "first", "last"]
+    };
+    let x_arg =
+        unwrap_or_return_none!(get_arg(call, formals, formals[0]).and_then(|arg| arg.value()));
+    let start_arg =
+        unwrap_or_return_none!(get_arg(call, formals, formals[1]).and_then(|arg| arg.value()));
+    let end_arg =
+        unwrap_or_return_none!(get_arg(call, formals, formals[2]).and_then(|arg| arg.value()));
+    let width = unwrap_or_return_none!(literal_string_length(string_expr));
 
     // Get the string being compared
     let string_text = string_expr.syntax().text_trimmed();
     let x_text = x_arg.syntax().text_trimmed();
 
-    // Check for startsWith pattern: start position is 1 or 1L
-    if is_literal_one(&start_arg) {
+    if literal_integer(&start_arg) == Some(1) && literal_integer(&end_arg) == Some(width) {
         let range = ast.syntax().text_trimmed_range();
 
         // Build the replacement: startsWith(x, "string") or !startsWith(x, "string")
@@ -111,8 +114,7 @@ pub fn string_boundary(ast: &RBinaryExpression) -> anyhow::Result<Option<Diagnos
         return Ok(Some(diagnostic));
     }
 
-    // Check for endsWith pattern: end position is nchar(x) where x is the same as the first arg
-    if is_nchar_of_same_expr(&end_arg, &x_arg) {
+    if is_nchar_of_same_expr(&end_arg, &x_arg) && is_suffix_start(&start_arg, &x_arg, width) {
         let range = ast.syntax().text_trimmed_range();
 
         // Build the replacement: endsWith(x, "string") or !endsWith(x, "string")
@@ -139,26 +141,50 @@ pub fn string_boundary(ast: &RBinaryExpression) -> anyhow::Result<Option<Diagnos
     Ok(None)
 }
 
-/// Check if an expression is the literal value 1 or 1L
-fn is_literal_one(expr: &AnyRExpression) -> bool {
-    // Check if it's an AnyRValue (numeric literal)
-    if let Some(r_value) = expr.as_any_r_value() {
-        // Check for integer value
-        if let Some(int) = r_value.as_r_integer_value()
-            && let Ok(token) = int.value_token()
-        {
-            let text = token.text_trimmed();
-            return text == "1" || text == "1L" || text == "1l";
-        }
-        // Check for double value
-        if let Some(double) = r_value.as_r_double_value()
-            && let Ok(token) = double.value_token()
-        {
-            let text = token.text_trimmed();
-            return text == "1" || text == "1.0" || text == "1.";
-        }
+fn literal_string_length(expr: &AnyRExpression) -> Option<usize> {
+    let string = expr.as_any_r_value()?.as_r_string_value()?;
+    let content = string.string_text()?;
+    let open = string.open_token().ok()?;
+    let is_raw = open.text_trimmed().starts_with(['r', 'R']);
+
+    // Token contents retain escapes, whose source length differs from R's nchar().
+    if content.is_empty() || (!is_raw && content.contains('\\')) {
+        return None;
     }
-    false
+    Some(content.chars().count())
+}
+
+fn literal_integer(expr: &AnyRExpression) -> Option<usize> {
+    let token = match expr.as_any_r_value()? {
+        AnyRValue::RIntegerValue(value) => value.value_token().ok()?,
+        AnyRValue::RDoubleValue(value) => value.value_token().ok()?,
+        _ => return None,
+    };
+    let value = token
+        .text_trimmed()
+        .trim_end_matches('L')
+        .parse::<f64>()
+        .ok()?;
+    // Substring indices are coerced to R integers; reject fractions and overflow.
+    (value >= 0.0 && value <= f64::from(i32::MAX) && value.fract() == 0.0).then_some(value as usize)
+}
+
+fn is_suffix_start(start: &AnyRExpression, x: &AnyRExpression, width: usize) -> bool {
+    if width == 1 && is_nchar_of_same_expr(start, x) {
+        return true;
+    }
+    let Some(binary) = start.as_r_binary_expression() else {
+        return false;
+    };
+    binary
+        .operator()
+        .is_ok_and(|op| op.kind() == RSyntaxKind::MINUS)
+        && binary
+            .left()
+            .is_ok_and(|left| is_nchar_of_same_expr(&left, x))
+        && binary
+            .right()
+            .is_ok_and(|right| literal_integer(&right) == width.checked_sub(1))
 }
 
 /// Check if end_expr is nchar(x_expr) where x_expr matches the first argument
@@ -186,18 +212,12 @@ fn is_nchar_of_same_expr(end_expr: &AnyRExpression, x_expr: &AnyRExpression) -> 
         _ => return false,
     };
 
-    let args: Vec<_> = arguments
-        .items()
-        .into_iter()
-        .filter_map(|a| a.ok())
-        .collect();
-
-    if args.len() != 1 {
+    if arguments.items().len() != 1 {
         return false;
     }
 
     // Get the expression from the first argument
-    let nchar_arg = match args[0].as_fields().value {
+    let nchar_arg = match get_arg(call, &["x"], "x").and_then(|arg| arg.value()) {
         Some(v) => v,
         None => return false,
     };

--- a/crates/jarl-core/src/rule_set.rs
+++ b/crates/jarl-core/src/rule_set.rs
@@ -620,7 +620,7 @@ declare_rules! {
         name: "string_boundary",
         categories: [Perf, Read],
         default: Enabled,
-        fix: Safe,
+        fix: Unsafe,
         min_r_version: None,
     },
     StringsAsFactors => {

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -16,6 +16,11 @@
 
 ### Bug fixes
 
+* The `string_boundary` rule now requires substring boundaries to match the
+  compared string's character length and handles reordered named arguments.
+  Its fixes are now unsafe because they can change attributes, input coercion,
+  or the number of times an expression is evaluated (@Yousa-Mirage).
+
 * Prevent the `sample_int` rule from panicking on calls with missing arguments
   (#687, @Yousa-Mirage).
 

--- a/docs/rules.qmd
+++ b/docs/rules.qmd
@@ -131,7 +131,7 @@ dat <- as.data.frame(
     c("sort", "performance, readability", "✅", ""),
     c("sprintf", "correctness, suspicious", "✅", ""),
     c("stopifnot_all", "readability", "❗", "Disabled by default"),
-    c("string_boundary", "performance, readability", "✅", ""),
+    c("string_boundary", "performance, readability", "❗", ""),
     c("strings_as_factors", "suspicious", "❌", "R < 4.0"),
     c("system_file", "readability", "✅", ""),
     c("true_false_symbol", "readability", "❌", ""),

--- a/docs/rules/string_boundary.md
+++ b/docs/rules/string_boundary.md
@@ -6,13 +6,17 @@
 
 Checks for `substr()` and `substring()` calls that can be replaced with
 `startsWith()` or `endsWith()`.
+Only comparisons to non-empty string literals with matching substring
+boundaries are reported. Ordinary strings containing escapes are skipped.
 
 ## Why is this bad?
 
 Using `startsWith()` and `endsWith()` is both more readable and more efficient
 than extracting substrings and comparing them.
 
-This rule has a safe fix.
+This rule has an unsafe fix because the replacement can drop names and other
+attributes, no longer coerces non-character inputs, and may evaluate repeated
+expressions fewer times.
 
 ## Example
 


### PR DESCRIPTION
Refactored the `string_boundary` rule to fix some bugs. Currently no human review and optimization so draft PR now.

The current code is generated by GPT-6 and seems to be of very good quality. It even fixed the problem of missing parameters that I didn't notice at the same time. The cost was that a single task almost reached my 5-hour limit.