### PR TITLE
fix: Support non-ASCII symbols in package analysis

### DIFF
--- a/crates/jarl-core/src/lints/base/unused_function/mod.rs
+++ b/crates/jarl-core/src/lints/base/unused_function/mod.rs
@@ -165,6 +165,48 @@ mod tests {
     }
 
     #[test]
+    fn test_non_ascii_function_used_across_files_not_flagged() {
+        let dir = TempDir::new().unwrap();
+        let r_dir = dir.path().join("R");
+        fs::create_dir(&r_dir).unwrap();
+        fs::write(dir.path().join("DESCRIPTION"), "Package: test").unwrap();
+        fs::write(dir.path().join("NAMESPACE"), "export(public_fn)\n").unwrap();
+
+        let file_a = r_dir.join("definitions.R");
+        fs::write(
+            &file_a,
+            "中文函数 <- function(x) x\n未使用 <- function() 1\nunused_helper <- function() 2\n",
+        )
+        .unwrap();
+
+        let file_b = r_dir.join("uses.R");
+        fs::write(&file_b, "use_functions <- function(x) 中文函数(x)\n").unwrap();
+
+        let shared = scan_r_package_paths(&[file_a, file_b], true);
+        let result =
+            compute_unused_from_shared(&shared, &default_options(), &read_namespace(dir.path()));
+
+        assert!(
+            !result
+                .values()
+                .any(|v| v.iter().any(|(name, _, _)| name == "中文函数")),
+            "used non-ASCII function should not be flagged"
+        );
+        assert!(
+            result
+                .values()
+                .any(|v| v.iter().any(|(name, _, _)| name == "未使用")),
+            "unused non-ASCII function should still be flagged"
+        );
+        assert!(
+            result
+                .values()
+                .any(|v| v.iter().any(|(name, _, _)| name == "unused_helper")),
+            "unused ASCII function should still be flagged"
+        );
+    }
+
+    #[test]
     fn test_internal_s3_method_not_flagged() {
         let dir = TempDir::new().unwrap();
         let r_dir = dir.path().join("R");

--- a/crates/jarl-core/src/utils.rs
+++ b/crates/jarl-core/src/utils.rs
@@ -417,26 +417,22 @@ pub fn scan_symbols(content: &str) -> HashMap<String, usize> {
             continue;
         }
 
-        let bytes = line.as_bytes();
-        let len = bytes.len();
-        let mut i = 0;
+        let mut chars = line.char_indices();
 
-        while i < len {
-            let b = bytes[i];
-
-            // R identifiers start with a letter, `.`, or `_`
-            if b.is_ascii_alphabetic() || b == b'.' || b == b'_' {
-                let start = i;
-                i += 1;
-                while i < len
-                    && (bytes[i].is_ascii_alphanumeric() || bytes[i] == b'.' || bytes[i] == b'_')
-                {
-                    i += 1;
-                }
-                let name = &line[start..i];
+        while let Some((start, character)) = chars.next() {
+            // R identifiers start with a letter, `.`, or `_`.
+            if character.is_alphabetic() || character == '.' || character == '_' {
+                let end = chars
+                    .find_map(|(index, character)| {
+                        if !character.is_alphanumeric() && character != '.' && character != '_' {
+                            Some(index)
+                        } else {
+                            None
+                        }
+                    })
+                    .unwrap_or(line.len());
+                let name = &line[start..end];
                 *symbols.entry(name).or_insert(0) += 1;
-            } else {
-                i += 1;
             }
         }
     }
@@ -514,5 +510,12 @@ mod tests {
         let syms = scan_symbols("123 + foo\n");
         assert!(syms.contains_key("foo"));
         assert!(!syms.contains_key("123"));
+    }
+
+    #[test]
+    fn test_scan_symbols_supports_non_ascii_identifiers() {
+        let syms = scan_symbols("中文函数 <- 1\n中文函数()\nhéllo <- 1\nhéllo()\n");
+        assert_eq!(syms.get("中文函数"), Some(&2));
+        assert_eq!(syms.get("héllo"), Some(&2));
     }
 }

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -27,7 +27,8 @@
 
 ### Bug fixes
 
-* Prevent `unused_function` and `unused_object` from falsely reporting non-ASCII names.
+* Prevent `unused_function` and `unused_object` from falsely reporting non-ASCII
+  names (#706, @Yousa-Mirage).
 
 * Prevent the `nzchar` rule from treating quote characters as empty strings and
   support empty raw string literals (#696, @Yousa-Mirage).

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -27,6 +27,8 @@
 
 ### Bug fixes
 
+* Prevent `unused_function` and `unused_object` from falsely reporting non-ASCII names.
+
 * Prevent the `nzchar` rule from treating quote characters as empty strings and
   support empty raw string literals (#696, @Yousa-Mirage).
 


### PR DESCRIPTION
The issue requires a minimal R package to reproduce because `unused_function` compares function definitions and symbol references across package files:

```text
test-jarl/
├── DESCRIPTION
├── NAMESPACE
└── R/
    ├── definitions.R
    └── uses.R
```

`DESCRIPTION`:

```text
Package: demo
Version: 0.0.1
```

`NAMESPACE`:

```r
export(use_functions)
```

`R/definitions.R`:

```r
中文函数 <- function(x) x
未使用 <- function() 1
unused_helper <- function() 2
```

`R/uses.R`:

```r
use_functions <- function(x) 中文函数(x)
```

Run the command in `test-jarl` dir:

```bash
jarl check .
```

Before the fix, `中文函数` is incorrectly reported as defined but never called, alongside the genuinely unused functions. After the fix, only `未使用` and `unused_helper` are reported.

This is because `scan_symbols` scanned raw bytes and recognized only ASCII identifier bytes, while package definition scanning recognized Unicode identifiers, so calls to non-ASCII functions were omitted from occurrence counts and reported as unused.

I use `char_indices()` to preserve UTF-8 byte offsets while scanning Unicode letters and alphanumeric characters, keeping `.` and `_` as valid identifier characters.

---

**Edit:**

The non-ASCII issue with `unused_object` will only occur in Rmd/Qmd:

````qmd
---
title: "test non-ASCII symbols in Rmd/Qmd"
format: html
---

```{r}
变量 <- 1
```

Value is `r 变量` here.
````

Run `jarl check test.qmd --select unused_object`:

```
warning: unused_object
 --> test.qmd:7:1
  |
7 | 变量 <- 1
  | ---- Object `变量` is defined but never used.
  |

── Summary ──────────────────────────────────────
Found 1 error.
```

This PR fixed this together.