### PR TITLE
feat: Implement `library_call`

### DIFF
--- a/crates/jarl-core/src/analyze/document.rs
+++ b/crates/jarl-core/src/analyze/document.rs
@@ -5,6 +5,7 @@ use oak_semantic::semantic_index::SemanticIndex;
 use crate::checker::Checker;
 use crate::diagnostic::*;
 use crate::lints::base::empty_file::empty_file::empty_file;
+use crate::lints::base::library_call::library_call::library_call;
 use crate::lints::base::unreachable_code::unreachable_code::unreachable_code_top_level;
 use crate::lints::base::unused_object::unused_object::unused_object;
 use crate::lints::comments::blanket_suppression::blanket_suppression::blanket_suppression;
@@ -144,6 +145,12 @@ pub(crate) fn check_document(
 
     if checker.is_rule_enabled(Rule::EmptyFile) {
         checker.report_diagnostic(empty_file(&expressions, syntax));
+    }
+
+    if checker.is_rule_enabled(Rule::LibraryCall) {
+        for diagnostic in library_call(&expressions, contents) {
+            checker.report_diagnostic(Some(diagnostic));
+        }
     }
 
     // Filter diagnostics by suppressions. This removes suppressed violations

--- a/crates/jarl-core/src/analyze/document.rs
+++ b/crates/jarl-core/src/analyze/document.rs
@@ -147,7 +147,12 @@ pub(crate) fn check_document(
         checker.report_diagnostic(empty_file(&expressions, syntax));
     }
 
-    if checker.is_rule_enabled(Rule::LibraryCall) {
+    // In an Rmd/Qmd document, a `library()` call belongs to the chunk that
+    // needs it: chunks are meant to be readable (and often run) one at a time,
+    // so grouping every attach in the first chunk is not the convention.
+    if checker.is_rule_enabled(Rule::LibraryCall)
+        && !crate::fs::has_rmd_extension(&checker.file_path)
+    {
         for diagnostic in library_call(&expressions, contents) {
             checker.report_diagnostic(Some(diagnostic));
         }

--- a/crates/jarl-core/src/lints/base/library_call/library_call.rs
+++ b/crates/jarl-core/src/lints/base/library_call/library_call.rs
@@ -1,0 +1,206 @@
+use crate::diagnostic::*;
+use crate::rule_set::Rule;
+use crate::utils::{get_function_name, line_start, next_line_start, node_contains_comments};
+use air_r_syntax::*;
+use biome_rowan::{AstNode, AstNodeList, TextRange, TextSize};
+
+/// A top-level statement that is either a `library()` call (possibly wrapped
+/// in `suppressMessages()`/`suppressPackageStartupMessages()`) or an `if`
+/// statement whose branches only contain such calls.
+struct LibraryStatement {
+    node: RSyntaxNode,
+    range: TextRange,
+}
+
+/// Version added: 0.6.0
+///
+/// ## What it does
+///
+/// Reports `library()` calls that are not grouped at the top of the script,
+/// and moves them there.
+///
+/// A preamble of setup code is allowed before the first `library()` call;
+/// what matters is that every `library()` call in the script forms a single
+/// consecutive block starting at the first one.
+///
+/// Only `library()` is considered: `require()` returns a value that is
+/// routinely used for its result, so it is out of scope for this rule.
+///
+/// ## Why is this bad?
+///
+/// Scripts where `library()` calls are scattered between the code are hard to
+/// read: a reader cannot tell at a glance which packages the script needs,
+/// and the attach order (which decides masking) becomes accidental rather
+/// than deliberate.
+///
+/// This rule has an unsafe fix: moving `library()` calls changes attach order
+/// and therefore which package masks which.
+///
+/// This rule is disabled by default.
+///
+/// ## Example
+///
+/// ```r
+/// library(dplyr)
+/// x <- 1
+/// library(purrr)
+/// ```
+///
+/// Use instead:
+/// ```r
+/// library(dplyr)
+/// library(purrr)
+/// x <- 1
+/// ```
+pub fn library_call(expressions: &[RSyntaxNode], contents: &str) -> Vec<Diagnostic> {
+    let mut diagnostics = Vec::new();
+
+    let statements: Vec<Option<LibraryStatement>> =
+        expressions.iter().map(classify_library_statement).collect();
+
+    let Some(first) = statements.iter().position(Option::is_some) else {
+        return diagnostics;
+    };
+
+    let mut block_end = first;
+    while block_end + 1 < statements.len() && statements[block_end + 1].is_some() {
+        block_end += 1;
+    }
+
+    let block_end_range = statements[block_end]
+        .as_ref()
+        .expect("block_end is a library statement")
+        .range;
+    let insertion_point =
+        TextSize::from(next_line_start(contents, usize::from(block_end_range.end())) as u32);
+
+    for stmt in statements.iter().skip(block_end + 1).flatten() {
+        diagnostics.push(misplaced_diagnostic(stmt, contents, insertion_point));
+    }
+
+    diagnostics
+}
+
+/// Classify a top-level statement as a library statement, if it is one.
+fn classify_library_statement(stmt: &RSyntaxNode) -> Option<LibraryStatement> {
+    if let Some(call) = RCall::cast(stmt.clone()) {
+        if !is_library_call(&call) {
+            return None;
+        }
+        return Some(LibraryStatement {
+            node: stmt.clone(),
+            range: stmt.text_trimmed_range(),
+        });
+    }
+
+    if let Some(if_stmt) = RIfStatement::cast(stmt.clone())
+        && if_is_library_only(&if_stmt)
+    {
+        return Some(LibraryStatement {
+            node: stmt.clone(),
+            range: stmt.text_trimmed_range(),
+        });
+    }
+
+    None
+}
+
+/// Whether `call` is a `library()` call, directly or wrapped in
+/// `suppressMessages()`/`suppressPackageStartupMessages()`.
+fn is_library_call(call: &RCall) -> bool {
+    let Some(name) = call.function().ok().map(get_function_name) else {
+        return false;
+    };
+
+    if name == "library" {
+        return true;
+    }
+
+    if name != "suppressMessages" && name != "suppressPackageStartupMessages" {
+        return false;
+    }
+
+    let Some(mut items) = call.arguments().ok().map(|args| args.items().into_iter()) else {
+        return false;
+    };
+    let Some(Ok(only)) = items.next() else {
+        return false;
+    };
+    if items.next().is_some() {
+        return false;
+    }
+
+    let Some(inner_call) = only.value().and_then(|value| value.as_r_call().cloned()) else {
+        return false;
+    };
+    inner_call.function().ok().map(get_function_name).as_deref() == Some("library")
+}
+
+/// Whether every branch of `if_stmt` contains only library statements.
+fn if_is_library_only(if_stmt: &RIfStatement) -> bool {
+    let RIfStatementFields { consequence, else_clause, .. } = if_stmt.as_fields();
+    let Ok(consequence) = consequence else {
+        return false;
+    };
+    if !branch_is_library_only(&consequence) {
+        return false;
+    }
+
+    match else_clause {
+        None => true,
+        Some(clause) => match clause.alternative() {
+            Ok(alternative) => branch_is_library_only(&alternative),
+            Err(_) => false,
+        },
+    }
+}
+
+/// A branch is library-only when it's a braced block whose statements are all
+/// library statements, or a single library statement itself (including a
+/// nested `if` for `else if` chains).
+fn branch_is_library_only(branch: &AnyRExpression) -> bool {
+    if let Some(braced) = branch.as_r_braced_expressions() {
+        return braced
+            .expressions()
+            .iter()
+            .all(|expr| classify_library_statement(expr.syntax()).is_some());
+    }
+    classify_library_statement(branch.syntax()).is_some()
+}
+
+/// Whether `range` is alone on its lines: nothing but whitespace before it on
+/// its first line, and nothing but whitespace after it on its last line.
+fn statement_alone_on_lines(contents: &str, range: TextRange) -> bool {
+    let start = usize::from(range.start());
+    let end = usize::from(range.end());
+    let before = &contents[line_start(contents, start)..start];
+    let after = &contents[end..next_line_start(contents, end)];
+    before.trim().is_empty() && after.trim().is_empty()
+}
+
+fn misplaced_diagnostic(
+    stmt: &LibraryStatement,
+    contents: &str,
+    insertion_point: TextSize,
+) -> Diagnostic {
+    let start = usize::from(stmt.range.start());
+    let end = usize::from(stmt.range.end());
+    let text = contents[start..end].to_string();
+
+    let to_skip =
+        node_contains_comments(&stmt.node) || !statement_alone_on_lines(contents, stmt.range);
+
+    let deletion =
+        Edit::deletion_with_offsets(line_start(contents, start), next_line_start(contents, end));
+    let insertion = Edit::insertion(insertion_point, format!("{text}\n"));
+
+    Diagnostic::new(
+        ViolationData::new(
+            Rule::LibraryCall,
+            "`library()` calls should be grouped at the top of the script.".to_string(),
+            Some("Move this call next to the other `library()` calls.".to_string()),
+        ),
+        stmt.range,
+        Fix::from_edits(vec![deletion, insertion], to_skip),
+    )
+}

--- a/crates/jarl-core/src/lints/base/library_call/library_call.rs
+++ b/crates/jarl-core/src/lints/base/library_call/library_call.rs
@@ -26,6 +26,9 @@ struct LibraryStatement {
 /// Only `library()` is considered: `require()` returns a value that is
 /// routinely used for its result, so it is out of scope for this rule.
 ///
+/// This rule is skipped in R Markdown and Quarto documents, where it is often
+/// more acceptable to have `library()` calls in various chunks.
+///
 /// ## Why is this bad?
 ///
 /// Scripts where `library()` calls are scattered between the code are hard to

--- a/crates/jarl-core/src/lints/base/library_call/mod.rs
+++ b/crates/jarl-core/src/lints/base/library_call/mod.rs
@@ -1,0 +1,175 @@
+pub(crate) mod library_call;
+
+#[cfg(test)]
+mod tests {
+    use crate::utils_test::*;
+
+    fn snapshot_lint(code: &str) -> String {
+        format_diagnostics(code, "library_call", None)
+    }
+
+    #[test]
+    fn test_no_lint_library_call() {
+        // Consecutive block at the very top.
+        expect_no_lint(
+            r#"
+library(dplyr)
+library(purrr)
+x <- 1
+"#,
+            "library_call",
+            None,
+        );
+
+        // Block after a preamble.
+        expect_no_lint(
+            r#"
+options(stringsAsFactors = FALSE)
+library(dplyr)
+library(purrr)
+x <- 1
+"#,
+            "library_call",
+            None,
+        );
+
+        // `if` whose branch contains only library calls, followed by another
+        // library call: both belong to the block.
+        expect_no_lint(
+            r#"
+if (foo) {
+  library(bar)
+}
+library(baz)
+"#,
+            "library_call",
+            None,
+        );
+
+        // `suppressPackageStartupMessages(library(x))` is part of the block.
+        expect_no_lint(
+            r#"
+library(dplyr)
+suppressPackageStartupMessages(library(zoo))
+x <- 1
+"#,
+            "library_call",
+            None,
+        );
+
+        // `library()` inside a function body is never reported.
+        expect_no_lint(
+            r#"
+foo <- function() {
+  library(dplyr)
+  1
+}
+"#,
+            "library_call",
+            None,
+        );
+
+        // Order within the block doesn't matter.
+        expect_no_lint(
+            r#"
+library(purrr)
+library(dplyr)
+x <- 1
+"#,
+            "library_call",
+            None,
+        );
+    }
+
+    #[test]
+    fn test_lint_library_call() {
+        insta::assert_snapshot!(
+            snapshot_lint(
+                r#"
+library(dplyr)
+x <- 1
+library(purrr)
+"#
+            ),
+            @"
+        warning: library_call
+         --> <test>:4:1
+          |
+        4 | library(purrr)
+          | -------------- `library()` calls should be grouped at the top of the script.
+          |
+          = help: Move this call next to the other `library()` calls.
+        Found 1 error.
+        "
+        );
+
+        insta::assert_snapshot!(
+            snapshot_lint(
+                r#"
+library(dplyr)
+x <- 1
+library(purrr)
+library(abc)
+"#
+            ),
+            @"
+        warning: library_call
+         --> <test>:4:1
+          |
+        4 | library(purrr)
+          | -------------- `library()` calls should be grouped at the top of the script.
+          |
+          = help: Move this call next to the other `library()` calls.
+        warning: library_call
+         --> <test>:5:1
+          |
+        5 | library(abc)
+          | ------------ `library()` calls should be grouped at the top of the script.
+          |
+          = help: Move this call next to the other `library()` calls.
+        Found 2 errors.
+        "
+        );
+    }
+
+    #[test]
+    fn fix_output() {
+        insta::assert_snapshot!(
+            "fix_output",
+            get_unsafe_fixed_text(
+                vec![
+                    "options(stringsAsFactors = FALSE)\nlibrary(dplyr)\nif (interactive()) {\n  library(rlang)\n}\nsuppressPackageStartupMessages(library(zoo))\nx <- 1\nlibrary(purrr)\nlibrary(abc)\n",
+                ],
+                "library_call",
+            )
+        );
+
+        // The fix is unsafe: the plain (safe-only) helper shows no change.
+        insta::assert_snapshot!(
+            "fix_output_unsafe_only",
+            get_fixed_text(
+                vec!["library(dplyr)\nx <- 1\nlibrary(purrr)\n"],
+                "library_call",
+                None,
+            )
+        );
+    }
+
+    #[test]
+    fn test_library_call_with_comments_no_fix() {
+        insta::assert_snapshot!(
+            "no_fix_with_comments",
+            get_unsafe_fixed_text(
+                vec![
+                    // Leading comment inside the call.
+                    "library(dplyr)\nx <- 1\nlibrary(\n  # leading\n  purrr\n)\n",
+                    // Inline comment inside the call.
+                    "library(dplyr)\nx <- 1\nlibrary(purrr # inline\n)\n",
+                    // Trailing comment on the same line.
+                    "library(dplyr)\nx <- 1\nlibrary(purrr) # trailing\n",
+                ],
+                "library_call",
+            )
+        );
+    }
+}

--- a/crates/jarl-core/src/lints/base/library_call/snapshots/jarl_core__lints__base__library_call__tests__fix_output.snap
+++ b/crates/jarl-core/src/lints/base/library_call/snapshots/jarl_core__lints__base__library_call__tests__fix_output.snap
@@ -1,0 +1,27 @@
+---
+source: crates/jarl-core/src/lints/base/library_call/mod.rs
+expression: "get_unsafe_fixed_text(vec![\"options(stringsAsFactors = FALSE)\\nlibrary(dplyr)\\nif (interactive()) {\\n  library(rlang)\\n}\\nsuppressPackageStartupMessages(library(zoo))\\nx <- 1\\nlibrary(purrr)\\nlibrary(abc)\\n\",],\n\"library_call\",)"
+---
+OLD:
+====
+options(stringsAsFactors = FALSE)
+library(dplyr)
+if (interactive()) {
+  library(rlang)
+}
+suppressPackageStartupMessages(library(zoo))
+x <- 1
+library(purrr)
+library(abc)
+
+NEW:
+====
+options(stringsAsFactors = FALSE)
+library(dplyr)
+if (interactive()) {
+  library(rlang)
+}
+suppressPackageStartupMessages(library(zoo))
+library(purrr)
+library(abc)
+x <- 1

--- a/crates/jarl-core/src/lints/base/library_call/snapshots/jarl_core__lints__base__library_call__tests__fix_output_unsafe_only.snap
+++ b/crates/jarl-core/src/lints/base/library_call/snapshots/jarl_core__lints__base__library_call__tests__fix_output_unsafe_only.snap
@@ -1,0 +1,15 @@
+---
+source: crates/jarl-core/src/lints/base/library_call/mod.rs
+expression: "get_fixed_text(vec![\"library(dplyr)\\nx <- 1\\nlibrary(purrr)\\n\"],\n\"library_call\", None,)"
+---
+OLD:
+====
+library(dplyr)
+x <- 1
+library(purrr)
+
+NEW:
+====
+library(dplyr)
+x <- 1
+library(purrr)

--- a/crates/jarl-core/src/lints/base/library_call/snapshots/jarl_core__lints__base__library_call__tests__no_fix_with_comments.snap
+++ b/crates/jarl-core/src/lints/base/library_call/snapshots/jarl_core__lints__base__library_call__tests__no_fix_with_comments.snap
@@ -1,0 +1,49 @@
+---
+source: crates/jarl-core/src/lints/base/library_call/mod.rs
+expression: "get_unsafe_fixed_text(vec![\"library(dplyr)\\nx <- 1\\nlibrary(\\n  # leading\\n  purrr\\n)\\n\",\n\"library(dplyr)\\nx <- 1\\nlibrary(purrr # inline\\n)\\n\",\n\"library(dplyr)\\nx <- 1\\nlibrary(purrr) # trailing\\n\",], \"library_call\",)"
+---
+OLD:
+====
+library(dplyr)
+x <- 1
+library(
+  # leading
+  purrr
+)
+
+NEW:
+====
+library(dplyr)
+x <- 1
+library(
+  # leading
+  purrr
+)
+
+
+OLD:
+====
+library(dplyr)
+x <- 1
+library(purrr # inline
+)
+
+NEW:
+====
+library(dplyr)
+x <- 1
+library(purrr # inline
+)
+
+
+OLD:
+====
+library(dplyr)
+x <- 1
+library(purrr) # trailing
+
+NEW:
+====
+library(dplyr)
+x <- 1
+library(purrr) # trailing

--- a/crates/jarl-core/src/lints/base/mod.rs
+++ b/crates/jarl-core/src/lints/base/mod.rs
@@ -29,6 +29,7 @@ pub(crate) mod is_numeric;
 pub(crate) mod length_levels;
 pub(crate) mod length_test;
 pub(crate) mod lengths;
+pub(crate) mod library_call;
 pub(crate) mod list2df;
 pub(crate) mod literal_coercion;
 pub(crate) mod matrix_apply;

--- a/crates/jarl-core/src/rule_set.rs
+++ b/crates/jarl-core/src/rule_set.rs
@@ -462,6 +462,13 @@ declare_rules! {
         fix: Safe,
         min_r_version: None,
     },
+    LibraryCall => {
+        name: "library_call",
+        categories: [Read],
+        default: Disabled,
+        fix: Unsafe,
+        min_r_version: None,
+    },
     List2df => {
         name: "list2df",
         categories: [Perf, Read],

--- a/crates/jarl/tests/integration/rmd.rs
+++ b/crates/jarl/tests/integration/rmd.rs
@@ -1735,3 +1735,45 @@ plot(1)
 
     Ok(())
 }
+
+/// `library_call` doesn't apply to documents: each chunk attaches what it
+/// needs, so scattered `library()` calls are not reported.
+#[test]
+fn test_rmd_library_call_is_skipped() -> anyhow::Result<()> {
+    let case = CliTest::with_file(
+        "test.Rmd",
+        "
+```{r}
+library(dplyr)
+x <- 1
+```
+
+```{r}
+library(purrr)
+```
+",
+    )?;
+
+    insta::assert_snapshot!(
+        &mut case
+            .command()
+            .arg("check")
+            .arg("test.Rmd")
+            .arg("--select")
+            .arg("library_call")
+            .run()
+            .normalize_os_executable_name(),
+        @"
+
+    success: true
+    exit_code: 0
+    ----- stdout -----
+    ── Summary ──────────────────────────────────────
+    All checks passed!
+
+    ----- stderr -----
+    "
+    );
+
+    Ok(())
+}

--- a/docs/_quarto.yml
+++ b/docs/_quarto.yml
@@ -128,6 +128,7 @@ website:
       - rules/length_levels.md
       - rules/length_test.md
       - rules/lengths.md
+      - rules/library_call.md
       - rules/list2df.md
       - rules/literal_coercion.md
       - rules/matrix_apply.md

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -17,6 +17,9 @@
 
 ### Changes
 
+* New rule: `library_call` reports `library()` calls that are not grouped at
+  the top of the script. Disabled by default (#701).
+
 * `expect_length` no longer reports cases where `length()` is in the `expected`
   argument, e.g. `expect_equal(nrow(x), length(y))` (#684).
 

--- a/docs/rules.qmd
+++ b/docs/rules.qmd
@@ -95,6 +95,7 @@ dat <- as.data.frame(
     c("length_levels", "readability", "✅", ""),
     c("length_test", "correctness", "✅", ""),
     c("lengths", "performance, readability", "✅", ""),
+    c("library_call", "readability", "❗", "Disabled by default"),
     c("list2df", "performance, readability", "✅", "R >= 4.0"),
     c("literal_coercion", "readability", "✅", ""),
     c("matrix_apply", "performance", "✅", ""),

--- a/docs/rules/library_call.md
+++ b/docs/rules/library_call.md
@@ -14,6 +14,9 @@ consecutive block starting at the first one.
 Only `library()` is considered: `require()` returns a value that is
 routinely used for its result, so it is out of scope for this rule.
 
+This rule is skipped in R Markdown and Quarto documents, where it is often
+more acceptable to have `library()` calls in various chunks.
+
 ## Why is this bad?
 
 Scripts where `library()` calls are scattered between the code are hard to

--- a/docs/rules/library_call.md
+++ b/docs/rules/library_call.md
@@ -1,0 +1,42 @@
+# library_call
+::: {.callout-note title="Added in 0.6.0" .low-opacity}
+:::
+
+## What it does
+
+Reports `library()` calls that are not grouped at the top of the script,
+and moves them there.
+
+A preamble of setup code is allowed before the first `library()` call;
+what matters is that every `library()` call in the script forms a single
+consecutive block starting at the first one.
+
+Only `library()` is considered: `require()` returns a value that is
+routinely used for its result, so it is out of scope for this rule.
+
+## Why is this bad?
+
+Scripts where `library()` calls are scattered between the code are hard to
+read: a reader cannot tell at a glance which packages the script needs,
+and the attach order (which decides masking) becomes accidental rather
+than deliberate.
+
+This rule has an unsafe fix: moving `library()` calls changes attach order
+and therefore which package masks which.
+
+This rule is disabled by default.
+
+## Example
+
+```r
+library(dplyr)
+x <- 1
+library(purrr)
+```
+
+Use instead:
+```r
+library(dplyr)
+library(purrr)
+x <- 1
+```


### PR DESCRIPTION
Part of #8 

Unsafe fix because it can break existing code that relies on specific loading order because of namespace conflicts.

This is also the main reason against sorting `library()` calls (and sorting library calls has little benefit). 

TODO:

- [x] handle Rmd / qmd because these calls are rarely in the first chunk
  - rule is deactivated on these files, ecosystem checks report a lot of legitimate cases  