### PR TITLE
refactor: Enable multi-edit fixes

### DIFF
--- a/crates/jarl-core/src/diagnostic.rs
+++ b/crates/jarl-core/src/diagnostic.rs
@@ -97,10 +97,6 @@ impl Fix {
     pub fn from_edits(edits: Vec<Edit>, to_skip: bool) -> Self {
         let mut edits: Vec<Edit> = edits.into_iter().filter(|e| !e.is_noop()).collect();
         edits.sort_by_key(|e| (e.range.start(), e.range.end()));
-        debug_assert!(
-            edits.windows(2).all(|w| w[0].end() <= w[1].start()),
-            "edits of a single fix must not overlap: {edits:?}"
-        );
         Self { edits, to_skip }
     }
 

--- a/crates/jarl-core/src/diagnostic.rs
+++ b/crates/jarl-core/src/diagnostic.rs
@@ -6,6 +6,7 @@ use std::path::PathBuf;
 
 use crate::location::Location;
 use crate::rule_set::{FixStatus, Rule};
+use crate::utils::{line_start, next_line_start};
 
 /// A single contiguous replacement: the source covered by `range` becomes
 /// `content`.
@@ -37,6 +38,11 @@ impl Edit {
             TextSize::from(start as u32),
             TextSize::from(end as u32),
         ))
+    }
+
+    /// Remove the whole line containing `offset`, line break included.
+    pub fn delete_line(source: &str, offset: usize) -> Self {
+        Self::deletion_with_offsets(line_start(source, offset), next_line_start(source, offset))
     }
 
     /// Insert `content` at `at`, leaving the surrounding source untouched.

--- a/crates/jarl-core/src/diagnostic.rs
+++ b/crates/jarl-core/src/diagnostic.rs
@@ -7,12 +7,66 @@ use std::path::PathBuf;
 use crate::location::Location;
 use crate::rule_set::{FixStatus, Rule};
 
