### PR TITLE
fix: Correct Rmd/Qmd suppression quickfix positions

### DIFF
--- a/crates/jarl-core/src/suppression_edit.rs
+++ b/crates/jarl-core/src/suppression_edit.rs
@@ -543,7 +543,7 @@ mod tests {
     fn test_create_suppression_edit_in_rmd_remaps_line() {
         let source = concat!(
             "---\n",
-            "title: \"demo\"\n",
+            "title: \"Demo\"\n",
             "output: html_document\n",
             "---\n",
             "\n",

--- a/crates/jarl-core/src/suppression_edit.rs
+++ b/crates/jarl-core/src/suppression_edit.rs
@@ -438,6 +438,7 @@ pub fn create_suppression_edit_in_rmd(
                 compute_suppression_insert_point(&chunk.code, local_start, local_end)?;
             // Remap chunk-local offset to file-level offset.
             insert_point.offset += chunk.start_byte;
+            insert_point.line = count_lines_to(file_content, insert_point.offset);
             let comment_text = format_suppression_comments(
                 &[rule_name],
                 explanation,
@@ -536,6 +537,41 @@ mod tests {
         // Should insert at the start of the line, no leading newline needed
         assert!(!insert.needs_leading_newline);
         assert_eq!(insert.indent, "  ");
+    }
+
+    #[test]
+    fn test_create_suppression_edit_in_rmd_remaps_line() {
+        let source = concat!(
+            "---\n",
+            "title: \"demo\"\n",
+            "output: html_document\n",
+            "---\n",
+            "\n",
+            "Introductory text.\n",
+            "\n",
+            "```{r}\n",
+            "x <- 1\n",
+            "any(is.na(x))\n",
+            "```\n",
+        );
+        let diagnostic_start = source.find("any(is.na(x))").unwrap();
+        let diagnostic_end = diagnostic_start + "any(is.na(x))".len();
+
+        let edit = create_suppression_edit_in_rmd(
+            source,
+            diagnostic_start,
+            diagnostic_end,
+            "any_is_na",
+            "<reason>",
+        )
+        .unwrap();
+
+        assert_eq!(edit.insert_point.line, 9);
+        assert_eq!(
+            edit.insert_point.offset,
+            source.find("any(is.na(x))").unwrap()
+        );
+        assert!(!edit.insert_point.needs_leading_newline);
     }
 
     #[test]

--- a/crates/jarl-lsp/src/server.rs
+++ b/crates/jarl-lsp/src/server.rs
@@ -1257,10 +1257,19 @@ select = ["ALL"]
         source_with_cursor: &str,
         encoding: PositionEncoding,
     ) -> Option<String> {
+        apply_jarl_ignore_at_cursor_with_encoding_and_extension(source_with_cursor, encoding, "R")
+    }
+
+    /// Apply a jarl-ignore action for a file with the given extension.
+    fn apply_jarl_ignore_at_cursor_with_encoding_and_extension(
+        source_with_cursor: &str,
+        encoding: PositionEncoding,
+        extension: &str,
+    ) -> Option<String> {
         let cursor_pos = source_with_cursor.find(CURSOR)?;
         let content = source_with_cursor.replace(CURSOR, "");
 
-        let env = TestEnv::new(&content);
+        let env = TestEnv::new_with_extension(&content, extension);
         let snapshot = env.create_snapshot_with_encoding(&content, encoding);
 
         // Run the linter to get real diagnostics
@@ -1471,6 +1480,47 @@ x <- foo(<CURS>any(is.na(x)))
         # jarl-ignore any_is_na: <reason>
         x <- foo(any(is.na(x)))
         ");
+    }
+
+    #[test]
+    fn test_suppression_insert_new_comment_in_rmd_and_qmd_chunk() {
+        let source = concat!(
+            "---\n",
+            "title: \"B-H7\"\n",
+            "output: html_document\n",
+            "---\n",
+            "\n",
+            "Introductory text.\n",
+            "\n",
+            "```{r}\n",
+            "x <- 1\n",
+            "<CURS>any(is.na(x))\n",
+            "```\n",
+        );
+        let expected = concat!(
+            "---\n",
+            "title: \"B-H7\"\n",
+            "output: html_document\n",
+            "---\n",
+            "\n",
+            "Introductory text.\n",
+            "\n",
+            "```{r}\n",
+            "x <- 1\n",
+            "# jarl-ignore any_is_na: <reason>\n",
+            "any(is.na(x))\n",
+            "```\n",
+        );
+
+        for extension in ["Rmd", "qmd"] {
+            let result = apply_jarl_ignore_at_cursor_with_encoding_and_extension(
+                source,
+                PositionEncoding::UTF8,
+                extension,
+            )
+            .unwrap();
+            assert_eq!(result, expected, "unexpected insertion for .{extension}");
+        }
     }
 
     #[test]

--- a/crates/jarl-lsp/src/server.rs
+++ b/crates/jarl-lsp/src/server.rs
@@ -1486,7 +1486,7 @@ x <- foo(<CURS>any(is.na(x)))
     fn test_suppression_insert_new_comment_in_rmd_and_qmd_chunk() {
         let source = concat!(
             "---\n",
-            "title: \"B-H7\"\n",
+            "title: \"Demo\"\n",
             "output: html_document\n",
             "---\n",
             "\n",
@@ -1499,7 +1499,7 @@ x <- foo(<CURS>any(is.na(x)))
         );
         let expected = concat!(
             "---\n",
-            "title: \"B-H7\"\n",
+            "title: \"Demo\"\n",
             "output: html_document\n",
             "---\n",
             "\n",

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -27,6 +27,8 @@
 
 ### Bug fixes
 
+* Fix LSP `jarl-ignore` quickfix insertion positions in Rmd and Qmd files.
+
 * Prevent the `nzchar` rule from treating quote characters as empty strings and
   support empty raw string literals (#696, @Yousa-Mirage).
 

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -27,7 +27,8 @@
 
 ### Bug fixes
 
-* Fix LSP `jarl-ignore` quickfix insertion positions in Rmd and Qmd files.
+* Fix LSP `jarl-ignore` quickfix insertion positions in Rmd and Qmd files
+  (#708, @Yousa-Mirage).
 
 * Prevent the `nzchar` rule from treating quote characters as empty strings and
   support empty raw string literals (#696, @Yousa-Mirage).

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -27,9 +27,6 @@
 
 ### Bug fixes
 
-* Fix LSP `jarl-ignore` quickfix insertion positions in Rmd and Qmd files
-  (#708, @Yousa-Mirage).
-
 * Prevent the `nzchar` rule from treating quote characters as empty strings and
   support empty raw string literals (#696, @Yousa-Mirage).
 
@@ -55,8 +52,8 @@
   autofix now also produces `lengths(x)` instead of the invalid
   `lengths(X = x)` when `X` is passed by name (#671, @Yousa-Mirage).
 
-* Fix language server suppression quickfix positions for non-ASCII text
-  (#676, @Yousa-Mirage).
+* Fix language server suppression quickfix positions for non-ASCII text and
+  Rmd/Qmd chunk insertion positions (#676, #708, @Yousa-Mirage).
 
 * Avoid invalid `literal_coercion` fixes for strings containing quotes
   (#678, @Yousa-Mirage).


### PR DESCRIPTION
Another issue with Rmd/Qmd.

An example `test.qmd`:

````qmd
---
title: "Suppress with jarl-ignore comment"
format: html
---

```{r}
x <- 1
any(is.na(x))
```
````

Click this in IDE:

<img width="400" height="122" alt="图片" src="https://github.com/user-attachments/assets/5f2be762-a934-4517-8494-a3eb36f96dc3" />

Then we will get:

````qmd
---
# jarl-ignore any_is_na: <reason>   # The comment is wrongly inserted here.
title: "Suppress with jarl-ignore comment"
format: html
---

```{r}
x <- 1
any(is.na(x))
```
````

The fix is only one line:

```rust
insert_point.line = count_lines_to(file_content, insert_point.offset);
```