### PR TITLE
feat: Custom messages for undesirable functions (#655)

### DIFF
--- a/artifacts/jarl.schema.json
+++ b/artifacts/jarl.schema.json
@@ -352,7 +352,7 @@
         },
         "undesirable_function": {
           "title": "Options for the `undesirable_function` rule",
-          "description": "Use `functions` to fully replace the default list of undesirable functions.\nUse `extend-functions` to add to the default list.\nSpecifying both is an error.",
+          "description": "Use `functions` to fully replace the default list of undesirable functions.\nUse `extend-functions` to add to the default list.\nEntries in `functions` and `extend-functions` can be strings or inline\ntables mapping a function to a custom suggestion.\nSpecifying both is an error.",
           "anyOf": [
             {
               "$ref": "#/$defs/UndesirableFunctionOptions"
@@ -503,8 +503,22 @@
       },
       "additionalProperties": false
     },
+    "UndesirableFunctionEntry": {
+      "description": "A function name, or a map from one or more function names to suggestions.",
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          }
+        }
+      ]
+    },
     "UndesirableFunctionOptions": {
-      "description": "TOML options for `[lint.undesirable_function]`.\n\nUse `functions` to fully replace the default list of undesirable functions.\nUse `extend-functions` to add to the default list.\nSpecifying both is an error.",
+      "description": "TOML options for `[lint.undesirable_function]`.\n\nUse `functions` to fully replace the default list of undesirable functions.\nUse `extend-functions` to add to the default list.\nEntries can be strings or inline tables mapping a function to a custom\nsuggestion.\nSpecifying both is an error.",
       "type": "object",
       "properties": {
         "extend-functions": {
@@ -513,7 +527,7 @@
             "null"
           ],
           "items": {
-            "type": "string"
+            "$ref": "#/$defs/UndesirableFunctionEntry"
           }
         },
         "functions": {
@@ -522,7 +536,7 @@
             "null"
           ],
           "items": {
-            "type": "string"
+            "$ref": "#/$defs/UndesirableFunctionEntry"
           }
         }
       },

