### PR TITLE
fix: Respect `exportPattern()` in `unused_object`

### DIFF
--- a/crates/jarl-core/src/check.rs
+++ b/crates/jarl-core/src/check.rs
@@ -321,6 +321,7 @@ pub fn get_checks(
         file,
         semantic,
         config,
+        pkg,
         pkg_contexts,
         file_pkg_info,
     );
@@ -492,6 +493,7 @@ fn get_package_info(
     file: &Path,
     semantic: &oak_semantic::semantic_index::SemanticIndex,
     config: &Config,
+    pkg: &PackageAnalysis,
     pkg_contexts: &HashMap<PathBuf, PackageContext>,
     file_pkg_info: &HashMap<PathBuf, FilePackageInfo>,
 ) {
@@ -500,7 +502,11 @@ fn get_package_info(
             match pkg_contexts.get(package_root) {
                 Some(ctx) => {
                     checker.import_from = ctx.import_from.clone();
-                    checker.namespace_exports = ctx.namespace_exports.clone();
+                    checker.namespace_exports = pkg
+                        .namespace_exports
+                        .get(package_root)
+                        .cloned()
+                        .unwrap_or_else(|| ctx.namespace_exports.clone());
                     // Already seeded with `DEFAULT_PACKAGES`.
                     ctx.loaded_packages.clone()
                 }
@@ -1065,6 +1071,7 @@ mod tests {
             &target_path,
             &index,
             &config,
+            &crate::package::PackageAnalysis::default(),
             &pkg_contexts,
             &file_pkg_info,
         );

--- a/crates/jarl-core/src/package.rs
+++ b/crates/jarl-core/src/package.rs
@@ -1,5 +1,5 @@
 use biome_rowan::TextRange;
-use oak_semantic::semantic_index::SemanticIndex;
+use oak_semantic::semantic_index::{ScopeId, SemanticIndex};
 use rayon::prelude::*;
 use std::collections::{HashMap, HashSet};
 use std::path::{Path, PathBuf};
@@ -92,6 +92,9 @@ pub struct PackageAnalysis {
     /// help)` triples for functions that are defined but never called and not
     /// exported.
     pub unused_functions: HashMap<PathBuf, Vec<(String, TextRange, String)>>,
+    /// Names exported by each package's NAMESPACE, with `exportPattern()`
+    /// expanded against all top-level definitions in that package.
+    pub namespace_exports: HashMap<PathBuf, HashSet<String>>,
     /// Per-file set of top-level object names that are read from *another*
     /// file. Keyed by relativized file path. All of a package's R files share
     /// one namespace, so a top-level binding defined in one file and used in
@@ -411,9 +414,47 @@ pub fn make_package_analysis(
         crate::db::CrossFileAnalysis::default()
     };
 
+    // `scan_top_level_assignments` only collects functions; use the semantic
+    // indices here so `exportPattern()` also covers ordinary objects.
+    let namespace_exports = if check_unused_object {
+        let mut all_defined_names: HashMap<PathBuf, Vec<String>> = HashMap::new();
+        let top_level = ScopeId::from(0);
+        for file in shared_data.iter().filter(|file| file.scope == FileScope::R) {
+            let Some(index) = cross_file.indices.get(&file.rel_path) else {
+                continue;
+            };
+            let symbols = index.symbols(top_level);
+            all_defined_names
+                .entry(file.package_root.clone())
+                .or_default()
+                .extend(
+                    index
+                        .definitions(top_level)
+                        .iter()
+                        .map(|(_, def)| symbols.symbol(def.symbol()).name().to_string()),
+                );
+        }
+
+        namespace_contents
+            .iter()
+            .map(|(root, content)| {
+                let names: Vec<&str> = all_defined_names
+                    .get(root)
+                    .into_iter()
+                    .flatten()
+                    .map(String::as_str)
+                    .collect();
+                (root.clone(), parse_namespace_exports(content, &names))
+            })
+            .collect()
+    } else {
+        HashMap::new()
+    };
+
     PackageAnalysis {
         duplicate_assignments,
         unused_functions,
+        namespace_exports,
         cross_file_used: cross_file.used,
         file_indices: cross_file.indices,
         source_index_cache: cross_file.source_index_cache,

--- a/crates/jarl/tests/integration/unused_object.rs
+++ b/crates/jarl/tests/integration/unused_object.rs
@@ -160,6 +160,46 @@ fn test_exported_alias_not_flagged() -> anyhow::Result<()> {
 }
 
 #[test]
+fn test_export_pattern_objects_not_flagged() -> anyhow::Result<()> {
+    let case = CliTest::package_with_files([
+        ("NAMESPACE", "exportPattern(\"^public_\")\n"),
+        ("R/public.R", "public_value <- 1\n"),
+        ("R/private.R", "private_value <- 1\n"),
+    ])?;
+
+    insta::assert_snapshot!(
+        &mut case
+            .command()
+            .arg("check")
+            .arg(".")
+            .arg("--select")
+            .arg("unused_object")
+            .run()
+            .normalize_os_executable_name(),
+        @"
+
+    success: false
+    exit_code: 1
+    ----- stdout -----
+    warning: unused_object
+     --> R/private.R:1:1
+      |
+    1 | private_value <- 1
+      | ------------- Object `private_value` is defined but never used.
+      |
+
+
+    ── Summary ──────────────────────────────────────
+    Found 1 error.
+
+    ----- stderr -----
+    "
+    );
+
+    Ok(())
+}
+
+#[test]
 fn test_source_cycle_terminates() -> anyhow::Result<()> {
     // `p.R` and `q.R` source each other. Resolution must terminate, and the
     // read of `k` in `p.R` still consumes `q.R`'s binding.

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -27,7 +27,8 @@
 
 ### Bug fixes
 
-* Prevent `unused_object` from reporting objects exported by `exportPattern()`.
+* Prevent `unused_object` from reporting objects exported by `exportPattern()`
+  (#711, @Yousa-Mirage).
 
 * Handle uppercase `.RMD`/`.QMD` extensions (and any other letter-case variant)
   files consistently (#709, @Yousa-Mirage).

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -27,6 +27,8 @@
 
 ### Bug fixes
 
+* Prevent `unused_object` from reporting objects exported by `exportPattern()`.
+
 * Handle uppercase `.RMD`/`.QMD` extensions (and any other letter-case variant)
   files consistently (#709, @Yousa-Mirage).
 


### PR DESCRIPTION
This minimized package:

```
testpkg/
├── DESCRIPTION
├── NAMESPACE
└── R/
    └── values.R
```

In `NAMESPACE` we export all objects that start with `public_`:

```r
exportPattern("^public_")
```

In `R/values.R`:

```r
public_value <- 1
private_value <- 1
```

Then run Jarl check:

```bash
$jarl check . --select unused_object

warning: unused_object
 --> R/values.R:1:1
  |
1 | public_value <- 1
  | ------------ Object `public_value` is defined but never used.
  |

warning: unused_object
 --> R/values.R:2:1
  |
2 | private_value <- 1
  | ------------- Object `private_value` is defined but never used.
  |


── Summary ──────────────────────────────────────
Found 2 errors.
```

This is becaue `PackageContext` parsed `NAMESPACE` with an empty `all_names` list, so `exportPattern()` never expanded to the package’s defined objects and `unused_object` treated them as unexported.

Now We collect all top-level object names from the package’s `R/` files and expand `exportPattern()` against them before checking `unused_object`.