### PR TITLE
feat: Detect zero comparisons of `nchar()` in the `nzchar` rule

### DIFF
--- a/crates/jarl-core/src/lints/base/nzchar/mod.rs
+++ b/crates/jarl-core/src/lints/base/nzchar/mod.rs
@@ -70,6 +70,33 @@ mod tests {
     }
 
     #[test]
+    fn test_lint_nchar_zero_comparisons() {
+        assert_snapshot!(
+            "nchar_zero_comparisons",
+            snapshot_lint(
+                "nchar(x) > 0\nnchar(x) != 0L\nnchar(x) <= 0.0\nnchar(x) == 0\nnchar(x) >= 0\nnchar(x) < 0\n0 < nchar(x)\n0 == nchar(x)"
+            )
+        );
+
+        assert_snapshot!(
+            "nchar_zero_fix_output",
+            get_unsafe_fixed_text(
+                vec![
+                    "nchar(x) > 0",
+                    "nchar(x) != 0L",
+                    "nchar(x) <= 0.0",
+                    "nchar(x) == 0",
+                    "nchar(x) >= 0",
+                    "nchar(x) < 0",
+                    "0 < nchar(x)",
+                    "0 == nchar(x)",
+                ],
+                "nzchar",
+            )
+        );
+    }
+
+    #[test]
     fn test_no_lint_nzchar() {
         // `x %in% NaN` returns missings, but `NaN %in% x` returns TRUE/FALSE.
         expect_no_lint("'' %in% x", "nzchar", None);
@@ -85,6 +112,16 @@ mod tests {
         expect_no_lint(r#"x == "''"#, "nzchar", None);
 
         expect_no_lint(r#"x != "''"#, "nzchar", None);
+
+        expect_no_lint("nchar(x) == 1", "nzchar", None);
+
+        expect_no_lint("nchar(x, type = 'width') == 0", "nzchar", None);
+
+        expect_no_lint("nchar(x, allowNA = TRUE) == 0", "nzchar", None);
+
+        expect_no_lint("nchar(type = 'chars') == 0", "nzchar", None);
+
+        expect_no_lint("nchar() == 0", "nzchar", None);
     }
 
     #[test]

--- a/crates/jarl-core/src/lints/base/nzchar/mod.rs
+++ b/crates/jarl-core/src/lints/base/nzchar/mod.rs
@@ -73,9 +73,21 @@ mod tests {
     fn test_lint_nchar_zero_comparisons() {
         assert_snapshot!(
             "nchar_zero_comparisons",
-            snapshot_lint(
-                "nchar(x) > 0\nnchar(x) != 0L\nnchar(x) <= 0.0\nnchar(x) == 0\nnchar(x) >= 0\nnchar(x) < 0\n0 < nchar(x)\n0 == nchar(x)"
-            )
+            snapshot_lint(concat!(
+                "nchar(x) > 0\n",
+                "nchar(x) != 0L\n",
+                "nchar(x) <= 0.0\n",
+                "nchar(x) == 0\n",
+                "nchar(x) >= 0\n",
+                "nchar(x) < 0\n",
+                "0 < nchar(x)\n",
+                "0 != nchar(x)\n",
+                "0 >= nchar(x)\n",
+                "0 == nchar(x)\n",
+                "0 <= nchar(x)\n",
+                "0 > nchar(x)\n",
+                "nchar(x = x) > 0",
+            ),)
         );
 
         assert_snapshot!(
@@ -89,7 +101,12 @@ mod tests {
                     "nchar(x) >= 0",
                     "nchar(x) < 0",
                     "0 < nchar(x)",
+                    "0 != nchar(x)",
+                    "0 >= nchar(x)",
+                    "0 <= nchar(x)",
                     "0 == nchar(x)",
+                    "0 > nchar(x)",
+                    "nchar(x = x) > 0",
                 ],
                 "nzchar",
             )
@@ -135,6 +152,7 @@ mod tests {
                     "# leading comment\nx == ''",
                     "x # comment\n== ''",
                     "x == '' # trailing comment",
+                    "nchar(x) # comment\n> 0",
                 ],
                 "nzchar"
             )

--- a/crates/jarl-core/src/lints/base/nzchar/nzchar.rs
+++ b/crates/jarl-core/src/lints/base/nzchar/nzchar.rs
@@ -1,16 +1,18 @@
 use crate::diagnostic::*;
 use crate::rule_set::Rule;
-use crate::utils::node_contains_comments;
+use crate::utils::{Formals, get_arg, get_function_name, node_contains_comments};
 use air_r_syntax::*;
-use biome_rowan::AstNode;
+use biome_rowan::{AstNode, AstSeparatedList};
 use jarl_semantic::strings::get_string_literal_contents;
+
+const FORMALS_NCHAR: Formals = &["x"];
 
 /// Version added: 0.5.0
 ///
 /// ## What it does
 ///
-/// Checks for usage of `x != ""` or `x == ""`
-///  instead of `nzchar(x)` or `!nzchar(x)`.
+/// Checks for usage of `x != ""` or `x == ""`, or comparisons of `nchar(x)`
+/// with zero, such as `nchar(x) == 0`, instead of `nzchar(x)` or `!nzchar(x)`.
 ///
 /// ## Why is this bad?
 /// `x == ""` is less efficient than `!nzchar(x)`
@@ -47,8 +49,102 @@ pub fn nzchar(ast: &RBinaryExpression) -> anyhow::Result<Option<Diagnostic>> {
     let left = left?;
     let operator = operator?;
     let right = right?;
+    let operator_kind = operator.kind();
 
-    if operator.kind() != RSyntaxKind::EQUAL2 && operator.kind() != RSyntaxKind::NOT_EQUAL {
+    let (nchar_expression, zero_on_left) = if is_zero_literal(&right) {
+        (Some(&left), false)
+    } else if is_zero_literal(&left) {
+        (Some(&right), true)
+    } else {
+        (None, false)
+    };
+
+    // Normalize equivalent comparisons so `nchar(...)` is treated as the left operand.
+    // `zero_on_left` is true for forms such as `0 < nchar(x)`.
+    let normalized_operator = match (operator_kind, zero_on_left) {
+        // `nchar(x) > 0` and `0 < nchar(x)`.
+        (RSyntaxKind::GREATER_THAN, false) | (RSyntaxKind::LESS_THAN, true) => {
+            Some(RSyntaxKind::GREATER_THAN)
+        }
+        // `nchar(x) != 0` and `0 != nchar(x)`.
+        (RSyntaxKind::NOT_EQUAL, _) => Some(RSyntaxKind::NOT_EQUAL),
+        // `nchar(x) <= 0` and `0 >= nchar(x)`.
+        (RSyntaxKind::LESS_THAN_OR_EQUAL_TO, false)
+        | (RSyntaxKind::GREATER_THAN_OR_EQUAL_TO, true) => Some(RSyntaxKind::LESS_THAN_OR_EQUAL_TO),
+        // `nchar(x) == 0` and `0 == nchar(x)`.
+        (RSyntaxKind::EQUAL2, _) => Some(RSyntaxKind::EQUAL2),
+        // `nchar(x) >= 0` and `0 <= nchar(x)`.
+        (RSyntaxKind::GREATER_THAN_OR_EQUAL_TO, false)
+        | (RSyntaxKind::LESS_THAN_OR_EQUAL_TO, true) => Some(RSyntaxKind::GREATER_THAN_OR_EQUAL_TO),
+        // `nchar(x) < 0` and `0 > nchar(x)`.
+        (RSyntaxKind::LESS_THAN, false) | (RSyntaxKind::GREATER_THAN, true) => {
+            Some(RSyntaxKind::LESS_THAN)
+        }
+        // Operators other than the six comparisons above are not supported.
+        _ => None,
+    };
+
+    if let Some(nchar_expression) = nchar_expression
+        && let Some(call) = nchar_expression.as_r_call()
+        && let Some(operator) = normalized_operator
+        && get_function_name(call.function()?) == "nchar"
+    {
+        if call.arguments()?.items().len() != 1 {
+            return Ok(None);
+        }
+        if let Some(argument) =
+            get_arg(call, FORMALS_NCHAR, "x").and_then(|argument| argument.value())
+        {
+            let range = ast.syntax().text_trimmed_range();
+            let argument = argument.to_trimmed_string();
+            let (body, suggestion, replacement) = match operator {
+                RSyntaxKind::GREATER_THAN => (
+                    "`nchar(x) > 0` is inefficient.",
+                    "Use `nzchar(x)` instead.",
+                    Some(format!("nzchar({argument})")),
+                ),
+                RSyntaxKind::NOT_EQUAL => (
+                    "`nchar(x) != 0` is inefficient.",
+                    "Use `nzchar(x)` instead.",
+                    Some(format!("nzchar({argument})")),
+                ),
+                RSyntaxKind::LESS_THAN_OR_EQUAL_TO => (
+                    "`nchar(x) <= 0` is inefficient.",
+                    "Use `!nzchar(x)` instead.",
+                    Some(format!("!nzchar({argument})")),
+                ),
+                RSyntaxKind::EQUAL2 => (
+                    "`nchar(x) == 0` is inefficient.",
+                    "Use `!nzchar(x)` instead.",
+                    Some(format!("!nzchar({argument})")),
+                ),
+                RSyntaxKind::GREATER_THAN_OR_EQUAL_TO => (
+                    "`nchar(x) >= 0` is always true.",
+                    "Maybe you want `nzchar(x)` instead.",
+                    None,
+                ),
+                RSyntaxKind::LESS_THAN => (
+                    "`nchar(x) < 0` is always false.",
+                    "Maybe you want `!nzchar(x)` instead.",
+                    None,
+                ),
+                _ => unreachable!("Only comparison operators are normalized above"),
+            };
+            let fix = match replacement {
+                Some(replacement) => {
+                    Fix::new(range, replacement, node_contains_comments(ast.syntax()))
+                }
+                None => Fix::empty(),
+            };
+            return Ok(Some(Diagnostic::new(
+                ViolationData::new(Rule::NzChar, body.to_string(), Some(suggestion.to_string())),
+                range,
+                fix,
+            )));
+        }
+    }
+
+    if operator_kind != RSyntaxKind::EQUAL2 && operator_kind != RSyntaxKind::NOT_EQUAL {
         return Ok(None);
     };
 
@@ -75,7 +171,7 @@ pub fn nzchar(ast: &RBinaryExpression) -> anyhow::Result<Option<Diagnostic>> {
         left.to_trimmed_string()
     };
 
-    let diagnostic = match operator.kind() {
+    let diagnostic = match operator_kind {
         RSyntaxKind::EQUAL2 => Diagnostic::new(
             ViolationData::new(
                 Rule::NzChar,
@@ -106,4 +202,22 @@ pub fn nzchar(ast: &RBinaryExpression) -> anyhow::Result<Option<Diagnostic>> {
     };
 
     Ok(Some(diagnostic))
+}
+
+fn is_zero_literal(expression: &AnyRExpression) -> bool {
+    let Some(value) = expression.as_any_r_value() else {
+        return false;
+    };
+
+    if let Some(integer) = value.as_r_integer_value() {
+        return integer
+            .value_token()
+            .is_ok_and(|token| matches!(token.text_trimmed(), "0" | "0L"));
+    }
+    if let Some(double) = value.as_r_double_value() {
+        return double
+            .value_token()
+            .is_ok_and(|token| matches!(token.text_trimmed(), "0" | "0.0" | "0."));
+    }
+    false
 }

--- a/crates/jarl-core/src/lints/base/nzchar/nzchar.rs
+++ b/crates/jarl-core/src/lints/base/nzchar/nzchar.rs
@@ -60,28 +60,23 @@ pub fn nzchar(ast: &RBinaryExpression) -> anyhow::Result<Option<Diagnostic>> {
     };
 
     // Normalize equivalent comparisons so `nchar(...)` is treated as the left operand.
-    // `zero_on_left` is true for forms such as `0 < nchar(x)`.
-    let normalized_operator = match (operator_kind, zero_on_left) {
-        // `nchar(x) > 0` and `0 < nchar(x)`.
-        (RSyntaxKind::GREATER_THAN, false) | (RSyntaxKind::LESS_THAN, true) => {
-            Some(RSyntaxKind::GREATER_THAN)
+    let normalized_operator = if matches!(
+        operator_kind,
+        RSyntaxKind::GREATER_THAN
+            | RSyntaxKind::LESS_THAN
+            | RSyntaxKind::GREATER_THAN_OR_EQUAL_TO
+            | RSyntaxKind::LESS_THAN_OR_EQUAL_TO
+            | RSyntaxKind::EQUAL2
+            | RSyntaxKind::NOT_EQUAL
+    ) {
+        // like `0 < nchar(x)`
+        if zero_on_left {
+            Some(flip_comparison_operator(operator_kind))
+        } else {
+            Some(operator_kind)
         }
-        // `nchar(x) != 0` and `0 != nchar(x)`.
-        (RSyntaxKind::NOT_EQUAL, _) => Some(RSyntaxKind::NOT_EQUAL),
-        // `nchar(x) <= 0` and `0 >= nchar(x)`.
-        (RSyntaxKind::LESS_THAN_OR_EQUAL_TO, false)
-        | (RSyntaxKind::GREATER_THAN_OR_EQUAL_TO, true) => Some(RSyntaxKind::LESS_THAN_OR_EQUAL_TO),
-        // `nchar(x) == 0` and `0 == nchar(x)`.
-        (RSyntaxKind::EQUAL2, _) => Some(RSyntaxKind::EQUAL2),
-        // `nchar(x) >= 0` and `0 <= nchar(x)`.
-        (RSyntaxKind::GREATER_THAN_OR_EQUAL_TO, false)
-        | (RSyntaxKind::LESS_THAN_OR_EQUAL_TO, true) => Some(RSyntaxKind::GREATER_THAN_OR_EQUAL_TO),
-        // `nchar(x) < 0` and `0 > nchar(x)`.
-        (RSyntaxKind::LESS_THAN, false) | (RSyntaxKind::GREATER_THAN, true) => {
-            Some(RSyntaxKind::LESS_THAN)
-        }
-        // Operators other than the six comparisons above are not supported.
-        _ => None,
+    } else {
+        None
     };
 
     if let Some(nchar_expression) = nchar_expression
@@ -202,6 +197,19 @@ pub fn nzchar(ast: &RBinaryExpression) -> anyhow::Result<Option<Diagnostic>> {
     };
 
     Ok(Some(diagnostic))
+}
+
+fn flip_comparison_operator(operator: RSyntaxKind) -> RSyntaxKind {
+    match operator {
+        // Swapping operands turns `>` into `<` and vice versa.
+        RSyntaxKind::GREATER_THAN => RSyntaxKind::LESS_THAN,
+        RSyntaxKind::LESS_THAN => RSyntaxKind::GREATER_THAN,
+        // Swapping operands turns `>=` into `<=` and vice versa.
+        RSyntaxKind::GREATER_THAN_OR_EQUAL_TO => RSyntaxKind::LESS_THAN_OR_EQUAL_TO,
+        RSyntaxKind::LESS_THAN_OR_EQUAL_TO => RSyntaxKind::GREATER_THAN_OR_EQUAL_TO,
+        // Equality and inequality are unchanged when operands are swapped.
+        operator => operator,
+    }
 }
 
 fn is_zero_literal(expression: &AnyRExpression) -> bool {

--- a/crates/jarl-core/src/lints/base/nzchar/nzchar.rs
+++ b/crates/jarl-core/src/lints/base/nzchar/nzchar.rs
@@ -44,6 +44,79 @@ const FORMALS_NCHAR: Formals = &["x"];
 ///
 /// See `?nzchar`
 pub fn nzchar(ast: &RBinaryExpression) -> anyhow::Result<Option<Diagnostic>> {
+    // Check for comparisons of `nchar(x)` with zero, such as `nchar(x) == 0`
+    if let Some(diagnostic) = nchar_zero_comparison(ast)? {
+        return Ok(Some(diagnostic));
+    }
+
+    let RBinaryExpressionFields { left, operator, right } = ast.as_fields();
+
+    let left = left?;
+    let operator = operator?;
+    let right = right?;
+    let operator_kind = operator.kind();
+
+    if operator_kind != RSyntaxKind::EQUAL2 && operator_kind != RSyntaxKind::NOT_EQUAL {
+        return Ok(None);
+    };
+
+    let left_is_empty_string = left
+        .as_any_r_value()
+        .and_then(|value| get_string_literal_contents(&value.to_trimmed_string()))
+        .is_some_and(|content| content.is_empty());
+    let right_is_empty_string = right
+        .as_any_r_value()
+        .and_then(|value| get_string_literal_contents(&value.to_trimmed_string()))
+        .is_some_and(|content| content.is_empty());
+
+    if (left_is_empty_string && right_is_empty_string)
+        || (!left_is_empty_string && !right_is_empty_string)
+    {
+        return Ok(None);
+    }
+
+    let range = ast.syntax().text_trimmed_range();
+
+    let replacement = if left_is_empty_string {
+        right.to_trimmed_string()
+    } else {
+        left.to_trimmed_string()
+    };
+
+    let diagnostic = match operator_kind {
+        RSyntaxKind::EQUAL2 => Diagnostic::new(
+            ViolationData::new(
+                Rule::NzChar,
+                "`x == \"\"` is inefficient.".to_string(),
+                Some("Use `!nzchar(x)` instead.".to_string()),
+            ),
+            range,
+            Fix::new(
+                range,
+                format!("!nzchar({replacement})"),
+                node_contains_comments(ast.syntax()),
+            ),
+        ),
+        RSyntaxKind::NOT_EQUAL => Diagnostic::new(
+            ViolationData::new(
+                Rule::NzChar,
+                "`x != \"\"` is inefficient.".to_string(),
+                Some("Use `nzchar(x)` instead.".to_string()),
+            ),
+            range,
+            Fix::new(
+                range,
+                format!("nzchar({replacement})"),
+                node_contains_comments(ast.syntax()),
+            ),
+        ),
+        _ => unreachable!("This case is an early return"),
+    };
+
+    Ok(Some(diagnostic))
+}
+
+fn nchar_zero_comparison(ast: &RBinaryExpression) -> anyhow::Result<Option<Diagnostic>> {
     let RBinaryExpressionFields { left, operator, right } = ast.as_fields();
 
     let left = left?;
@@ -139,64 +212,7 @@ pub fn nzchar(ast: &RBinaryExpression) -> anyhow::Result<Option<Diagnostic>> {
         }
     }
 
-    if operator_kind != RSyntaxKind::EQUAL2 && operator_kind != RSyntaxKind::NOT_EQUAL {
-        return Ok(None);
-    };
-
-    let left_is_empty_string = left
-        .as_any_r_value()
-        .and_then(|value| get_string_literal_contents(&value.to_trimmed_string()))
-        .is_some_and(|content| content.is_empty());
-    let right_is_empty_string = right
-        .as_any_r_value()
-        .and_then(|value| get_string_literal_contents(&value.to_trimmed_string()))
-        .is_some_and(|content| content.is_empty());
-
-    if (left_is_empty_string && right_is_empty_string)
-        || (!left_is_empty_string && !right_is_empty_string)
-    {
-        return Ok(None);
-    }
-
-    let range = ast.syntax().text_trimmed_range();
-
-    let replacement = if left_is_empty_string {
-        right.to_trimmed_string()
-    } else {
-        left.to_trimmed_string()
-    };
-
-    let diagnostic = match operator_kind {
-        RSyntaxKind::EQUAL2 => Diagnostic::new(
-            ViolationData::new(
-                Rule::NzChar,
-                "`x == \"\"` is inefficient.".to_string(),
-                Some("Use `!nzchar(x)` instead.".to_string()),
-            ),
-            range,
-            Fix::new(
-                range,
-                format!("!nzchar({replacement})"),
-                node_contains_comments(ast.syntax()),
-            ),
-        ),
-        RSyntaxKind::NOT_EQUAL => Diagnostic::new(
-            ViolationData::new(
-                Rule::NzChar,
-                "`x != \"\"` is inefficient.".to_string(),
-                Some("Use `nzchar(x)` instead.".to_string()),
-            ),
-            range,
-            Fix::new(
-                range,
-                format!("nzchar({replacement})"),
-                node_contains_comments(ast.syntax()),
-            ),
-        ),
-        _ => unreachable!("This case is an early return"),
-    };
-
-    Ok(Some(diagnostic))
+    Ok(None)
 }
 
 fn flip_comparison_operator(operator: RSyntaxKind) -> RSyntaxKind {

--- a/crates/jarl-core/src/lints/base/nzchar/snapshots/jarl_core__lints__base__nzchar__tests__nchar_zero_comparisons.snap
+++ b/crates/jarl-core/src/lints/base/nzchar/snapshots/jarl_core__lints__base__nzchar__tests__nchar_zero_comparisons.snap
@@ -1,6 +1,6 @@
 ---
 source: crates/jarl-core/src/lints/base/nzchar/mod.rs
-expression: "snapshot_lint(\"nchar(x) > 0\\nnchar(x) != 0L\\nnchar(x) <= 0.0\\nnchar(x) == 0\\nnchar(x) >= 0\\nnchar(x) < 0\\n0 < nchar(x)\\n0 == nchar(x)\")"
+expression: "snapshot_lint(\"nchar(x) > 0\\nnchar(x) != 0L\\nnchar(x) <= 0.0\\nnchar(x) == 0\\nnchar(x) >= 0\\nnchar(x) < 0\\n0 < nchar(x)\\n0 != nchar(x)\\n0 >= nchar(x)\\n0 == nchar(x)\\n0 <= nchar(x)\\n0 > nchar(x)\\nnchar(x = x) > 0\",)"
 ---
 warning: nzchar
  --> <test>:1:1
@@ -54,8 +54,43 @@ warning: nzchar
 warning: nzchar
  --> <test>:8:1
   |
-8 | 0 == nchar(x)
-  | ------------- `nchar(x) == 0` is inefficient.
+8 | 0 != nchar(x)
+  | ------------- `nchar(x) != 0` is inefficient.
+  |
+  = help: Use `nzchar(x)` instead.
+warning: nzchar
+ --> <test>:9:1
+  |
+9 | 0 >= nchar(x)
+  | ------------- `nchar(x) <= 0` is inefficient.
   |
   = help: Use `!nzchar(x)` instead.
-Found 8 errors.
+warning: nzchar
+  --> <test>:10:1
+   |
+10 | 0 == nchar(x)
+   | ------------- `nchar(x) == 0` is inefficient.
+   |
+   = help: Use `!nzchar(x)` instead.
+warning: nzchar
+  --> <test>:11:1
+   |
+11 | 0 <= nchar(x)
+   | ------------- `nchar(x) >= 0` is always true.
+   |
+   = help: Maybe you want `nzchar(x)` instead.
+warning: nzchar
+  --> <test>:12:1
+   |
+12 | 0 > nchar(x)
+   | ------------ `nchar(x) < 0` is always false.
+   |
+   = help: Maybe you want `!nzchar(x)` instead.
+warning: nzchar
+  --> <test>:13:1
+   |
+13 | nchar(x = x) > 0
+   | ---------------- `nchar(x) > 0` is inefficient.
+   |
+   = help: Use `nzchar(x)` instead.
+Found 13 errors.

--- a/crates/jarl-core/src/lints/base/nzchar/snapshots/jarl_core__lints__base__nzchar__tests__nchar_zero_comparisons.snap
+++ b/crates/jarl-core/src/lints/base/nzchar/snapshots/jarl_core__lints__base__nzchar__tests__nchar_zero_comparisons.snap
@@ -1,0 +1,61 @@
+---
+source: crates/jarl-core/src/lints/base/nzchar/mod.rs
+expression: "snapshot_lint(\"nchar(x) > 0\\nnchar(x) != 0L\\nnchar(x) <= 0.0\\nnchar(x) == 0\\nnchar(x) >= 0\\nnchar(x) < 0\\n0 < nchar(x)\\n0 == nchar(x)\")"
+---
+warning: nzchar
+ --> <test>:1:1
+  |
+1 | nchar(x) > 0
+  | ------------ `nchar(x) > 0` is inefficient.
+  |
+  = help: Use `nzchar(x)` instead.
+warning: nzchar
+ --> <test>:2:1
+  |
+2 | nchar(x) != 0L
+  | -------------- `nchar(x) != 0` is inefficient.
+  |
+  = help: Use `nzchar(x)` instead.
+warning: nzchar
+ --> <test>:3:1
+  |
+3 | nchar(x) <= 0.0
+  | --------------- `nchar(x) <= 0` is inefficient.
+  |
+  = help: Use `!nzchar(x)` instead.
+warning: nzchar
+ --> <test>:4:1
+  |
+4 | nchar(x) == 0
+  | ------------- `nchar(x) == 0` is inefficient.
+  |
+  = help: Use `!nzchar(x)` instead.
+warning: nzchar
+ --> <test>:5:1
+  |
+5 | nchar(x) >= 0
+  | ------------- `nchar(x) >= 0` is always true.
+  |
+  = help: Maybe you want `nzchar(x)` instead.
+warning: nzchar
+ --> <test>:6:1
+  |
+6 | nchar(x) < 0
+  | ------------ `nchar(x) < 0` is always false.
+  |
+  = help: Maybe you want `!nzchar(x)` instead.
+warning: nzchar
+ --> <test>:7:1
+  |
+7 | 0 < nchar(x)
+  | ------------ `nchar(x) > 0` is inefficient.
+  |
+  = help: Use `nzchar(x)` instead.
+warning: nzchar
+ --> <test>:8:1
+  |
+8 | 0 == nchar(x)
+  | ------------- `nchar(x) == 0` is inefficient.
+  |
+  = help: Use `!nzchar(x)` instead.
+Found 8 errors.

--- a/crates/jarl-core/src/lints/base/nzchar/snapshots/jarl_core__lints__base__nzchar__tests__nchar_zero_fix_output.snap
+++ b/crates/jarl-core/src/lints/base/nzchar/snapshots/jarl_core__lints__base__nzchar__tests__nchar_zero_fix_output.snap
@@ -1,0 +1,59 @@
+---
+source: crates/jarl-core/src/lints/base/nzchar/mod.rs
+expression: "get_unsafe_fixed_text(vec![\"nchar(x) > 0\", \"nchar(x) != 0L\",\n\"nchar(x) <= 0.0\", \"nchar(x) == 0\", \"nchar(x) >= 0\", \"nchar(x) < 0\",\n\"0 < nchar(x)\", \"0 == nchar(x)\",], \"nzchar\",)"
+---
+OLD:
+====
+nchar(x) > 0
+NEW:
+====
+nzchar(x)
+
+OLD:
+====
+nchar(x) != 0L
+NEW:
+====
+nzchar(x)
+
+OLD:
+====
+nchar(x) <= 0.0
+NEW:
+====
+!nzchar(x)
+
+OLD:
+====
+nchar(x) == 0
+NEW:
+====
+!nzchar(x)
+
+OLD:
+====
+nchar(x) >= 0
+NEW:
+====
+nchar(x) >= 0
+
+OLD:
+====
+nchar(x) < 0
+NEW:
+====
+nchar(x) < 0
+
+OLD:
+====
+0 < nchar(x)
+NEW:
+====
+nzchar(x)
+
+OLD:
+====
+0 == nchar(x)
+NEW:
+====
+!nzchar(x)

--- a/crates/jarl-core/src/lints/base/nzchar/snapshots/jarl_core__lints__base__nzchar__tests__nchar_zero_fix_output.snap
+++ b/crates/jarl-core/src/lints/base/nzchar/snapshots/jarl_core__lints__base__nzchar__tests__nchar_zero_fix_output.snap
@@ -1,6 +1,6 @@
 ---
 source: crates/jarl-core/src/lints/base/nzchar/mod.rs
-expression: "get_unsafe_fixed_text(vec![\"nchar(x) > 0\", \"nchar(x) != 0L\",\n\"nchar(x) <= 0.0\", \"nchar(x) == 0\", \"nchar(x) >= 0\", \"nchar(x) < 0\",\n\"0 < nchar(x)\", \"0 == nchar(x)\",], \"nzchar\",)"
+expression: "get_unsafe_fixed_text(vec![\"nchar(x) > 0\", \"nchar(x) != 0L\",\n\"nchar(x) <= 0.0\", \"nchar(x) == 0\", \"nchar(x) >= 0\", \"nchar(x) < 0\",\n\"0 < nchar(x)\", \"0 != nchar(x)\", \"0 >= nchar(x)\", \"0 <= nchar(x)\",\n\"0 == nchar(x)\", \"0 > nchar(x)\", \"nchar(x = x) > 0\",], \"nzchar\",)"
 ---
 OLD:
 ====
@@ -53,7 +53,42 @@ nzchar(x)
 
 OLD:
 ====
+0 != nchar(x)
+NEW:
+====
+nzchar(x)
+
+OLD:
+====
+0 >= nchar(x)
+NEW:
+====
+!nzchar(x)
+
+OLD:
+====
+0 <= nchar(x)
+NEW:
+====
+0 <= nchar(x)
+
+OLD:
+====
 0 == nchar(x)
 NEW:
 ====
 !nzchar(x)
+
+OLD:
+====
+0 > nchar(x)
+NEW:
+====
+0 > nchar(x)
+
+OLD:
+====
+nchar(x = x) > 0
+NEW:
+====
+nzchar(x)

--- a/crates/jarl-core/src/lints/base/nzchar/snapshots/jarl_core__lints__base__nzchar__tests__no_fix_with_comments.snap
+++ b/crates/jarl-core/src/lints/base/nzchar/snapshots/jarl_core__lints__base__nzchar__tests__no_fix_with_comments.snap
@@ -1,6 +1,6 @@
 ---
 source: crates/jarl-core/src/lints/base/nzchar/mod.rs
-expression: "get_unsafe_fixed_text(vec![\"# leading comment\\nx == ''\", \"x # comment\\n== ''\",\n\"x == '' # trailing comment\",], \"nzchar\")"
+expression: "get_unsafe_fixed_text(vec![\"# leading comment\\nx == ''\", \"x # comment\\n== ''\",\n\"x == '' # trailing comment\", \"nchar(x) # comment\\n> 0\",], \"nzchar\")"
 ---
 OLD:
 ====
@@ -26,3 +26,12 @@ x == '' # trailing comment
 NEW:
 ====
 !nzchar(x) # trailing comment
+
+OLD:
+====
+nchar(x) # comment
+> 0
+NEW:
+====
+nchar(x) # comment
+> 0

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -20,6 +20,9 @@
 * `expect_length` no longer reports cases where `length()` is in the `expected`
   argument, e.g. `expect_equal(nrow(x), length(y))` (#684).
 
+* The `nzchar` rule now also reports comparisons of `nchar(x)` with zero, such
+  as `nchar(x) == 0`.
+
 * The LSP now also publishes diagnostics when opening a file (#685).
 
 * The CLI now prints a message suggesting `fix-roxygen = true` when some fixes

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -21,7 +21,7 @@
   argument, e.g. `expect_equal(nrow(x), length(y))` (#684).
 
 * The `nzchar` rule now also reports comparisons of `nchar(x)` with zero, such
-  as `nchar(x) == 0`.
+  as `nchar(x) == 0` (#705, @Yousa-Mirage).
 
 * The LSP now also publishes diagnostics when opening a file (#685).
 

--- a/docs/rules/nzchar.md
+++ b/docs/rules/nzchar.md
@@ -4,8 +4,8 @@
 
 ## What it does
 
-Checks for usage of `x != ""` or `x == ""`
- instead of `nzchar(x)` or `!nzchar(x)`.
+Checks for usage of `x != ""` or `x == ""`, or comparisons of `nchar(x)`
+with zero, such as `nchar(x) == 0`, instead of `nzchar(x)` or `!nzchar(x)`.
 
 ## Why is this bad?
 `x == ""` is less efficient than `!nzchar(x)`


### PR DESCRIPTION
See the discussion at #696. Now `nzchar` rule will check for comparisons of `nchar(x)` with zero, such as `nchar(x) == 0`.