--- a/crates/jarl-core/src/lints/base/undesirable_function/mod.rs
+++ b/crates/jarl-core/src/lints/base/undesirable_function/mod.rs
@@ -4,6 +4,7 @@ pub(crate) mod undesirable_function;
 #[cfg(test)]
 mod tests {
     use crate::lints::base::undesirable_function::options::ResolvedUndesirableFunctionOptions;
+    use crate::lints::base::undesirable_function::options::UndesirableFunctionEntry;
     use crate::lints::base::undesirable_function::options::UndesirableFunctionOptions;
     use crate::rule_options::ResolvedRuleOptions;
     use crate::settings::{LinterSettings, Settings};
@@ -76,7 +77,7 @@ mod tests {
     #[test]
     fn test_custom_functions() {
         let settings = settings_with_options(UndesirableFunctionOptions {
-            functions: Some(vec!["debug".to_string()]),
+            functions: Some(vec![UndesirableFunctionEntry::Name("debug".to_string())]),
             extend_functions: None,
         });
 
@@ -102,7 +103,7 @@ mod tests {
     fn test_extend_functions() {
         let settings = settings_with_options(UndesirableFunctionOptions {
             functions: None,
-            extend_functions: Some(vec!["debug".to_string()]),
+            extend_functions: Some(vec![UndesirableFunctionEntry::Name("debug".to_string())]),
         });
 
         // "browser" is still in the defaults -> lints
@@ -131,6 +132,50 @@ mod tests {
           |
         Found 1 error.
         "
+        );
+    }
+
+    #[test]
+    fn test_custom_messages() {
+        let options: UndesirableFunctionOptions = toml::from_str(
+            r#"
+            extend-functions = [
+                { setwd = 'Use here::here().' },
+                "sprintf",
+                { transmute = 'Use mutate(.keep = "none").' },
+            ]
+            "#,
+        )
+        .unwrap();
+
+        let settings = settings_with_options(options);
+
+        assert_snapshot!(
+            snapshot_lint_with_settings("setwd()", settings.clone()),
+            @"
+        warning: undesirable_function
+         --> <test>:1:1
+          |
+        1 | setwd()
+          | ------- `setwd()` is listed as an undesirable function.
+          |
+          = help: Use here::here().
+        Found 1 error.
+        "
+        );
+
+        assert_snapshot!(
+            snapshot_lint_with_settings("transmute()", settings),
+            @r#"
+        warning: undesirable_function
+         --> <test>:1:1
+          |
+        1 | transmute()
+          | ----------- `transmute()` is listed as an undesirable function.
+          |
+          = help: Use mutate(.keep = "none").
+        Found 1 error.
+        "#
         );
     }
 }

--- a/crates/jarl-core/src/lints/base/undesirable_function/options.rs
+++ b/crates/jarl-core/src/lints/base/undesirable_function/options.rs
@@ -1,21 +1,32 @@
-use std::collections::HashSet;
+use std::collections::{HashMap, HashSet};
 
 use crate::rule_options::resolve_with_extend;
 
 /// Default functions that are considered undesirable.
 const DEFAULT_FUNCTIONS: &[&str] = &["browser"];
 
+/// A function name, or a map from one or more function names to suggestions.
+#[derive(Clone, Debug, PartialEq, Eq, serde::Deserialize)]
+#[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
+#[serde(untagged)]
+pub enum UndesirableFunctionEntry {
+    Name(String),
+    Message(HashMap<String, String>),
+}
+
 /// TOML options for `[lint.undesirable_function]`.
 ///
 /// Use `functions` to fully replace the default list of undesirable functions.
 /// Use `extend-functions` to add to the default list.
+/// Entries can be strings or inline tables mapping a function to a custom
+/// suggestion.
 /// Specifying both is an error.
 #[derive(Clone, Debug, PartialEq, Eq, Default, serde::Deserialize)]
 #[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 #[serde(deny_unknown_fields, rename_all = "kebab-case")]
 pub struct UndesirableFunctionOptions {
-    pub functions: Option<Vec<String>>,
-    pub extend_functions: Option<Vec<String>>,
+    pub functions: Option<Vec<UndesirableFunctionEntry>>,
+    pub extend_functions: Option<Vec<UndesirableFunctionEntry>>,
 }
 
 /// Resolved options for the `undesirable_function` rule, ready for use during
@@ -23,6 +34,7 @@ pub struct UndesirableFunctionOptions {
 #[derive(Clone, Debug)]
 pub struct ResolvedUndesirableFunctionOptions {
     pub functions: HashSet<String>,
+    pub messages: HashMap<String, String>,
 }
 
 impl ResolvedUndesirableFunctionOptions {
@@ -32,14 +44,42 @@ impl ResolvedUndesirableFunctionOptions {
             None => (None, None),
         };
 
+        let base_names = base.map(|entries| entry_names(entries));
+        let extend_names = extend.map(|entries| entry_names(entries));
         let functions = resolve_with_extend(
-            base,
-            extend,
+            base_names.as_ref(),
+            extend_names.as_ref(),
             DEFAULT_FUNCTIONS,
             "undesirable_function",
             "functions",
         )?;
+        let mut messages = HashMap::new();
 
-        Ok(Self { functions })
+        if let Some(entries) = base.or(extend) {
+            add_messages(entries, &mut messages);
+        }
+
+        Ok(Self { functions, messages })
+    }
+}
+
+fn entry_names(entries: &[UndesirableFunctionEntry]) -> Vec<String> {
+    let mut names = Vec::new();
+
+    for entry in entries {
+        match entry {
+            UndesirableFunctionEntry::Name(function) => names.push(function.clone()),
+            UndesirableFunctionEntry::Message(entries) => names.extend(entries.keys().cloned()),
+        }
+    }
+
+    names
+}
+
+fn add_messages(entries: &[UndesirableFunctionEntry], messages: &mut HashMap<String, String>) {
+    for entry in entries {
+        if let UndesirableFunctionEntry::Message(entries) = entry {
+            messages.extend(entries.clone());
+        }
     }
 }

--- a/crates/jarl-core/src/lints/base/undesirable_function/undesirable_function.rs
+++ b/crates/jarl-core/src/lints/base/undesirable_function/undesirable_function.rs
@@ -6,6 +6,7 @@ use biome_rowan::AstNode;
 
 pub struct UndesirableFunction {
     pub fn_name: String,
+    pub message: Option<String>,
 }
 
 /// Version added: 0.5.0
@@ -30,8 +31,12 @@ pub struct UndesirableFunction {
 /// # Replace the default list entirely:
 /// functions = ["browser", "debug"]
 ///
-/// # Or add to the defaults:
-/// extend-functions = ["debug"]
+/// # Or add to the defaults, with optional suggestions:
+/// extend-functions = [
+///   { setwd = 'Use here::here().' },
+///   "sprintf",
+///   { transmute = 'Use mutate(.keep = "none").' },
+/// ]
 /// ```
 ///
 /// ## Example
@@ -49,6 +54,9 @@ impl Violation for UndesirableFunction {
     }
     fn body(&self) -> String {
         format!("`{}()` is listed as an undesirable function.", self.fn_name)
+    }
+    fn suggestion(&self) -> Option<String> {
+        self.message.clone()
     }
 }
 
@@ -68,7 +76,15 @@ pub fn undesirable_function(
 
     let range = ast.syntax().text_trimmed_range();
     let diagnostic = Diagnostic::new(
-        UndesirableFunction { fn_name: fn_name.to_string() },
+        UndesirableFunction {
+            fn_name: fn_name.to_string(),
+            message: checker
+                .rule_options
+                .undesirable_function
+                .messages
+                .get(fn_name)
+                .cloned(),
+        },
         range,
         Fix::empty(),
     );

--- a/crates/jarl-core/src/toml.rs
+++ b/crates/jarl-core/src/toml.rs
@@ -322,6 +322,8 @@ pub struct LinterTomlOptions {
     ///
     /// Use `functions` to fully replace the default list of undesirable functions.
     /// Use `extend-functions` to add to the default list.
+    /// Entries in `functions` and `extend-functions` can be strings or inline
+    /// tables mapping a function to a custom suggestion.
     /// Specifying both is an error.
     #[serde(rename = "undesirable_function")]
     pub undesirable_function: Option<UndesirableFunctionOptions>,

--- a/crates/jarl/tests/integration/toml_rule_args.rs
+++ b/crates/jarl/tests/integration/toml_rule_args.rs
@@ -683,6 +683,252 @@ quote = "foo"
     Ok(())
 }
 
+// undesirable_function ----------------------------------------
+
+#[test]
+fn test_undesirable_function_both_functions_and_extend_is_error() -> anyhow::Result<()> {
+    let case = CliTest::with_files([
+        (
+            "jarl.toml",
+            r#"
+[lint.undesirable_function]
+functions = ["setwd"]
+extend-functions = ["sprintf"]
+"#,
+        ),
+        ("test.R", "setwd(\"data\")"),
+    ])?;
+
+    insta::assert_snapshot!(
+        &mut case
+            .command()
+            .arg("check")
+            .arg(".")
+            .run()
+            .normalize_os_executable_name()
+            .normalize_temp_paths(),
+        @r#"
+
+    success: false
+    exit_code: 255
+    ----- stdout -----
+
+    ----- stderr -----
+    jarl failed
+      Cause: Invalid configuration in [TEMP_DIR]/jarl.toml:
+    Cannot specify both `functions` and `extend-functions` in `[lint.undesirable_function]`.
+    "#
+    );
+
+    Ok(())
+}
+
+#[test]
+fn test_undesirable_function_unknown_field_is_error() -> anyhow::Result<()> {
+    let case = CliTest::with_files([
+        (
+            "jarl.toml",
+            r#"
+[lint.undesirable_function]
+unknown-option = ["setwd"]
+"#,
+        ),
+        ("test.R", "setwd(\"data\")"),
+    ])?;
+
+    insta::assert_snapshot!(
+        &mut case
+            .command()
+            .arg("check")
+            .arg(".")
+            .run()
+            .normalize_os_executable_name()
+            .normalize_temp_paths(),
+        @r#"
+
+    success: false
+    exit_code: 255
+    ----- stdout -----
+
+    ----- stderr -----
+    jarl failed
+      Cause: Failed to parse [TEMP_DIR]/jarl.toml:
+    TOML parse error at line 3, column 1
+      |
+    3 | unknown-option = ["setwd"]
+      | ^^^^^^^^^^^^^^
+    unknown field `unknown-option`, expected `functions` or `extend-functions`
+    "#
+    );
+
+    Ok(())
+}
+
+#[test]
+fn test_undesirable_function_invalid_entry_is_error() -> anyhow::Result<()> {
+    let case = CliTest::with_files([
+        (
+            "jarl.toml",
+            r#"
+[lint.undesirable_function]
+extend-functions = [123]
+"#,
+        ),
+        ("test.R", "setwd(\"data\")"),
+    ])?;
+
+    insta::assert_snapshot!(
+        &mut case
+            .command()
+            .arg("check")
+            .arg(".")
+            .run()
+            .normalize_os_executable_name()
+            .normalize_temp_paths(),
+        @r#"
+
+    success: false
+    exit_code: 255
+    ----- stdout -----
+
+    ----- stderr -----
+    jarl failed
+      Cause: Failed to parse [TEMP_DIR]/jarl.toml:
+    TOML parse error at line 3, column 20
+      |
+    3 | extend-functions = [123]
+      |                    ^^^^^
+    data did not match any variant of untagged enum UndesirableFunctionEntry
+    "#
+    );
+
+    Ok(())
+}
+
+#[test]
+fn test_undesirable_function_custom_messages_change_reported_diagnostics() -> anyhow::Result<()> {
+    let case = CliTest::with_files([
+        (
+            "jarl.toml",
+            r#"
+[lint]
+select = ["undesirable_function"]
+
+[lint.undesirable_function]
+extend-functions = [
+  { setwd = 'Use here::here().' },
+  "sprintf",
+  { transmute = 'Use mutate(.keep = "none").' },
+]
+"#,
+        ),
+        (
+            "test.R",
+            "setwd(\"data\")\nsprintf()\ntransmute()\nbrowser()\n",
+        ),
+    ])?;
+
+    insta::assert_snapshot!(
+        &mut case
+            .command()
+            .arg("check")
+            .arg(".")
+            .run()
+            .normalize_os_executable_name()
+            .normalize_temp_paths(),
+        @r#"
+
+    success: false
+    exit_code: 1
+    ----- stdout -----
+    warning: undesirable_function
+     --> test.R:1:1
+      |
+    1 | setwd("data")
+      | ------------- `setwd()` is listed as an undesirable function.
+      |
+      = help: Use here::here().
+
+    warning: undesirable_function
+     --> test.R:2:1
+      |
+    2 | sprintf()
+      | --------- `sprintf()` is listed as an undesirable function.
+      |
+
+    warning: undesirable_function
+     --> test.R:3:1
+      |
+    3 | transmute()
+      | ----------- `transmute()` is listed as an undesirable function.
+      |
+      = help: Use mutate(.keep = "none").
+
+    warning: undesirable_function
+     --> test.R:4:1
+      |
+    4 | browser()
+      | --------- `browser()` is listed as an undesirable function.
+      |
+
+
+    ── Summary ──────────────────────────────────────
+    Found 4 errors.
+
+    ----- stderr -----
+    "#
+    );
+
+    Ok(())
+}
+
+#[test]
+fn test_undesirable_function_string_entries_remain_supported() -> anyhow::Result<()> {
+    let case = CliTest::with_files([
+        (
+            "jarl.toml",
+            r#"
+[lint]
+select = ["undesirable_function"]
+
+[lint.undesirable_function]
+functions = ["setwd"]
+"#,
+        ),
+        ("test.R", "setwd()\nbrowser()\n"),
+    ])?;
+
+    insta::assert_snapshot!(
+        &mut case
+            .command()
+            .arg("check")
+            .arg(".")
+            .run()
+            .normalize_os_executable_name()
+            .normalize_temp_paths(),
+        @r#"
+
+    success: false
+    exit_code: 1
+    ----- stdout -----
+    warning: undesirable_function
+     --> test.R:1:1
+      |
+    1 | setwd()
+      | ------- `setwd()` is listed as an undesirable function.
+      |
+
+
+    ── Summary ──────────────────────────────────────
+    Found 1 error.
+
+    ----- stderr -----
+    "#
+    );
+
+    Ok(())
+}
+
 // unreachable_code ----------------------------------------
 
 #[test]

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -83,6 +83,9 @@
   to list functions whose arguments are allowed to contain the `T` and `F`
   symbols (#542).
 
+* `undesirable_function` now accepts inline tables in `functions` and
+  `extend-functions` to attach custom suggestions to undesirable functions.
+
 
 ### Other improvements
 

--- a/docs/reference/config-file.md
+++ b/docs/reference/config-file.md
@@ -455,6 +455,28 @@ Default: `skipped-functions = []`
 skipped-functions = ["foo"]
 ```
 
+### `undesirable_function`
+
+Use `functions` to replace the default list of undesirable functions, or
+`extend-functions` to add to it. Specifying both is an error. The default list
+contains `browser`.
+
+Entries can be function-name strings or inline tables mapping function names to
+custom suggestion text. A mapped function is included in the selected list,
+and its suggestion is shown alongside the default diagnostic body.
+
+```toml
+[lint]
+...
+
+[lint.undesirable_function]
+extend-functions = [
+  { setwd = 'Use here::here().' },
+  "sprintf",
+  { transmute = 'Use mutate(.keep = "none").' },
+]
+```
+
 ### `unreachable_code`
 
 Use `stopping-functions` to fully replace the default list of functions that are

--- a/docs/rules/undesirable_function.md
+++ b/docs/rules/undesirable_function.md
@@ -22,9 +22,16 @@ By default, only `browser` is flagged. You can customise the list in
 # Replace the default list entirely:
 functions = ["browser", "debug"]
 
-# Or add to the defaults:
-extend-functions = ["debug"]
+# Or add to the defaults, with optional suggestions:
+extend-functions = [
+  { setwd = 'Use here::here().' },
+  "sprintf",
+  { transmute = 'Use mutate(.keep = "none").' },
+]
 ```
+
+Use a string with just the function name for the default diagnostic. Use an
+inline table to attach custom suggestion text to the default message.
 
 ## Example
 


### PR DESCRIPTION
Provides support to make comments of the form:

```toml
extend-functions = [
  { setwd = 'Use here::here().' },
  { sprintf = 'Use glue::glue().' },
  { transmute = 'Use mutate(.keep = "none").' },
]
```

Comments remain optional and the custom comments are appended, rather than replacing the base message.

Closes #655.