+/// A single contiguous replacement: the source covered by `range` becomes
+/// `content`.
+///
+/// An empty `range` is an insertion at that offset, and an empty `content` is a
+/// deletion.
+#[derive(Debug, Serialize, Deserialize, PartialEq, Eq, Clone)]
+pub struct Edit {
+    // Portion of the source replaced by `content`.
+    pub range: TextRange,
+    pub content: String,
+}
+
+impl Edit {
+    /// Replace the source covered by `range` with `content`.
+    pub fn replacement(range: TextRange, content: String) -> Self {
+        Self { range, content }
+    }
+
+    /// Remove the source covered by `range`.
+    pub fn deletion(range: TextRange) -> Self {
+        Self { range, content: String::new() }
+    }
+
+    /// Same as [`Edit::deletion`] for callers that compute byte offsets outside
+    /// of the syntax tree (e.g. from the raw source).
+    pub fn deletion_with_offsets(start: usize, end: usize) -> Self {
+        Self::deletion(TextRange::new(
+            TextSize::from(start as u32),
+            TextSize::from(end as u32),
+        ))
+    }
+
+    /// Insert `content` at `at`, leaving the surrounding source untouched.
+    pub fn insertion(at: TextSize, content: String) -> Self {
+        Self { range: TextRange::new(at, at), content }
+    }
+
+    pub fn start(&self) -> usize {
+        self.range.start().into()
+    }
+
+    pub fn end(&self) -> usize {
+        self.range.end().into()
+    }
+
+    /// An edit that replaces nothing with nothing leaves the source unchanged.
+    fn is_noop(&self) -> bool {
+        self.range.is_empty() && self.content.is_empty()
+    }
+}
+
 #[derive(Debug, Serialize, Deserialize, PartialEq, Eq)]
 // The fix to apply to the violation.
 pub struct Fix {
-    pub content: String,
-    // Portion of the source replaced by `content`.
-    pub range: TextRange,
+    /// Edits applied together, all-or-nothing, sorted by start offset.
+    ///
+    /// Most fixes hold a single edit, but a repair that touches disjoint spots
+    /// (removing both comments of a `jarl-ignore-start`/`jarl-ignore-end` pair,
+    /// say) holds one edit per spot.
+    pub edits: Vec<Edit>,
     // TODO: This is used only to not add a Fix when the node contains a comment
     // because I don't know how to handle them for now, #95.
     pub to_skip: bool,
@@ -21,10 +75,10 @@ pub struct Fix {
 impl Fix {
     /// Replace the source covered by `range` with `content`.
     pub fn new(range: TextRange, content: String, to_skip: bool) -> Self {
-        Self { content, range, to_skip }
+        Self::from_edits(vec![Edit::replacement(range, content)], to_skip)
     }
 
-    /// Same as [`Fix::replace`] for callers that compute byte offsets outside
+    /// Same as [`Fix::new`] for callers that compute byte offsets outside
     /// of the syntax tree (e.g. from the raw source).
     pub fn new_with_offsets(start: usize, end: usize, content: String, to_skip: bool) -> Self {
         Self::new(
@@ -34,20 +88,34 @@ impl Fix {
         )
     }
 
+    /// Build a fix out of several edits applied together.
+    ///
+    /// Edits that change nothing are dropped, and the rest are sorted by start
+    /// offset. Edits of a single fix must not overlap each other: they describe
+    /// one repair, so an overlap is a bug in the rule rather than something to
+    /// resolve at apply time.
+    pub fn from_edits(edits: Vec<Edit>, to_skip: bool) -> Self {
+        let mut edits: Vec<Edit> = edits.into_iter().filter(|e| !e.is_noop()).collect();
+        edits.sort_by_key(|e| (e.range.start(), e.range.end()));
+        debug_assert!(
+            edits.windows(2).all(|w| w[0].end() <= w[1].start()),
+            "edits of a single fix must not overlap: {edits:?}"
+        );
+        Self { edits, to_skip }
+    }
+
     pub fn empty() -> Self {
-        Self {
-            content: "".to_string(),
-            range: TextRange::default(),
-            to_skip: true,
-        }
+        Self { edits: Vec::new(), to_skip: true }
     }
 
+    /// Start of the first edit, or `0` when the fix changes nothing.
     pub fn start(&self) -> usize {
-        self.range.start().into()
+        self.edits.first().map_or(0, Edit::start)
     }
 
+    /// End of the last edit, or `0` when the fix changes nothing.
     pub fn end(&self) -> usize {
-        self.range.end().into()
+        self.edits.last().map_or(0, Edit::end)
     }
 }
 

--- a/crates/jarl-core/src/fix.rs
+++ b/crates/jarl-core/src/fix.rs
@@ -3,40 +3,66 @@ use crate::diagnostic::*;
 /// Takes all diagnostics found in a given file and the content of this file,
 /// and applies automatic fixes.
 ///
-/// Overlapping fixes are skipped rather than applied, since adjusting their
-/// ranges in a single pass is error-prone. The caller is expected to re-lint
-/// and re-apply until the content stabilizes (no more fixable diagnostics or
-/// no progress made).
-pub fn apply_fixes(fixes: &[Diagnostic], contents: &str) -> String {
-    let fixes = fixes
+/// A fix is all-or-nothing: it is applied only if none of its edits touches an
+/// edit already accepted from an earlier fix. Fixes that do conflict are left
+/// out rather than applied on stale offsets; the caller is expected to re-lint
+/// and re-apply until the content stabilizes (no more fixable diagnostics or no
+/// progress made).
+pub fn apply_fixes(diagnostics: &[Diagnostic], contents: &str) -> String {
+    let mut candidates: Vec<&Diagnostic> = diagnostics
         .iter()
-        .map(|diagnostic| &diagnostic.fix)
-        .collect::<Vec<_>>();
+        .filter(|diagnostic| !diagnostic.fix.to_skip && !diagnostic.fix.edits.is_empty())
+        .collect();
 
-    let old_content = contents;
-    let mut new_content = old_content.to_string();
-    // Track the end of the last applied fix in original positions so that
-    // overlap detection works even when earlier fixes change the content
-    // length.
-    let mut last_original_end: usize = 0;
+    // Diagnostics reach us in reporting order, which is neither sorted nor
+    // stable across rules. Order the fixes so that conflicts are resolved in
+    // favour of the earliest one in the file, and so that two runs on the same
+    // input make the same choices.
+    candidates.sort_by(|a, b| {
+        a.fix
+            .start()
+            .cmp(&b.fix.start())
+            .then_with(|| a.range.start().cmp(&b.range.start()))
+            .then_with(|| a.range.end().cmp(&b.range.end()))
+            .then_with(|| a.message.rule.name().cmp(b.message.rule.name()))
+    });
 
-    let old_length = old_content.len() as i32;
-    let mut new_length = old_length;
-
-    for fix in fixes {
-        // Skip overlapping fixes; they'll be handled in the next iteration.
-        if fix.start() < last_original_end {
+    let mut accepted: Vec<&Edit> = Vec::new();
+    for diagnostic in candidates {
+        let edits = &diagnostic.fix.edits;
+        if edits
+            .iter()
+            .any(|edit| accepted.iter().any(|other| conflicts(edit, other)))
+        {
             continue;
         }
+        accepted.extend(edits);
+    }
 
-        let diff_length = new_length - old_length;
-        let start = (fix.start() as i32 + diff_length) as usize;
-        let end = (fix.end() as i32 + diff_length) as usize;
+    // Splicing back-to-front keeps every remaining offset valid, so no offset
+    // arithmetic is needed. At a shared start offset the widest edit goes
+    // first, which puts an insertion in front of the replacement it abuts.
+    accepted.sort_by(|a, b| b.start().cmp(&a.start()).then(b.end().cmp(&a.end())));
 
-        new_content.replace_range(start..end, &fix.content);
-        new_length = new_content.len() as i32;
-        last_original_end = fix.end();
+    let mut new_content = contents.to_string();
+    for edit in accepted {
+        new_content.replace_range(edit.start()..edit.end(), &edit.content);
     }
 
     new_content
+}
+
+/// Whether two edits cannot be applied in the same pass.
+///
+/// Replacements conflict when their ranges intersect. An insertion is an empty
+/// range, so it conflicts with a replacement only when it lands strictly inside
+/// it — inserting at a boundary is well defined. Two insertions at the same
+/// offset conflict because the order between them would be arbitrary.
+fn conflicts(a: &Edit, b: &Edit) -> bool {
+    match (a.range.is_empty(), b.range.is_empty()) {
+        (true, true) => a.start() == b.start(),
+        (true, false) => b.start() < a.start() && a.start() < b.end(),
+        (false, true) => a.start() < b.start() && b.start() < a.end(),
+        (false, false) => a.start() < b.end() && b.start() < a.end(),
+    }
 }

--- a/crates/jarl-core/src/lints/comments/outdated_suppression/mod.rs
+++ b/crates/jarl-core/src/lints/comments/outdated_suppression/mod.rs
@@ -192,6 +192,12 @@ y <- 2",
 # jarl-ignore-start any_is_na: <reason>
 # jarl-ignore-end any_is_na
 x <- 1",
+                    // The region fix only removes the two comments, so a fix
+                    // for the code they wrap is applied too.
+                    "
+# jarl-ignore-start quotes: <reason>
+z <- any(is.na(x))
+# jarl-ignore-end quotes",
                 ],
                 "outdated_suppression,any_is_na",
                 None

--- a/crates/jarl-core/src/lints/comments/outdated_suppression/outdated_suppression.rs
+++ b/crates/jarl-core/src/lints/comments/outdated_suppression/outdated_suppression.rs
@@ -72,8 +72,5 @@ fn create_fix(suppression: &UnusedSuppression, source: &str) -> Fix {
 
 /// Delete the whole line containing `offset`, line break included.
 fn delete_line(source: &str, offset: usize) -> Edit {
-    Edit::deletion_with_offsets(
-        line_start(source, offset),
-        next_line_start(source, offset),
-    )
+    Edit::deletion_with_offsets(line_start(source, offset), next_line_start(source, offset))
 }

--- a/crates/jarl-core/src/lints/comments/outdated_suppression/outdated_suppression.rs
+++ b/crates/jarl-core/src/lints/comments/outdated_suppression/outdated_suppression.rs
@@ -1,6 +1,7 @@
 use crate::diagnostic::*;
 use crate::rule_set::Rule;
 use crate::suppression::UnusedSuppression;
+use crate::utils::{line_start, next_line_start};
 
 /// Version added: 0.4.0
 ///
@@ -55,38 +56,24 @@ fn create_diagnostic(suppression: &UnusedSuppression, source: &str) -> Diagnosti
 /// reported by `misplaced_suppression` instead and never suppresses anything),
 /// so the indentation and the line break go with it.
 ///
-/// A `jarl-ignore-start`/`jarl-ignore-end` pair needs both comments gone, but a
-/// fix is a single contiguous replacement: the edit therefore spans the whole
-/// region and puts back the code it wraps.
+/// A `jarl-ignore-start`/`jarl-ignore-end` pair needs both comments gone, which
+/// is one deletion per comment; the code they wrap is untouched.
 fn create_fix(suppression: &UnusedSuppression, source: &str) -> Fix {
     let comment = suppression.comment_range;
-    let last_comment_end = suppression.region_range.unwrap_or(comment).end().into();
+    let mut edits = vec![delete_line(source, comment.start().into())];
 
-    // For a region, the code between the two comments is put back untouched.
-    let content = match suppression.region_range {
-        Some(_) => source
-            [next_line_start(source, comment.end().into())..line_start(source, last_comment_end)]
-            .to_string(),
-        None => String::new(),
-    };
+    // For a region, the closing comment sits on its own line further down.
+    if let Some(region) = suppression.region_range {
+        edits.push(delete_line(source, region.end().into()));
+    }
 
-    Fix::new_with_offsets(
-        line_start(source, comment.start().into()),
-        next_line_start(source, last_comment_end),
-        content,
-        false,
+    Fix::from_edits(edits, false)
+}
+
+/// Delete the whole line containing `offset`, line break included.
+fn delete_line(source: &str, offset: usize) -> Edit {
+    Edit::deletion_with_offsets(
+        line_start(source, offset),
+        next_line_start(source, offset),
     )
-}
-
-/// Offset of the first character of the line containing `offset`.
-fn line_start(source: &str, offset: usize) -> usize {
-    source[..offset].rfind('\n').map_or(0, |i| i + 1)
-}
-
-/// Offset just past the line break ending the line that contains `offset`, or
-/// the end of the source if that line is the last one.
-fn next_line_start(source: &str, offset: usize) -> usize {
-    source[offset..]
-        .find('\n')
-        .map_or(source.len(), |i| offset + i + 1)
 }

--- a/crates/jarl-core/src/lints/comments/outdated_suppression/outdated_suppression.rs
+++ b/crates/jarl-core/src/lints/comments/outdated_suppression/outdated_suppression.rs
@@ -1,7 +1,6 @@
 use crate::diagnostic::*;
 use crate::rule_set::Rule;
 use crate::suppression::UnusedSuppression;
-use crate::utils::{line_start, next_line_start};
 
 /// Version added: 0.4.0
 ///
@@ -60,17 +59,12 @@ fn create_diagnostic(suppression: &UnusedSuppression, source: &str) -> Diagnosti
 /// is one deletion per comment; the code they wrap is untouched.
 fn create_fix(suppression: &UnusedSuppression, source: &str) -> Fix {
     let comment = suppression.comment_range;
-    let mut edits = vec![delete_line(source, comment.start().into())];
+    let mut edits = vec![Edit::delete_line(source, comment.start().into())];
 
     // For a region, the closing comment sits on its own line further down.
     if let Some(region) = suppression.region_range {
-        edits.push(delete_line(source, region.end().into()));
+        edits.push(Edit::delete_line(source, region.end().into()));
     }
 
     Fix::from_edits(edits, false)
-}
-
-/// Delete the whole line containing `offset`, line break included.
-fn delete_line(source: &str, offset: usize) -> Edit {
-    Edit::deletion_with_offsets(line_start(source, offset), next_line_start(source, offset))
 }

--- a/crates/jarl-core/src/lints/comments/outdated_suppression/snapshots/jarl_core__lints__comments__outdated_suppression__tests__fix_output.snap
+++ b/crates/jarl-core/src/lints/comments/outdated_suppression/snapshots/jarl_core__lints__comments__outdated_suppression__tests__fix_output.snap
@@ -1,6 +1,6 @@
 ---
 source: crates/jarl-core/src/lints/comments/outdated_suppression/mod.rs
-expression: "get_fixed_text(vec![\"\n# jarl-ignore any_is_na: <reason>\nf <- function(x) {\n  1 + 1\n}\",\n\"\n# jarl-ignore-start any_is_na: <reason>\nx <- 1\n# jarl-ignore-end any_is_na\ny <- 2\",\n\"\n# jarl-ignore-start any_is_na: <reason>\n  foo( bar\n + 1 )\n      1 + 1\n# jarl-ignore-end any_is_na\",\n\"\n    # jarl-ignore-start any_is_na: <reason>\n  foo( bar\n + 1 )\n      1 + 1\n      # jarl-ignore-end any_is_na\",\n\"\nf <- function(x) {\n  # jarl-ignore any_is_na: <reason>\n  x <- 1\n}\",\n\"\n# jarl-ignore any_is_na: <reason>\nany(is.na(x))\n# jarl-ignore any_is_na: <reason>\ny <- 2\",\n\"\n# jarl-ignore-file any_is_na: <reason>\nx <- 1\n# jarl-ignore any_is_na: <reason>\ny <- 2\",\n\"x <- 1\n# jarl-ignore any_is_na: <reason>\",\n\"\n# jarl-ignore-start any_is_na: <reason>\n# jarl-ignore-end any_is_na\nx <- 1\",],\n\"outdated_suppression,any_is_na\", None)"
+expression: "get_fixed_text(vec![\"\n# jarl-ignore any_is_na: <reason>\nf <- function(x) {\n  1 + 1\n}\",\n\"\n# jarl-ignore-start any_is_na: <reason>\nx <- 1\n# jarl-ignore-end any_is_na\ny <- 2\",\n\"\n# jarl-ignore-start any_is_na: <reason>\n  foo( bar\n + 1 )\n      1 + 1\n# jarl-ignore-end any_is_na\",\n\"\n    # jarl-ignore-start any_is_na: <reason>\n  foo( bar\n + 1 )\n      1 + 1\n      # jarl-ignore-end any_is_na\",\n\"\nf <- function(x) {\n  # jarl-ignore any_is_na: <reason>\n  x <- 1\n}\",\n\"\n# jarl-ignore any_is_na: <reason>\nany(is.na(x))\n# jarl-ignore any_is_na: <reason>\ny <- 2\",\n\"\n# jarl-ignore-file any_is_na: <reason>\nx <- 1\n# jarl-ignore any_is_na: <reason>\ny <- 2\",\n\"x <- 1\n# jarl-ignore any_is_na: <reason>\",\n\"\n# jarl-ignore-start any_is_na: <reason>\n# jarl-ignore-end any_is_na\nx <- 1\",\n\"\n# jarl-ignore-start quotes: <reason>\nz <- any(is.na(x))\n# jarl-ignore-end quotes\",],\n\"outdated_suppression,any_is_na\", None)"
 ---
 OLD:
 ====
@@ -121,3 +121,14 @@ NEW:
 ====
 
 x <- 1
+
+OLD:
+====
+
+# jarl-ignore-start quotes: <reason>
+z <- any(is.na(x))
+# jarl-ignore-end quotes
+NEW:
+====
+
+z <- anyNA(x)

--- a/crates/jarl-core/src/roxygen.rs
+++ b/crates/jarl-core/src/roxygen.rs
@@ -5,9 +5,9 @@
 //! those blocks, and extracts the subsequent R code lines with their `#' `
 //! prefix stripped.
 
-use crate::diagnostic::Fix;
+use crate::diagnostic::{Edit, Fix};
 use air_r_syntax::{RLanguage, RSyntaxNode};
-use biome_rowan::{SyntaxNode, TextSize};
+use biome_rowan::{SyntaxNode, TextRange, TextSize};
 
 /// An R code chunk extracted from a roxygen `@examples` or `@examplesIf` section.
 #[derive(Debug)]
@@ -250,15 +250,25 @@ pub fn remap_roxygen_range(
 
 /// Remap a fix from chunk-local byte offsets to original file positions.
 ///
-/// This remaps the fix range, and also inserts the roxygen comment
-/// prefix (e.g. `#' `) before each new line in the fix content so that the
+/// This remaps the range of every edit, and also inserts the roxygen comment
+/// prefix (e.g. `#' `) before each new line in the edit content so that the
 /// replacement text is valid roxygen when applied to the original file.
 pub fn remap_roxygen_fix(fix: &Fix, chunk: &RoxygenExamplesChunk, contents: &str) -> Fix {
-    let start = fix.start();
-    let new_start = remap_byte_offset(start, chunk);
-    let new_end = remap_byte_offset(fix.end(), chunk);
+    let edits = fix
+        .edits
+        .iter()
+        .map(|edit| remap_roxygen_edit(edit, chunk, contents))
+        .collect();
 
-    // Determine the roxygen prefix from the line where the fix starts.
+    Fix::from_edits(edits, fix.to_skip)
+}
+
+fn remap_roxygen_edit(edit: &Edit, chunk: &RoxygenExamplesChunk, contents: &str) -> Edit {
+    let start = edit.start();
+    let new_start = remap_byte_offset(start, chunk);
+    let new_end = remap_byte_offset(edit.end(), chunk);
+
+    // Determine the roxygen prefix from the line where the edit starts.
     let start_line_idx = match chunk.code_line_starts.binary_search(&start) {
         Ok(i) => i,
         Err(i) => i.saturating_sub(1),
@@ -267,10 +277,16 @@ pub fn remap_roxygen_fix(fix: &Fix, chunk: &RoxygenExamplesChunk, contents: &str
     let prefix_len = chunk.line_prefix_lengths[start_line_idx];
     let prefix = &contents[prefix_offset..prefix_offset + prefix_len];
 
-    // Insert the roxygen prefix before each new line in the fix content.
-    let content = fix.content.replace('\n', &format!("\n{prefix}"));
+    // Insert the roxygen prefix before each new line in the edit content.
+    let content = edit.content.replace('\n', &format!("\n{prefix}"));
 
-    Fix::new_with_offsets(new_start, new_end, content, fix.to_skip)
+    Edit::replacement(
+        TextRange::new(
+            TextSize::from(new_start as u32),
+            TextSize::from(new_end as u32),
+        ),
+        content,
+    )
 }
 
 /// Pre-compute the byte offset of each line within a `code` string (lines

--- a/crates/jarl-core/src/utils.rs
+++ b/crates/jarl-core/src/utils.rs
@@ -447,6 +447,19 @@ pub fn scan_symbols(content: &str) -> HashMap<String, usize> {
         .collect()
 }
 
+/// Offset of the first character of the line containing `offset`.
+pub fn line_start(source: &str, offset: usize) -> usize {
+    source[..offset].rfind('\n').map_or(0, |i| i + 1)
+}
+
+/// Offset just past the line break ending the line that contains `offset`, or
+/// the end of the source if that line is the last one.
+pub fn next_line_start(source: &str, offset: usize) -> usize {
+    source[offset..]
+        .find('\n')
+        .map_or(source.len(), |i| offset + i + 1)
+}
+
 #[cfg(test)]
 mod tests {
     use super::scan_symbols;
@@ -502,17 +515,4 @@ mod tests {
         assert!(syms.contains_key("foo"));
         assert!(!syms.contains_key("123"));
     }
-}
-
-/// Offset of the first character of the line containing `offset`.
-pub fn line_start(source: &str, offset: usize) -> usize {
-    source[..offset].rfind('\n').map_or(0, |i| i + 1)
-}
-
-/// Offset just past the line break ending the line that contains `offset`, or
-/// the end of the source if that line is the last one.
-pub fn next_line_start(source: &str, offset: usize) -> usize {
-    source[offset..]
-        .find('\n')
-        .map_or(source.len(), |i| offset + i + 1)
 }

--- a/crates/jarl-core/src/utils.rs
+++ b/crates/jarl-core/src/utils.rs
@@ -503,3 +503,16 @@ mod tests {
         assert!(!syms.contains_key("123"));
     }
 }
+
+/// Offset of the first character of the line containing `offset`.
+pub fn line_start(source: &str, offset: usize) -> usize {
+    source[..offset].rfind('\n').map_or(0, |i| i + 1)
+}
+
+/// Offset just past the line break ending the line that contains `offset`, or
+/// the end of the source if that line is the last one.
+pub fn next_line_start(source: &str, offset: usize) -> usize {
+    source[offset..]
+        .find('\n')
+        .map_or(source.len(), |i| offset + i + 1)
+}

--- a/crates/jarl-lsp/src/lint.rs
+++ b/crates/jarl-lsp/src/lint.rs
@@ -25,15 +25,23 @@ use jarl_core::package::{is_in_r_package, make_package_analysis, summarize_packa
 use jarl_core::rule_set::Rule;
 use jarl_core::settings::Settings;
 
+/// A single replacement making up a fix
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct DiagnosticEdit {
+    /// The replacement content for the edit
+    pub content: String,
+    /// The start byte offset of the edit range
+    pub start: usize,
+    /// The end byte offset of the edit range
+    pub end: usize,
+}
+
 /// Fix information that can be attached to a diagnostic for code actions
 #[derive(Debug, Serialize, Deserialize, Clone)]
 pub struct DiagnosticFix {
-    /// The replacement content for the fix
-    pub content: String,
-    /// The start byte offset of the fix range
-    pub start: usize,
-    /// The end byte offset of the fix range
-    pub end: usize,
+    /// The edits making up the fix, applied together. Empty when the
+    /// diagnostic has no fix.
+    pub edits: Vec<DiagnosticEdit>,
     /// Whether this fix is safe to apply automatically
     pub is_safe: bool,
     /// The name of the rule that produced this diagnostic
@@ -279,9 +287,16 @@ fn convert_to_lsp_diagnostic(
     // Extract fix information if available
     // Always include fix_data even if there's no actual fix, so we can access the rule_name
     let diagnostic_fix = DiagnosticFix {
-        content: jarl_diag.fix.content.clone(),
-        start: jarl_diag.fix.start(),
-        end: jarl_diag.fix.end(),
+        edits: jarl_diag
+            .fix
+            .edits
+            .iter()
+            .map(|edit| DiagnosticEdit {
+                content: edit.content.clone(),
+                start: edit.start(),
+                end: edit.end(),
+            })
+            .collect(),
         is_safe: jarl_diag.has_safe_fix(),
         rule_name: jarl_diag.message.rule.name().to_string(),
         diagnostic_start: start_offset,

--- a/crates/jarl-lsp/src/server.rs
+++ b/crates/jarl-lsp/src/server.rs
@@ -476,7 +476,7 @@ impl Server {
         let fix_data = diagnostic.data.as_ref()?;
         let fix: crate::lint::DiagnosticFix = serde_json::from_value(fix_data.clone()).ok()?;
 
-        if fix.content.is_empty() && fix.start == fix.end {
+        if fix.edits.is_empty() {
             return None; // No fix available
         }
 
@@ -484,18 +484,24 @@ impl Server {
         let content = snapshot.content();
         let encoding = snapshot.position_encoding();
 
-        let start_pos =
-            crate::lint::byte_offset_to_lsp_position(fix.start, content, encoding).ok()?;
-        let end_pos = crate::lint::byte_offset_to_lsp_position(fix.end, content, encoding).ok()?;
+        // A fix is all-or-nothing, and a `WorkspaceEdit` holds several edits
+        // per file, so the whole fix lands as one undo step.
+        let mut text_edits = Vec::with_capacity(fix.edits.len());
+        for edit in &fix.edits {
+            let start_pos =
+                crate::lint::byte_offset_to_lsp_position(edit.start, content, encoding).ok()?;
+            let end_pos =
+                crate::lint::byte_offset_to_lsp_position(edit.end, content, encoding).ok()?;
 
-        let edit_range = types::Range::new(start_pos, end_pos);
-
-        // Create the text edit for this single file
-        let text_edit = types::TextEdit { range: edit_range, new_text: fix.content.clone() };
+            text_edits.push(types::TextEdit {
+                range: types::Range::new(start_pos, end_pos),
+                new_text: edit.content.clone(),
+            });
+        }
 
         // Create workspace edit with just this file's changes
         let mut changes = std::collections::HashMap::new();
-        changes.insert(snapshot.uri().clone(), vec![text_edit]);
+        changes.insert(snapshot.uri().clone(), text_edits);
 
         let workspace_edit = types::WorkspaceEdit { changes: Some(changes), ..Default::default() };
 
@@ -1393,9 +1399,11 @@ select = ["ALL"]
         let snapshot = create_test_snapshot("any(duplicated(x))\n");
 
         let fix = lint::DiagnosticFix {
-            content: "anyDuplicated(x) > 0".to_string(),
-            start: 0,
-            end: 18,
+            edits: vec![lint::DiagnosticEdit {
+                content: "anyDuplicated(x) > 0".to_string(),
+                start: 0,
+                end: 18,
+            }],
             is_safe: false,
             rule_name: "any_duplicated".to_string(),
             diagnostic_start: 0,

--- a/crates/jarl-lsp/tests/integration_tests.rs
+++ b/crates/jarl-lsp/tests/integration_tests.rs
@@ -62,15 +62,17 @@ fn test_server_startup_basic() {
 
 #[test]
 fn test_diagnostic_fix_serialization() {
-    use jarl_lsp::lint::DiagnosticFix;
+    use jarl_lsp::lint::{DiagnosticEdit, DiagnosticFix};
     use serde_json;
 
     // Test that DiagnosticFix can be properly serialized/deserialized
-    // This is used when embedding fix data in LSP diagnostics
+    // This is used when embedding fix data in LSP diagnostics. A fix can hold
+    // several edits, so the round-trip has to preserve all of them.
     let fix = DiagnosticFix {
-        content: "x <- 1".to_string(),
-        start: 0,
-        end: 5,
+        edits: vec![
+            DiagnosticEdit { content: "x <- 1".to_string(), start: 0, end: 5 },
+            DiagnosticEdit { content: String::new(), start: 10, end: 14 },
+        ],
         is_safe: true,
         rule_name: "assignment".to_string(),
         diagnostic_start: 0,
@@ -80,9 +82,12 @@ fn test_diagnostic_fix_serialization() {
     let json_value = serde_json::to_value(&fix).unwrap();
     let deserialized: DiagnosticFix = serde_json::from_value(json_value).unwrap();
 
-    assert_eq!(deserialized.content, fix.content);
-    assert_eq!(deserialized.start, fix.start);
-    assert_eq!(deserialized.end, fix.end);
+    assert_eq!(deserialized.edits.len(), fix.edits.len());
+    for (got, expected) in deserialized.edits.iter().zip(&fix.edits) {
+        assert_eq!(got.content, expected.content);
+        assert_eq!(got.start, expected.start);
+        assert_eq!(got.end, expected.end);
+    }
     assert_eq!(deserialized.is_safe, fix.is_safe);
 }
 

--- a/crates/jarl/src/output_format.rs
+++ b/crates/jarl/src/output_format.rs
@@ -466,7 +466,7 @@ struct SarifFix {
 #[serde(rename_all = "camelCase")]
 struct SarifArtifactChange {
     artifact_location: SarifArtifactLocation,
-    replacements: [SarifReplacement; 1],
+    replacements: Vec<SarifReplacement>,
 }
 
 #[derive(Debug, Serialize)]
@@ -572,13 +572,20 @@ impl Emitter for SarifEmitter {
             }
             .replace('\\', "/");
 
-            // A fix is only emitted when it edits the source (not skipped, and
-            // it either inserts content or deletes a non-empty range).
+            // A fix is only emitted when it edits the source: not skipped, and
+            // carrying at least one edit. Its edits become the replacements of
+            // a single artifact change, so they are applied together.
             let fix = &diagnostic.fix;
-            let fixes = if !fix.to_skip && (fix.start() != fix.end() || !fix.content.is_empty()) {
-                let deleted_region = range_to_region(content, fix.start(), fix.end());
-                let inserted_content = (!fix.content.is_empty())
-                    .then(|| SarifMessage { text: Cow::Owned(fix.content.clone()) });
+            let fixes = if !fix.to_skip && !fix.edits.is_empty() {
+                let replacements = fix
+                    .edits
+                    .iter()
+                    .map(|edit| SarifReplacement {
+                        deleted_region: range_to_region(content, edit.start(), edit.end()),
+                        inserted_content: (!edit.content.is_empty())
+                            .then(|| SarifMessage { text: Cow::Owned(edit.content.clone()) }),
+                    })
+                    .collect();
                 vec![SarifFix {
                     description: SarifMessage { text: Cow::Owned(message.clone()) },
                     artifact_changes: [SarifArtifactChange {
@@ -586,7 +593,7 @@ impl Emitter for SarifEmitter {
                             uri: uri.clone(),
                             uri_base_id: "ROOTPATH",
                         },
-                        replacements: [SarifReplacement { deleted_region, inserted_content }],
+                        replacements,
                     }],
                 }]
             } else {

--- a/crates/jarl/tests/integration/output_format.rs
+++ b/crates/jarl/tests/integration/output_format.rs
@@ -170,10 +170,14 @@ fn test_output_json() -> anyhow::Result<()> {
             "column": 0
           },
           "fix": {
-            "content": "anyNA(x)",
-            "range": [
-              0,
-              13
+            "edits": [
+              {
+                "range": [
+                  0,
+                  13
+                ],
+                "content": "anyNA(x)"
+              }
             ],
             "to_skip": false
           }
@@ -194,10 +198,14 @@ fn test_output_json() -> anyhow::Result<()> {
             "column": 0
           },
           "fix": {
-            "content": "anyDuplicated(x) > 0",
-            "range": [
-              0,
-              18
+            "edits": [
+              {
+                "range": [
+                  0,
+                  18
+                ],
+                "content": "anyDuplicated(x) > 0"
+              }
             ],
             "to_skip": false
           }
@@ -243,10 +251,14 @@ fn test_output_json() -> anyhow::Result<()> {
             "column": 0
           },
           "fix": {
-            "content": "anyNA(x)",
-            "range": [
-              0,
-              13
+            "edits": [
+              {
+                "range": [
+                  0,
+                  13
+                ],
+                "content": "anyNA(x)"
+              }
             ],
             "to_skip": false
           }
@@ -267,10 +279,14 @@ fn test_output_json() -> anyhow::Result<()> {
             "column": 0
           },
           "fix": {
-            "content": "anyDuplicated(x) > 0",
-            "range": [
-              0,
-              18
+            "edits": [
+              {
+                "range": [
+                  0,
+                  18
+                ],
+                "content": "anyDuplicated(x) > 0"
+              }
             ],
             "to_skip": false
           }
@@ -629,10 +645,14 @@ fn test_with_parsing_error() -> anyhow::Result<()> {
             "column": 0
           },
           "fix": {
-            "content": "anyNA(x)",
-            "range": [
-              0,
-              13
+            "edits": [
+              {
+                "range": [
+                  0,
+                  13
+                ],
+                "content": "anyNA(x)"
+              }
             ],
             "to_skip": false
           }

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -8,8 +8,8 @@
   the rule-specific option `[lint.assignment]` instead (#663).
 
 * A fix can now edit several places of a file at once, so in the `json` output
-  format the `fix` object holds a list of edits instead of a single
-  `content`/`range` pair:
+  format the `fix` object contains a list of edits instead of a single
+  `content`/`range` pair (#700):
 
   ```json
   "fix": { "edits": [ { "range": [0, 13], "content": "anyNA(x)" } ], "to_skip": false }

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -7,6 +7,14 @@
 * The `jarl.toml` argument `assignment` (deprecated since 0.5.0) is removed. Use
   the rule-specific option `[lint.assignment]` instead (#663).
 
+* A fix can now edit several places of a file at once, so in the `json` output
+  format the `fix` object holds a list of edits instead of a single
+  `content`/`range` pair:
+
+  ```json
+  "fix": { "edits": [ { "range": [0, 13], "content": "anyNA(x)" } ], "to_skip": false }
+  ```
+
 ### Changes
 
 * `expect_length` no longer reports cases where `length()` is in the `expected`


### PR DESCRIPTION
This enables fixes that modify several parts of the file, like `outdated_suppression` or a future rule to detect `library()` calls that are not at the top of the file.