### PR TITLE
fix: Handle `Rmd` and `Qmd` extensions case-insensitively

### DIFF
--- a/crates/jarl-core/src/fs.rs
+++ b/crates/jarl-core/src/fs.rs
@@ -38,5 +38,5 @@ pub fn has_rmd_extension(path: &Path) -> bool {
 }
 
 pub fn is_rmd_extension(ext: &str) -> bool {
-    matches!(ext, "rmd" | "Rmd" | "qmd" | "Qmd")
+    ext.eq_ignore_ascii_case("rmd") || ext.eq_ignore_ascii_case("qmd")
 }

--- a/crates/jarl/tests/integration/rmd.rs
+++ b/crates/jarl/tests/integration/rmd.rs
@@ -1735,3 +1735,56 @@ plot(1)
 
     Ok(())
 }
+
+/// Rmd/Qmd files must be handled consistently regardless of extension casing.
+#[test]
+fn test_uppercase_rmd_qmd_no_autofix() -> anyhow::Result<()> {
+    let content = "```{r}
+any(is.na(x))
+```
+";
+    let case = CliTest::with_files([("report.RMD", content), ("notes.QMD", content)])?;
+
+    insta::assert_snapshot!(
+        &mut case
+            .command()
+            .arg("check")
+            .arg("report.RMD")
+            .arg("notes.QMD")
+            .arg("--fix")
+            .arg("--allow-no-vcs")
+            .run()
+            .normalize_os_executable_name(),
+        @"
+
+    success: false
+    exit_code: 1
+    ----- stdout -----
+    warning: any_is_na
+     --> notes.QMD:2:1
+      |
+    2 | any(is.na(x))
+      | ------------- `any(is.na(...))` is inefficient.
+      |
+      = help: Use `anyNA(...)` instead.
+
+    warning: any_is_na
+     --> report.RMD:2:1
+      |
+    2 | any(is.na(x))
+      | ------------- `any(is.na(...))` is inefficient.
+      |
+      = help: Use `anyNA(...)` instead.
+
+
+    ── Summary ──────────────────────────────────────
+    Found 2 errors.
+
+    ----- stderr -----
+    "
+    );
+    assert_eq!(case.read_file("report.RMD")?, content);
+    assert_eq!(case.read_file("notes.QMD")?, content);
+
+    Ok(())
+}

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -27,8 +27,8 @@
 
 ### Bug fixes
 
-* Treat uppercase `.RMD`/`.QMD` extensions (and any other letter-case variant)
-  files consistently.
+* Handle uppercase `.RMD`/`.QMD` extensions (and any other letter-case variant)
+  files consistently (#709, @Yousa-Mirage).
 
 * Prevent the `nzchar` rule from treating quote characters as empty strings and
   support empty raw string literals (#696, @Yousa-Mirage).

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -27,6 +27,9 @@
 
 ### Bug fixes
 
+* Treat uppercase `.RMD`/`.QMD` extensions (and any other letter-case variant)
+  files consistently.
+
 * Prevent the `nzchar` rule from treating quote characters as empty strings and
   support empty raw string literals (#696, @Yousa-Mirage).
 


### PR DESCRIPTION
We have two same Rmarkdown files expect their extension names, `test.RMD` and `test.Rmd`:

````rmd
---
title: RMD is different from Rmd
---

```{r}
x <- any(is.na(y))
```
````

Now run check:

```bash
$jarl check test.RMD

── Summary ──────────────────────────────────────
All checks passed!
```

```bash
$jarl check test.Rmd

warning: any_is_na
 --> test.Rmd:6:6
  |
6 | x <- any(is.na(y))
  |      ------------- `any(is.na(...))` is inefficient.
  |
  = help: Use `anyNA(...)` instead.


── Summary ──────────────────────────────────────
Found 1 error.
```

The fix is simple, just from `matches!(ext, "rmd" | "Rmd" | "qmd" | "Qmd")` to `ext.eq_ignore_ascii_case("rmd") || ext.eq_ignore_ascii_case("qmd")`